### PR TITLE
fix new logic for custom many-to-one join with Django 1.3

### DIFF
--- a/frontend/afe/model_logic.py
+++ b/frontend/afe/model_logic.py
@@ -223,12 +223,10 @@ class ExtendedManager(dbmodels.Manager):
         rhs_where = join_to_query.query.where
         rhs_where.relabel_aliases({rhs_table: alias})
         compiler = join_to_query.query.get_compiler(using=join_to_query.db)
-        initial_clause, values = compiler.as_sql()
-        all_clauses = (initial_clause,)
-        if hasattr(join_to_query.query, 'extra_where'):
-            all_clauses += join_to_query.query.extra_where
-        info['where_clause'] = (
-                    ' AND '.join('(%s)' % clause for clause in all_clauses))
+        where_clause, values = rhs_where.as_sql(
+            compiler.quote_name_unless_alias,
+            compiler.connection)
+        info['where_clause'] = where_clause
         info['values'] = values
         return info
 


### PR DESCRIPTION
this is a fixup for 31367ea which fixed this rather subtle code for
changes to Django's internals.  the function is intended to take a
query on the joined-to table and extract just the where clause, for
use in the ON clause of a JOIN.  the new version in 31367ea was
extracting the entire query rather than the WHERE clause only, which
resulted in invalid SQL.  this fixes a number of unit test failures.

additionally, the code to manually append the extra_where SQL is no
longer necessary, because Django's query code is now smart enough to
incorporate any extra SQL into the rhs_where object itself.
