### PR TITLE
KVM test: Refactor NIC hotplug testing

### DIFF
--- a/client/tests/kvm/subtests.cfg.sample
+++ b/client/tests/kvm/subtests.cfg.sample
@@ -625,12 +625,13 @@ variants:
         find_pci_cmd = 'lspci | tail -n1'
         pci_test_cmd = 'nslookup www.redhat.com'
         wait_secs_for_hook_up = 3
+        run_dhclient = no
         variants:
             - nic_8139:
                 pci_model = rtl8139
                 match_string = "8139"
             - nic_virtio:
-                pci_model = virtio
+                pci_model = virtio-net-pci
                 match_string = "Virtio network device"
             - nic_e1000:
                 pci_model = e1000

--- a/client/tests/kvm/tests/nic_hotplug.py
+++ b/client/tests/kvm/tests/nic_hotplug.py
@@ -16,119 +16,62 @@ def run_nic_hotplug(test, params, env):
     7) Delete nic device and netdev
     8) Re-enable primary link of guest
 
+    BEWARE OF THE NETWORK BRIDGE DEVICE USED FOR THIS TEST ("bridge" param).
+    The KVM autotest default bridge virbr0, leveraging libvirt, works fine
+    for the purpose of this test. When using other bridges, the timeouts
+    which usually happen when the bridge topology changes (that is, devices
+    get added and removed) may cause random failures.
+
     @param test:   KVM test object.
     @param params: Dictionary with the test parameters.
     @param env:    Dictionary with test environment.
     """
     vm = virt_test_utils.get_living_vm(env, params.get("main_vm"))
-    timeout = int(params.get("login_timeout", 360))
+    login_timeout = int(params.get("login_timeout", 360))
     guest_delay = int(params.get("guest_delay", 20))
-    session = virt_test_utils.wait_for_login(vm, timeout=timeout)
-    romfile = params.get("romfile")
+    romfile = params.get("romfile", "")
+    pci_model = params.get("pci_model", "rtl8139")
+    run_dhclient = params.get("run_dhclient", "no")
+    guest_is_not_windows = "Win" not in params.get("guest_name", "")
 
-    # Modprobe the module if specified in config file
-    module = params.get("modprobe_module")
-    if module:
-        session.get_command_output("modprobe %s" % module)
+    session = virt_test_utils.wait_for_login(vm, timeout=login_timeout)
 
-    def netdev_add(vm):
-        netdev_id = virt_utils.generate_random_id()
-        attach_cmd = ("netdev_add tap,id=%s" % netdev_id)
-        nic_script = params.get("nic_script")
-        if nic_script:
-            attach_cmd += ",script=%s" % virt_utils.get_path(vm.root_dir,
-                                                            nic_script)
-        netdev_extra_params = params.get("netdev_extra_params")
-        if netdev_extra_params:
-            attach_cmd += ",%s" % netdev_extra_params
-        logging.info("Adding netdev through %s", attach_cmd)
-        vm.monitor.cmd(attach_cmd)
+    if guest_is_not_windows:
+        # Disable udev rules that usually mess up with device naming
+        mv_stat, o = session.cmd_status_output("mv /etc/udev/rules.d/"
+                                               "70-persistent-net.rules /tmp")
+        logging.debug("command to disable udev rules returned status: %s" %
+                      mv_stat)
 
-        network = vm.monitor.info("network")
-        if netdev_id not in network:
-            logging.error(network)
-            raise error.TestError("Fail to add netdev: %s" % netdev_id)
-        else:
-            return netdev_id
+        # Modprobe the module if specified in config file
+        module = params.get("modprobe_module")
+        if module:
+            session.get_command_output("modprobe %s" % module)
 
-    def netdev_del(vm, n_id):
-        vm.monitor.cmd("netdev_del %s" % n_id)
+    # hot-add the nic
+    nic_info = vm.add_nic(model=pci_model)
 
-        network = vm.monitor.info("network")
-        if n_id in network:
-            logging.error(network)
-            raise error.TestError("Fail to remove netdev %s" % n_id)
-
-    def nic_add(vm, model, netdev_id, mac, rom=None):
-        """
-        Add a nic to virtual machine
-
-        @vm: VM object
-        @model: nic model
-        @netdev_id: id of netdev
-        @mac: Mac address of new nic
-        @rom: Rom file
-        """
-        nic_id = virt_utils.generate_random_id()
-        if model == "virtio":
-            model = "virtio-net-pci"
-        device_add_cmd = "device_add %s,netdev=%s,mac=%s,id=%s" % (model,
-                                                                   netdev_id,
-                                                                   mac, nic_id)
-        if rom:
-            device_add_cmd += ",romfile=%s" % rom
-        logging.info("Adding nic through %s", device_add_cmd)
-        vm.monitor.cmd(device_add_cmd)
-
-        qdev = vm.monitor.info("qtree")
-        if not nic_id in qdev:
-            logging.error(qdev)
-            raise error.TestFail("Device %s was not plugged into qdev"
-                                 "tree" % nic_id)
-        else:
-            return nic_id
-
-    def nic_del(vm, nic_id, wait=True):
-        """
-        Remove the nic from pci tree.
-
-        @vm: VM object
-        @id: the nic id
-        @wait: Whether need to wait for the guest to unplug the device
-        """
-        nic_del_cmd = "device_del %s" % nic_id
-        vm.monitor.cmd(nic_del_cmd)
-        if wait:
-            logging.info("waiting for the guest to finish the unplug")
-            if not virt_utils.wait_for(lambda: nic_id not in
-                                      vm.monitor.info("qtree"),
-                                      guest_delay, 5 ,1):
-                logging.error(vm.monitor.info("qtree"))
-                raise error.TestError("Device is not unplugged by "
-                                      "guest, please check whether the "
-                                      "hotplug module was loaded in guest")
-
-    logging.info("Attach a virtio nic to vm")
-    mac = virt_utils.generate_mac_address(vm.instance, 1)
-    if not mac:
-        mac = "00:00:02:00:00:02"
-    netdev_id = netdev_add(vm)
-    device_id = nic_add(vm, "virtio", netdev_id, mac, romfile)
-
-    if "Win" not in params.get("guest_name", ""):
-        session.sendline("dhclient %s &" %
-                         virt_test_utils.get_linux_ifname(session, mac))
+    # Only run dhclient if explicitly set and guest is not running Windows.
+    # Most modern Linux guests run NetworkManager, and thus do not need this.
+    if run_dhclient == "yes" and guest_is_not_windows:
+        session_serial = vm.wait_for_serial_login(timeout=login_timeout)
+        ifname = virt_test_utils.get_linux_ifname(session, nic_info['mac'])
+        session_serial.cmd("dhclient %s &" % ifname)
 
     logging.info("Shutting down the primary link")
-    vm.monitor.cmd("set_link %s down" % vm.netdev_id[0])
+    vm.monitor.cmd("set_link %s off" % vm.netdev_id[0])
 
     try:
         logging.info("Waiting for new nic's ip address acquisition...")
-        if not virt_utils.wait_for(lambda: (vm.address_cache.get(mac) is
-                                           not None), 10, 1):
+        if not virt_utils.wait_for(lambda:
+                                   (vm.address_cache.get(nic_info['mac'])
+                                    is not None),
+                                   10, 1):
             raise error.TestFail("Could not get ip address of new nic")
-        ip = vm.address_cache.get(mac)
-        if not virt_utils.verify_ip_address_ownership(ip, mac):
+
+        ip = vm.address_cache.get(nic_info['mac'])
+
+        if not virt_utils.verify_ip_address_ownership(ip, nic_info['mac']):
             raise error.TestFail("Could not verify the ip address of new nic")
         else:
             logging.info("Got the ip address of new nic: %s", ip)
@@ -139,11 +82,19 @@ def run_nic_hotplug(test, params, env):
             logging.error(o)
             raise error.TestFail("New nic failed ping test")
 
-        logging.info("Detaching a virtio nic from vm")
-        nic_del(vm, device_id)
-        netdev_del(vm, netdev_id)
+        logging.info("Detaching the previously attached nic from vm")
+        vm.del_nic(nic_info, guest_delay)
 
     finally:
         vm.free_mac_address(1)
         logging.info("Re-enabling the primary link")
-        vm.monitor.cmd("set_link %s up" % vm.netdev_id[0])
+        vm.monitor.cmd("set_link %s on" % vm.netdev_id[0])
+
+    # Attempt to put back udev network naming rules, even if the command to
+    # disable the rules failed. We may be undoing what was done in a previous
+    # (failed) test that never reached this point.
+    if guest_is_not_windows:
+        mv_stat, o = session.cmd_status_output("mv /tmp/70-persistent-net"
+                                               ".rules /etc/udev/rules.d/")
+        logging.debug("command to revert udev rules returned status: %s" %
+                      mv_stat)

--- a/client/virt/virt_vm.py
+++ b/client/virt/virt_vm.py
@@ -152,6 +152,22 @@ class VMIPAddressMissingError(VMAddressError):
         return "Cannot find IP address for MAC address %s" % self.mac
 
 
+class VMAddNetDevError(VMError):
+    pass
+
+
+class VMDelNetDevError(VMError):
+    pass
+
+
+class VMAddNicError(VMError):
+    pass
+
+
+class VMDelNicError(VMError):
+    pass
+
+
 class VMMigrateError(VMError):
     pass
 


### PR DESCRIPTION
This patch adds the following VM method APIs:

vm.add_nic(): Hot plug a NIC to a VM, already attached
              to a netdev, attached to a bridged TAP dev
vm.del_nic(): Hot unplug the same NIC and the netdev

For now, these methods have not been added to BaseVM, that
is, they are not mandatory on every single hypervisor
implementation that autotest supports.

Useful information for users of this test code:
- Beware of the network bridge device being used, we
  strongly recommend that libvirt's virbr0 be used
- The e1000 nic hotplug on linux guests fails every
  single time on freshly booted guests, and succeeds every
  single time on guests that were up and failed a test
  earlier. Go figure it out.
  
  For reference, here follows a logged session showing that:
  
  First run:
  [   59.427861] e1000: Intel(R) PRO/1000 Network Driver - version 7.3.21-k8-NAPI
  [   59.427883] e1000: Copyright (c) 1999-2006 Intel Corporation.
  [   59.427993] e1000 0000:00:04.0: enabling device (0000 -> 0003)
  [   59.428195] e1000 0000:00:04.0: PCI INT A -> Link[LNKD] -> GSI 10 (level, high) -> IRQ 10
  [   59.428275] e1000 0000:00:04.0: setting latency timer to 64
  [   59.428680] ioremap error for 0x40000000-0x40020000, requested 0x10, got 0x0
  [   59.438110] e1000 0000:00:04.0: PCI INT A disabled
  [   59.438127] e1000: probe of 0000:00:04.0 failed with error -5
  
  Further run:
  [  193.637954] e1000 0000:00:05.0: enabling device (0000 -> 0003)
  [  193.638096] e1000 0000:00:05.0: PCI INT A -> Link[LNKA] -> GSI 10 (level, high) -> IRQ 10
  [  194.048907] e1000 0000:00:05.0: eth1: (PCI:33MHz:32-bit) 9a:02:de:7d:dd:3f
  [  194.087818] e1000: eth1 NIC Link is Up 1000 Mbps Full Duplex, Flow Control: RX
  [  197.993499] e1000 0000:00:05.0: PCI INT A disabled

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
Signed-off-by: Cleber Rosa crosa@redhat.com
