### PR TITLE
KVM Test: client: Cache Exception in all try-except block

### DIFF
--- a/client/bin/autotest
+++ b/client/bin/autotest
@@ -89,7 +89,7 @@ if options.client_test_setup:
     exit_code = 0
     try:
         setup_job.setup_tests(options)
-    except:
+    except Exception:
         exit_code = 1
     sys.exit(exit_code)
 

--- a/client/bin/base_utils.py
+++ b/client/bin/base_utils.py
@@ -154,7 +154,7 @@ def unmap_url_cache(cachedir, url, expected_hash, method="md5"):
     if not os.path.isdir(cachedir):
         try:
             os.makedirs(cachedir)
-        except:
+        except Exception:
             raise ValueError('Could not create cache directory %s' % cachedir)
     file_from_url = os.path.basename(url)
     file_local_path = os.path.join(cachedir, file_from_url)
@@ -434,7 +434,7 @@ def dump_object(object):
         try:
             (key,value) = item
             dump_object(value)
-        except:
+        except Exception:
             continue
 
 
@@ -480,7 +480,7 @@ def avgtime_print(dir):
             elapsed += (float(s.group(3)) * 60) + float(s.group(4))
             cpu += float(s.group(5))
             count += 1
-        except:
+        except Exception:
             raise ValueError("badly formatted times")
 
     f.close()

--- a/client/bin/fsdev_disks.py
+++ b/client/bin/fsdev_disks.py
@@ -169,7 +169,7 @@ def mkfs_all_disks(job, disk_list, fs_type, fs_makeopt, fs_mnt_opt):
         # Create a file system instance
         try:
             fs = job.filesystem(device=dev_path, mountpoint=mnt_path)
-        except:
+        except Exception:
             raise Exception("Could not create a filesystem on '%s'" % dev_path)
 
         # Make sure the volume is unmounted
@@ -179,7 +179,7 @@ def mkfs_all_disks(job, disk_list, fs_type, fs_makeopt, fs_mnt_opt):
             except Exception, info:
                 raise Exception("umount failed: exception = %s, args = %s" %
                                                (sys.exc_info()[0], info.args))
-            except:
+            except Exception:
                 raise Exception("Could not unmount device ", dev_path)
 
         # Is the drive already formatted with the right file system?
@@ -189,7 +189,7 @@ def mkfs_all_disks(job, disk_list, fs_type, fs_makeopt, fs_mnt_opt):
         try:
             if not skip_mkfs:
                 fs.mkfs(fstype = fs_type, args = fs_makeopt)
-        except:
+        except Exception:
             raise Exception("Could not 'mkfs " + "-t " + fs_type + " " +
                                        fs_makeopt + " " + dev_path + "'")
 
@@ -499,7 +499,7 @@ class fsdev_disks:
             # See if we have a matching entry in the path dictionary
             try:
                 tune_path = self.tune_loc[tune_name]
-            except:
+            except Exception:
                 raise Exception("Unknown config entry: " + cfgline)
 
             self.tune_list.append((tune_name, tune_path, tune_val))

--- a/client/bin/harness_ABAT.py
+++ b/client/bin/harness_ABAT.py
@@ -17,7 +17,7 @@ def autobench_load(fn):
 
     try:
         fd = file(fn, "r")
-    except:
+    except Exception:
         return conf
     for ln in fd.readlines():
         m = disks.match(ln)

--- a/client/bin/net/net_utils.py
+++ b/client/bin/net/net_utils.py
@@ -105,7 +105,7 @@ def network():
     try:
         from autotest_lib.client.bin.net import site_net_utils
         return site_net_utils.network_utils()
-    except:
+    except Exception:
         return network_utils()
 
 
@@ -388,7 +388,7 @@ def netif(name):
     try:
         from autotest_lib.client.bin.net import site_net_utils
         return site_net_utils.network_interface(name)
-    except:
+    except Exception:
         return network_interface(name)
 
 
@@ -453,7 +453,7 @@ def bond():
     try:
         from autotest_lib.client.bin.net import site_net_utils
         return site_net_utils.bonding()
-    except:
+    except Exception:
         return bonding()
 
 
@@ -584,7 +584,7 @@ class raw_socket(object):
             raise error.TestError('Raw socket not open')
         try:
             packet = ethernet.pack(dst_mac, src_mac, protocol, payload)
-        except:
+        except Exception:
             raise error.TestError('Invalid Packet')
         self.send(packet)
 
@@ -747,5 +747,5 @@ def ethernet_packet():
     try:
         from autotest_lib.client.bin.net import site_net_utils
         return site_net_utils.ethernet()
-    except:
+    except Exception:
         return ethernet()

--- a/client/bin/net/net_utils_unittest.py
+++ b/client/bin/net/net_utils_unittest.py
@@ -857,7 +857,7 @@ class TestNetUtils(unittest.TestCase):
                 f.close.expect_call()
             try:
                 mock_netif.wait_for_carrier(mock_netif, max_timeout)
-            except:
+            except Exception:
                 pass
             else:
                 if not y:

--- a/client/bin/package.py
+++ b/client/bin/package.py
@@ -58,10 +58,10 @@ def _rpm_info(rpm_package):
         try:
             utils.system(i_cmd)
             package_info['installed'] = True
-        except:
+        except Exception:
             package_info['installed'] = False
 
-    except:
+    except Exception:
         package_info['system_support'] = False
         package_info['installed'] = False
         # File gives a wealth of information about rpm packages.
@@ -144,7 +144,7 @@ def _dpkg_info(dpkg_package):
         else:
             package_info['installed'] = True
 
-    except:
+    except Exception:
         package_info['system_support'] = False
         package_info['installed'] = False
         # The output of file is not as generous for dpkg files as
@@ -261,7 +261,7 @@ def convert(package, destination_format):
     """
     try:
         os_dep.command('alien')
-    except:
+    except Exception:
         e_msg = 'Cannot convert to %s, alien not installed' % destination_format
         raise error.TestError(e_msg)
 
@@ -299,13 +299,13 @@ def os_support():
         try:
             os_dep.command(package_manager)
             support_info[package_manager] = True
-        except:
+        except Exception:
             support_info[package_manager] = False
 
     try:
         os_dep.command('alien')
         support_info['conversion'] = True
-    except:
+    except Exception:
         support_info['conversion'] = False
 
     return support_info

--- a/client/bin/partition.py
+++ b/client/bin/partition.py
@@ -81,7 +81,7 @@ def wipe_filesystem(job, mountpoint):
     wipe_cmd = 'rm -rf %s/*' % mountpoint
     try:
         utils.system(wipe_cmd)
-    except:
+    except Exception:
         job.record('FAIL', None, wipe_cmd, error.format_error())
         raise
     else:
@@ -393,7 +393,7 @@ class partition(object):
             partitions = job.config_get('partition.partitions')
             try:
                 device = partitions[number]
-            except:
+            except Exception:
                 raise NameError("Partition '" + device + "' not available")
 
         self.device = device
@@ -597,7 +597,7 @@ class partition(object):
             if record:
                 self.job.record('FAIL', None, mkfs_cmd, error.format_error())
             raise
-        except:
+        except Exception:
             if record:
                 self.job.record('FAIL', None, mkfs_cmd, error.format_error())
             raise
@@ -642,7 +642,7 @@ class partition(object):
         sys.stdout.flush()
         try:
             utils.system_output(fsck_cmd)
-        except:
+        except Exception:
             if record:
                 self.job.record('FAIL', None, fsck_cmd, error.format_error())
             raise error.TestError('Fsck found errors with the underlying '
@@ -702,7 +702,7 @@ class partition(object):
         try:
             utils.system(mount_cmd)
             mtab.close()
-        except:
+        except Exception:
             mtab.close()
             if record:
                 self.job.record('FAIL', None, mount_cmd, error.format_error())
@@ -989,7 +989,7 @@ class virtual_partition:
         logging.debug('Removing disk image %s', self.img)
         try:
             os.remove(self.img)
-        except:
+        except Exception:
             e_msg = 'Error removing image file %s' % self.img
             raise error.AutotestError(e_msg)
 

--- a/client/common_lib/autotemp.py
+++ b/client/common_lib/autotemp.py
@@ -62,11 +62,11 @@ class tempfile(object):
             if self.name is not None:
                 logging.debug('Clean was not called for ' + self.name)
                 self.clean()
-        except:
+        except Exception:
             try:
                 msg = 'An exception occurred while calling the destructor'
                 logging.exception(msg)
-            except:
+            except Exception:
                 pass
 
 
@@ -104,9 +104,9 @@ class tempdir(object):
             if self.name:
                 logging.debug('Clean was not called for ' + self.name)
                 self.clean()
-        except:
+        except Exception:
             try:
                 msg = 'An exception occurred while calling the destructor'
                 logging.exception(msg)
-            except:
+            except Exception:
                 pass

--- a/client/common_lib/base_barrier.py
+++ b/client/common_lib/base_barrier.py
@@ -346,7 +346,7 @@ class barrier(object):
 
             try:
                 client.close()
-            except:
+            except Exception:
                 pass
 
 

--- a/client/common_lib/base_packages.py
+++ b/client/common_lib/base_packages.py
@@ -803,7 +803,7 @@ class BasePackageManager(object):
 
         try:
             utils.system(' '.join(cmd_list))
-        except:
+        except Exception:
             os.unlink(temp_path)
             raise
 

--- a/client/common_lib/global_config.py
+++ b/client/common_lib/global_config.py
@@ -194,7 +194,7 @@ class global_config(object):
         try:
             conv_val = value_type(sval)
             return conv_val
-        except:
+        except Exception:
             msg = ("Could not convert %s value %r in section %s to type %s" %
                     (key, sval, section, value_type))
             raise ConfigValueError(msg)

--- a/client/common_lib/global_config_unittest.py
+++ b/client/common_lib/global_config_unittest.py
@@ -94,7 +94,7 @@ class global_config_test(unittest.TestCase):
         try:
             val = self.conf.get_config_value("SECTION_B",
                                             "value_2", int)
-        except:
+        except Exception:
             error = 1
         self.assertEquals(error, 1)
 

--- a/client/common_lib/hosts/base_classes.py
+++ b/client/common_lib/hosts/base_classes.py
@@ -148,7 +148,7 @@ class Host(object):
         try:
             runlevel = int(self.run("runlevel").stdout.strip().split()[1])
             return runlevel in (0, 6)
-        except:
+        except Exception:
             return False
 
 

--- a/client/common_lib/logging_manager.py
+++ b/client/common_lib/logging_manager.py
@@ -541,7 +541,7 @@ class _FdRedirectionStreamManager(_StreamManager):
                 os.close(1)
                 os.close(2)
                 self._run_logging_subprocess(read_end) # never returns
-            except:
+            except Exception:
                 # don't let exceptions in the child escape
                 try:
                     logging.exception('Logging subprocess died:')

--- a/client/common_lib/magic.py
+++ b/client/common_lib/magic.py
@@ -144,7 +144,7 @@ class MagicTest(object):
                 [data] = struct.unpack('>l', data[self.offset:self.offset + 4])
             else:
                 pass
-        except:
+        except Exception:
             return None
 
         return self.test(data)

--- a/client/common_lib/pexpect.py
+++ b/client/common_lib/pexpect.py
@@ -534,7 +534,7 @@ class spawn (object):
             try:
                 self.child_fd = sys.stdout.fileno() # used by setwinsize()
                 self.setwinsize(24, 80)
-            except:
+            except Exception:
                 # Some platforms do not like setwinsize (Cygwin).
                 # This will cause problem when running applications that
                 # are very picky about window size.
@@ -624,7 +624,7 @@ class spawn (object):
             if fd >= 0:
                 os.close(fd)
                 raise ExceptionPexpect, "Error! We are not disconnected from a controlling tty."
-        except:
+        except Exception:
             # Good! We are disconnected from a controlling tty.
             pass
 
@@ -1407,7 +1407,7 @@ class spawn (object):
                 self.match = None
                 self.match_index = None
                 raise TIMEOUT (str(e) + '\n' + str(self))
-        except:
+        except Exception:
             self.before = incoming
             self.after = None
             self.match = None

--- a/client/common_lib/software_manager.py
+++ b/client/common_lib/software_manager.py
@@ -18,7 +18,7 @@ implement the given backend class.
 import os, re, logging, ConfigParser, optparse, random, string
 try:
     import yum
-except:
+except Exception:
     pass
 import common
 from autotest_lib.client.bin import os_dep, utils
@@ -78,7 +78,7 @@ class SystemInspector(object):
             try:
                 os_dep.command(high_level_pm)
                 list_supported.append(high_level_pm)
-            except:
+            except Exception:
                 pass
 
         pm_supported = None
@@ -404,7 +404,7 @@ class YumBackend(RpmBackend):
         try:
             utils.system(i_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -418,7 +418,7 @@ class YumBackend(RpmBackend):
         try:
             utils.system(r_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -469,7 +469,7 @@ class YumBackend(RpmBackend):
         try:
             utils.system(r_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -517,7 +517,7 @@ class ZypperBackend(RpmBackend):
         try:
             utils.system(i_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -531,7 +531,7 @@ class ZypperBackend(RpmBackend):
         try:
             utils.system(ar_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -545,7 +545,7 @@ class ZypperBackend(RpmBackend):
         try:
             utils.system(rr_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -558,7 +558,7 @@ class ZypperBackend(RpmBackend):
         try:
             utils.system(r_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -571,7 +571,7 @@ class ZypperBackend(RpmBackend):
         try:
             utils.system(u_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -600,7 +600,7 @@ class ZypperBackend(RpmBackend):
                 logging.info("Package %s provides %s", list_provides[0], name)
                 return list_provides[0]
             return None
-        except:
+        except Exception:
             return None
 
 
@@ -637,7 +637,7 @@ class AptBackend(DpkgBackend):
         try:
             utils.system(i_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -654,7 +654,7 @@ class AptBackend(DpkgBackend):
         try:
             utils.system(r_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -698,14 +698,14 @@ class AptBackend(DpkgBackend):
         ud_cmd = self.base_command + ' ' + ud_command
         try:
             utils.system(ud_cmd)
-        except:
+        except Exception:
             logging.error("Apt package update failed")
         up_command = 'upgrade'
         up_cmd = self.base_command + ' ' + up_command
         try:
             utils.system(up_cmd)
             return True
-        except:
+        except Exception:
             return False
 
 
@@ -721,7 +721,7 @@ class AptBackend(DpkgBackend):
         cache_update_cmd = command + ' update'
         try:
             utils.system(cache_update_cmd, ignore_status=True)
-        except:
+        except Exception:
             logging.error("Apt file cache update failed")
         fu_cmd = command + ' search ' + file
         try:
@@ -744,7 +744,7 @@ class AptBackend(DpkgBackend):
                 logging.info("Package %s provides %s", list_provides[0], file)
                 return list_provides[0]
             return None
-        except:
+        except Exception:
             return None
 
 

--- a/client/common_lib/test.py
+++ b/client/common_lib/test.py
@@ -128,7 +128,7 @@ class base_test(object):
             try:
                 if not eval(constraint, keyval_env):
                     failures.append('%s: constraint was not met' % constraint)
-            except:
+            except Exception:
                 failures.append('could not evaluate constraint: %s'
                                 % constraint)
 

--- a/client/common_lib/test_unittest.py
+++ b/client/common_lib/test_unittest.py
@@ -88,7 +88,7 @@ class Test_base_test_execute(TestTestCase):
         after_hook.expect_call(self.test)
         try:
             self.test._call_run_once([], False, None, (1, 2), {'arg': 'val'})
-        except:
+        except Exception:
             pass
         self.god.check_playback()
 

--- a/client/common_lib/test_utils/mock_demo.py
+++ b/client/common_lib/test_utils/mock_demo.py
@@ -65,7 +65,7 @@ def do_more_stuff(d):
     print d.method6(False)
     try:
         d.method6(True)
-    except:
+    except Exception:
         print "caught error"
 
 

--- a/client/common_lib/test_utils/unittest.py
+++ b/client/common_lib/test_utils/unittest.py
@@ -96,7 +96,7 @@ def _EmulateWith(context, func):
     context.__enter__()
     try:
         func()
-    except:
+    except Exception:
         if not context.__exit__(sys.exc_type, sys.exc_value, sys.exc_traceback):
             raise
     else:

--- a/client/deps/mysql/mysql.py
+++ b/client/deps/mysql/mysql.py
@@ -22,7 +22,7 @@ def setup(tarball, topdir):
     #
     try:
         os.mkdir(topdir + '/mysql/var')
-    except:
+    except Exception:
         pass
     #
     # Initialize the database.

--- a/client/profilers/oprofile/oprofile.py
+++ b/client/profilers/oprofile/oprofile.py
@@ -44,7 +44,7 @@ class oprofile(profiler.profiler):
                                                     self.srcdir)
             utils.make('-j %d' % utils.count_cpus())
             utils.make('install')
-        except:
+        except Exception:
             # Build from source failed.
             # But maybe can still use the local copy
             local_opcontrol = os.path.exists('/usr/bin/opcontrol')

--- a/client/samples/control.profilers
+++ b/client/samples/control.profilers
@@ -19,6 +19,6 @@ for profiler in ('readprofile', 'oprofile', 'catprofile', 'lockmeter'):
         job.profilers.add(profiler)
         job.run_test('sleeptest', seconds=5, tag=profiler)
         job.profilers.delete(profiler)
-    except:
+    except Exception:
         logging.error("Test of profiler %s failed", profiler)
         raise

--- a/client/tests/cgroup/cgroup.py
+++ b/client/tests/cgroup/cgroup.py
@@ -351,7 +351,7 @@ class cgroup(test.test):
         try:
             # Available cpus: cpuset.cpus = "0-$CPUS\n"
             no_cpus = int(item.get_prop("cpuset.cpus").split('-')[1]) + 1
-        except:
+        except Exception:
             raise error.TestFail("Failed to get no_cpus or no_cpus = 1")
 
         pwd = item.mk_cgroup()
@@ -363,7 +363,7 @@ class cgroup(test.test):
             item.set_property("cpuset.cpus", tmp, pwd)
             tmp = item.get_prop("cpuset.mems")
             item.set_property("cpuset.mems", tmp, pwd)
-        except:
+        except Exception:
             cleanup(True)
             raise error.TestFail("Failed to set cpus and mems of"
                                  "a new cgroup")

--- a/client/tests/cgroup/cgroup_client.py
+++ b/client/tests/cgroup/cgroup_client.py
@@ -46,7 +46,7 @@ def test_memfill(args):
         try:
             f.flush()
             os.fsync(f)
-        except:
+        except Exception:
             pass
     f.write("PASS: memfill (%dM)\n" % size)
 

--- a/client/tests/cgroup/cgroup_common.py
+++ b/client/tests/cgroup/cgroup_common.py
@@ -215,7 +215,7 @@ class Cgroup(object):
                 value = int(value[:-1]) * 1048576
             elif value[-1] == 'G':
                 value = int(value[:-1]) * 1073741824
-        except:
+        except Exception:
             logging.error("cg.set_prop() fallback into cg.set_property.")
             value = _value
         return self.set_property(prop, value, pwd, check)
@@ -339,7 +339,7 @@ class CgroupModules(object):
                                  % (self.modules[1][i], failure_detail))
         try:
             shutil.rmtree(self.mountdir)
-        except:
+        except Exception:
             logging.warn("CGM: Couldn't remove the %s directory", self.mountdir)
 
     def init(self, _modules):

--- a/client/tests/ctcs/ctcs.py
+++ b/client/tests/ctcs/ctcs.py
@@ -80,7 +80,7 @@ class ctcs(test.test):
         os.chdir(self.srcdir)
         try:
             utils.system('./run %s' % self.tcf_path)
-        except:
+        except Exception:
             self.nfail += 1
         log_base_path = os.path.join(self.srcdir, 'log')
         log_dir = glob.glob(os.path.join(log_base_path,

--- a/client/tests/iosched_bugs/iosched_bugs.py
+++ b/client/tests/iosched_bugs/iosched_bugs.py
@@ -37,7 +37,7 @@ class iosched_bugs(test.test):
 #       try:
 #           utils.run(dirty_bin + ' ' + blah + '1 > ' + dirty_op, 900, False,
 #                     None, None)
-#       except:
+#       except Exception:
 #           utils.nuke_subprocess(p1)
 #           raise error.TestFail('Writes made no progress')
         utils.nuke_subprocess(p1)

--- a/client/tests/iozone/postprocessing.py
+++ b/client/tests/iozone/postprocessing.py
@@ -339,7 +339,7 @@ class IOzonePlotter(object):
         self.active = True
         try:
             self.gnuplot = os_dep.command("gnuplot")
-        except:
+        except Exception:
             logging.error("Command gnuplot not found, disabling graph "
                           "generation")
             self.active = False

--- a/client/tests/iperf/iperf.py
+++ b/client/tests/iperf/iperf.py
@@ -240,13 +240,13 @@ class iperf(test.test):
                         runs['Bandwidth_S2C'].append(int(stats['bandwidth']))
                         try:
                             runs['Jitter_S2C'].append(float(stats['jitter']))
-                        except:
+                        except Exception:
                             pass
                     else:
                         runs['Bandwidth_C2S'].append(int(stats['bandwidth']))
                         try:
                             runs['Jitter_C2S'].append(float(stats['jitter']))
-                        except:
+                        except Exception:
                             pass
 
                 # Calculate sums assuming there are values

--- a/client/tests/kvm/scripts/ksm_overcommit_guest.py
+++ b/client/tests/kvm/scripts/ksm_overcommit_guest.py
@@ -89,7 +89,7 @@ class MemFill(object):
         for i in range((PAGE_SIZE / a.itemsize)):
             try:
                 a.append(value)
-            except:
+            except Exception:
                 print "FAIL: Value can be only in range (0..255)"
         return a
 

--- a/client/tests/kvm/scripts/multicast_guest.py
+++ b/client/tests/kvm/scripts/multicast_guest.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
             mreq = struct.pack("4sl", socket.inet_aton(mcast),
                                socket.INADDR_ANY)
             s.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
-        except:
+        except Exception:
             s.close()
             print "Could not join multicast: %s" % mcast
             raise

--- a/client/tests/kvm/scripts/virtio_console_guest.py
+++ b/client/tests/kvm/scripts/virtio_console_guest.py
@@ -48,7 +48,7 @@ class VirtioGuest:
             f = open(name, "r")
             out = f.read()
             f.close()
-        except:
+        except Exception:
             print "FAIL: Cannot open file %s" % (name)
 
         return out
@@ -68,7 +68,7 @@ class VirtioGuest:
         try:
             if not os.path.isdir('%s/virtio-ports' % (DEBUGPATH)):
                 print not_present_msg
-        except:
+        except Exception:
             print not_present_msg
         else:
             viop_names = os.listdir('%s/virtio-ports' % (DEBUGPATH))
@@ -719,7 +719,7 @@ def worker(virt):
             str = raw_input()
             try:
                 exec str
-            except:
+            except Exception:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 print "On Guest exception from: \n" + "".join(
                                 traceback.format_exception(exc_type,

--- a/client/tests/kvm/tests/cgroup.py
+++ b/client/tests/kvm/tests/cgroup.py
@@ -259,7 +259,7 @@ def run_cgroup(test, params, env):
         try:
             loops = int(rexpr[rexpr.rfind(':')+1:])
             rexpr = rexpr[:rexpr.rfind(':')]
-        except:
+        except Exception:
             loops = 1
         # number of loops per regular expression
         for _loop in range(loops):

--- a/client/tests/kvm/tests/ksm_overcommit.py
+++ b/client/tests/kvm/tests/ksm_overcommit.py
@@ -558,7 +558,7 @@ def run_ksm_overcommit(test, params, env):
     try:
         tmp = open(params.get('pid_' + vm_name), 'r')
         params['pid_' + vm_name] = int(tmp.readline())
-    except:
+    except Exception:
         raise error.TestFail("Could not get PID of %s" % (vm_name))
 
     # Creating other guest systems
@@ -586,7 +586,7 @@ def run_ksm_overcommit(test, params, env):
         try:
             tmp = open(params.get('pid_' + vm_name), 'r')
             params['pid_' + vm_name] = int(tmp.readline())
-        except:
+        except Exception:
             raise error.TestFail("Could not get PID of %s" % (vm_name))
 
     # Let guests rest a little bit :-)

--- a/client/tests/kvm/tests/migration_with_file_transfer.py
+++ b/client/tests/kvm/tests/migration_with_file_transfer.py
@@ -46,7 +46,7 @@ def run_migration_with_file_transfer(test, params, env):
                     logging.info("File transfer not ended, starting a round of "
                                  "migration...")
                     vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay)
-            except:
+            except Exception:
                 # If something bad happened in the main thread, ignore
                 # exceptions raised in the background thread
                 bg.join(suppress_exception=True)

--- a/client/tests/kvm/tests/migration_with_reboot.py
+++ b/client/tests/kvm/tests/migration_with_reboot.py
@@ -32,7 +32,7 @@ def run_migration_with_reboot(test, params, env):
         try:
             while bg.isAlive():
                 vm.migrate(mig_timeout, mig_protocol, mig_cancel_delay)
-        except:
+        except Exception:
             # If something bad happened in the main thread, ignore exceptions
             # raised in the background thread
             bg.join(suppress_exception=True)

--- a/client/tests/kvm/tests/nic_bonding.py
+++ b/client/tests/kvm/tests/nic_bonding.py
@@ -52,7 +52,7 @@ def run_nic_bonding(test, params, env):
                     vm.monitor.cmd("set_link %s down" % device_id)
                     time.sleep(1)
                     vm.monitor.cmd("set_link %s up" % device_id)
-        except:
+        except Exception:
             transfer_thread.join(suppress_exception=True)
             raise
         else:

--- a/client/tests/kvm/tests/pci_hotplug.py
+++ b/client/tests/kvm/tests/pci_hotplug.py
@@ -195,7 +195,7 @@ def run_pci_hotplug(test, params, env):
 
         session.close()
 
-    except:
+    except Exception:
         pci_del(ignore_failure=True)
         raise
 

--- a/client/tests/kvm/tests/qemu_img.py
+++ b/client/tests/kvm/tests/qemu_img.py
@@ -325,7 +325,7 @@ def run_qemu_img(test, params, env):
                 output = session.cmd("[ ! -e /commit_testfile ] && echo $?")
                 logging.info("Output of [ ! -e /commit_testfile ] && echo $?: "
                              "%s", output)
-            except:
+            except Exception:
                 output = session.cmd("rm -f /commit_testfile")
                 raise error.TestFail("The commit_testfile exists on the "
                                      "original file")
@@ -352,7 +352,7 @@ def run_qemu_img(test, params, env):
                 logging.info("Output of [ -e /commit_testfile ] && echo $?: %s",
                              output)
                 session.cmd("rm -f /commit_testfile")
-            except:
+            except Exception:
                 raise error.TestFail("Could not find commit_testfile after a "
                                      "commit")
             vm.destroy()
@@ -430,7 +430,7 @@ def run_qemu_img(test, params, env):
         try:
             os.remove(sn2)
             os.remove(sn1)
-        except:
+        except Exception:
             pass
 
 

--- a/client/tests/kvm/tests/qmp_basic.py
+++ b/client/tests/kvm/tests/qmp_basic.py
@@ -78,7 +78,7 @@ def run_qmp_basic(test, params, env):
         fail_no_key(qmp_dict, key)
         try:
             value = int(qmp_dict[key])
-        except:
+        except Exception:
             raise error.TestFail("'%s' key is not of type int, it's '%s'" %
                                  (key, type(qmp_dict[key])))
 

--- a/client/tests/kvm/tests/qmp_basic_rhel6.py
+++ b/client/tests/kvm/tests/qmp_basic_rhel6.py
@@ -79,7 +79,7 @@ def run_qmp_basic_rhel6(test, params, env):
         fail_no_key(qmp_dict, key)
         try:
             int(qmp_dict[key])
-        except:
+        except Exception:
             raise error.TestFail("'%s' key is not of type int, it's '%s'" %
                                  (key, type(qmp_dict[key])))
 

--- a/client/tests/kvm/tests/steps.py
+++ b/client/tests/kvm/tests/steps.py
@@ -110,7 +110,7 @@ def barrier_2(vm, words, params, debug_dir, data_scrdump_filename,
             whole_image_md5sum not in prev_whole_image_md5sums[:1]):
             try:
                 os.makedirs(history_dir)
-            except:
+            except Exception:
                 pass
             history_scrdump_filename = os.path.join(history_dir,
                     "scrdump-step_%s-%s.jpg" % (current_step_num,

--- a/client/tests/kvm/tests/virtio_console.py
+++ b/client/tests/kvm/tests/virtio_console.py
@@ -90,7 +90,7 @@ def run_virtio_console(test, params, env):
                 self.result.append(res)
                 self.passed += 1
                 return ret
-            except:
+            except Exception:
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 logging.error("In function (" + function.func_name + "):")
                 logging.error("Call from:\n" +
@@ -108,7 +108,7 @@ def run_virtio_console(test, params, env):
                 if cleanup:
                     try:
                         self.cleanup_func(*self.cleanup_args)
-                    except:
+                    except Exception:
                         error.TestFail("Cleanup function crashed as well")
                 if fatal:
                     raise
@@ -370,7 +370,7 @@ def run_virtio_console(test, params, env):
                                     self.port.open()
                                     try:
                                         idx = self.port.sock.send(buf)
-                                    except:
+                                    except Exception:
                                         attempt += 1
                                         time.sleep(10)
                                     else:
@@ -1259,7 +1259,7 @@ def run_virtio_console(test, params, env):
             try:
                 os.system("dd if=/dev/random of='%s' bs=4096 &>/dev/null &"
                           % port.path)
-            except:
+            except Exception:
                 pass
         # Just start sending, it won't finish anyway...
         _on_guest("virt.send('%s', 1024**3, True, is_static=True)"
@@ -1768,7 +1768,7 @@ def run_virtio_console(test, params, env):
             if len(param) > 1:
                 try:
                     duration = float(param[1])
-                except:
+                except Exception:
                     pass
             param = param[0].split('@')
             if len(param) > 1 and param[1].isdigit():

--- a/client/tests/libhugetlbfs/libhugetlbfs.py
+++ b/client/tests/libhugetlbfs/libhugetlbfs.py
@@ -45,7 +45,7 @@ class libhugetlbfs(test.test):
         # version, in that case try only for the 64 bit version
         try:
             utils.make()
-        except:
+        except Exception:
             utils.make('OBJDIRS=obj64')
 
 
@@ -55,7 +55,7 @@ class libhugetlbfs(test.test):
         # had failed. See if it passes for 64 bit in that case.
         try:
             utils.make('check')
-        except:
+        except Exception:
             utils.make('check OBJDIRS=obj64')
 
 

--- a/client/tests/lsb_dtk/lsb_dtk.py
+++ b/client/tests/lsb_dtk/lsb_dtk.py
@@ -89,7 +89,7 @@ class lsb_dtk(test.test):
                     if not 'lsb-dtk-manager' in line:
                         line = re.findall(pkg_pattern, line)[0]
                         lsb_pkg_list.append(line)
-                except:
+                except Exception:
                     # If we don't get a match, no problem
                     pass
 

--- a/client/tests/ltp/ltp-diff.py
+++ b/client/tests/ltp/ltp-diff.py
@@ -40,7 +40,7 @@ def get_results(results_files):
             fh = utils.urlopen(file)
             results = fh.readlines()
             fh.close()
-        except:
+        except Exception:
             print "ERROR: reading results resource [%s]" % (file)
             usage()
         for line in results:
@@ -50,7 +50,7 @@ def get_results(results_files):
                 status = s.group(2)
                 runs[i][testname] = status
                 testnames[testname] = 1
-            except:
+            except Exception:
                 pass
         i += 1
     return (runs, testnames)

--- a/client/tests/npb/npb.py
+++ b/client/tests/npb/npb.py
@@ -58,7 +58,7 @@ class npb(test.test):
             itest_cmd = os.path.join('NPB3.3-OMP/bin/', itest)
             try:
                 itest = utils.run(itest_cmd)
-            except:
+            except Exception:
                 logging.error('NPB benchmark %s has failed. Output: %s',
                               itest_cmd, itest.stdout)
                 self.n_fail += 1
@@ -106,7 +106,7 @@ class npb(test.test):
             itest_single_cmd = ''.join(['OMP_NUM_THREADS=1 ', itest_cmd])
             try:
                 itest_single = utils.run(itest_single_cmd)
-            except:
+            except Exception:
                 logging.error('NPB benchmark single thread %s has failed. '
                               'Output: %s',
                               itest_single_cmd,

--- a/client/tests/sysbench/sysbench.py
+++ b/client/tests/sysbench/sysbench.py
@@ -46,7 +46,7 @@ class sysbench(test.test):
         # Check for nobody user
         try:
             utils.system(self.sudo + '/bin/true')
-        except:
+        except Exception:
             raise error.TestError('Unable to run as nobody')
 
         if (db_type == 'pgsql'):
@@ -93,7 +93,7 @@ class sysbench(test.test):
             self.results.append(utils.system_output(cmd + ' run',
                                                     retain_output=True))
 
-        except:
+        except Exception:
             utils.system(self.sudo + bin + '/pg_ctl -D ' + data + ' stop')
             raise
 
@@ -138,7 +138,7 @@ class sysbench(test.test):
             self.results.append(utils.system_output(cmd + ' run',
                                                     retain_output=True))
 
-        except:
+        except Exception:
             utils.system(bin + '/mysqladmin shutdown')
             raise
 

--- a/client/tests/systemtap/systemtap.py
+++ b/client/tests/systemtap/systemtap.py
@@ -51,7 +51,7 @@ class systemtap(test.test):
         script = "PATH=%s/bin:$PATH stap -c /bin/true -e 'probe syscall.read { exit() }'" % self.systemtap_dir
         try:
             utils.system(script)
-        except:
+        except Exception:
             raise error.TestError('simple systemtap test failed, kernel debuginfo package may be missing: %s' % script)
 
 

--- a/client/tools/crash_handler.py
+++ b/client/tools/crash_handler.py
@@ -31,7 +31,7 @@ def get_parent_pid(pid):
     """
     try:
         ppid = int(open('/proc/%s/stat' % pid).read().split()[3])
-    except:
+    except Exception:
         # It is not possible to determine the parent because the process
         # already left the process table.
         ppid = 1

--- a/client/tools/diffprofile
+++ b/client/tools/diffprofile
@@ -15,7 +15,7 @@ def parse_lines(filename):
             key = ' '.join(a[start_key:])
             count = int(a[0])
             results.append((key, count))
-        except:         # presumably a header line
+        except Exception:         # presumably a header line
             if re.match(r'samples\s*%\s*app name\s*symbol name', line):
                 start_key = 2
             elif re.match(r'samples\s*%\s*image name\s*app name\s*symbol name', line):

--- a/client/virt/aexpect.py
+++ b/client/virt/aexpect.py
@@ -26,11 +26,11 @@ def _unlock(fd):
 def _locked(filename):
     try:
         fd = os.open(filename, os.O_RDWR)
-    except:
+    except Exception:
         return False
     try:
         fcntl.lockf(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except:
+    except Exception:
         os.close(fd)
         return True
     fcntl.lockf(fd, fcntl.LOCK_UN)
@@ -391,7 +391,7 @@ class Spawn:
         base_dir = "/tmp/kvm_spawn"
         try:
             os.makedirs(base_dir)
-        except:
+        except Exception:
             pass
         (self.shell_pid_filename,
          self.status_filename,
@@ -444,7 +444,7 @@ class Spawn:
             assert(_locked(self.lock_server_running_filename))
             for reader, filename in self.reader_filenames.items():
                 self.reader_fds[reader] = os.open(filename, os.O_RDONLY)
-        except:
+        except Exception:
             pass
 
         # Allow the server to continue
@@ -530,7 +530,7 @@ class Spawn:
             pid = int(file.read())
             file.close()
             return pid
-        except:
+        except Exception:
             return None
 
 
@@ -545,7 +545,7 @@ class Spawn:
             status = int(file.read())
             file.close()
             return status
-        except:
+        except Exception:
             return None
 
 
@@ -558,7 +558,7 @@ class Spawn:
             output = file.read()
             file.close()
             return output
-        except:
+        except Exception:
             return ""
 
 
@@ -587,7 +587,7 @@ class Spawn:
         for fd in self.reader_fds.values():
             try:
                 os.close(fd)
-            except:
+            except Exception:
                 pass
         self.reader_fds = {}
         # Remove all used files
@@ -618,7 +618,7 @@ class Spawn:
             fd = os.open(self.inpipe_filename, os.O_RDWR)
             os.write(fd, str)
             os.close(fd)
-        except:
+        except Exception:
             pass
 
 
@@ -794,7 +794,7 @@ class Tail(Spawn):
                 try:
                     # See if there's any data to read from the pipe
                     r, w, x = select.select([fd], [], [], 0.05)
-                except:
+                except Exception:
                     break
                 if fd in r:
                     # Some data is available; read it
@@ -912,7 +912,7 @@ class Expect(Tail):
         while True:
             try:
                 r, w, x = select.select([fd], [], [], timeout)
-            except:
+            except Exception:
                 return data
             if fd in r:
                 new_data = os.read(fd, 1024)

--- a/client/virt/kvm_monitor.py
+++ b/client/virt/kvm_monitor.py
@@ -511,7 +511,7 @@ class QMPMonitor(Monitor):
                 if line:
                     try:
                         json.loads(line)
-                    except:
+                    except Exception:
                         # Found an incomplete or broken line -- keep reading
                         break
             else:
@@ -522,7 +522,7 @@ class QMPMonitor(Monitor):
         for line in s.splitlines():
             try:
                 objs += [json.loads(line)]
-            except:
+            except Exception:
                 pass
         # Keep track of asynchronous events
         self._events += [obj for obj in objs if "event" in obj]

--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -483,7 +483,7 @@ class VM(virt_vm.BaseVM):
             if nic_params.get("nic_mode") == "tap":
                 try:
                     tapfd = vm.tapfds[vlan]
-                except:
+                except Exception:
                     tapfd = None
             else:
                 tapfd = None

--- a/client/virt/ppm_utils.py
+++ b/client/virt/ppm_utils.py
@@ -166,7 +166,7 @@ def image_verify_ppm_file(filename):
         fin.close()
         assert(size - size_read == width*height*3)
         return True
-    except:
+    except Exception:
         return False
 
 

--- a/client/virt/rss_client.py
+++ b/client/virt/rss_client.py
@@ -344,7 +344,7 @@ class FileUploadClient(FileTransferClient):
                 else:
                     # Neither RSS_OK nor RSS_ERROR found
                     raise FileTransferProtocolError("Received unexpected msg")
-        except:
+        except Exception:
             # In any case, if the transfer failed, close the connection
             self.close()
             raise
@@ -448,7 +448,7 @@ class FileDownloadClient(FileTransferClient):
                 else:
                     # Unexpected msg
                     raise FileTransferProtocolError("Received unexpected msg")
-        except:
+        except Exception:
             # In any case, if the transfer failed, close the connection
             self.close()
             raise

--- a/client/virt/tests/ethtool.py
+++ b/client/virt/tests/ethtool.py
@@ -55,7 +55,7 @@ def run_ethtool(test, params, env):
             try:
                 session.cmd(cmd)
                 return True
-            except:
+            except Exception:
                 return False
         if ethtool_get(f_type) != status:
             logging.error("Fail to set %s %s", f_type, status)

--- a/client/virt/tests/iofuzz.py
+++ b/client/virt/tests/iofuzz.py
@@ -80,7 +80,7 @@ def run_iofuzz(test, params, env):
                     logging.debug("VM is alive, try to re-login")
                     try:
                         session = vm.wait_for_login(timeout=10)
-                    except:
+                    except Exception:
                         logging.debug("Could not re-login, reboot the guest")
                         session = vm.reboot(method="system_reset")
                 else:

--- a/client/virt/tests/kdump.py
+++ b/client/virt/tests/kdump.py
@@ -58,7 +58,7 @@ def run_kdump(test, params, env):
         logging.info("Checking the existence of crash kernel...")
         try:
             session.cmd(crash_kernel_prob_cmd)
-        except:
+        except Exception:
             logging.info("Crash kernel is not loaded. Trying to load it")
             session.cmd(kernel_param_cmd)
             session = vm.reboot(session, timeout=timeout)

--- a/client/virt/tests/netperf.py
+++ b/client/virt/tests/netperf.py
@@ -31,7 +31,7 @@ def run_netperf(test, params, env):
     session_serial.cmd_output(firewall_flush)
     try:
         utils.run("iptables -F")
-    except:
+    except Exception:
         pass
 
     for i in params.get("netperf_files").split():
@@ -50,7 +50,7 @@ def run_netperf(test, params, env):
         try:
             logging.debug("Stopping the background tcpdump")
             env["tcpdump"].close()
-        except:
+        except Exception:
             pass
 
     def netperf(i=0):
@@ -72,7 +72,7 @@ def run_netperf(test, params, env):
                     netperf_output = utils.system_output(cmd,
                                                          retain_output=True)
                     result.write("%s\n" % netperf_output)
-                except:
+                except Exception:
                     logging.error("Test of protocol %s failed", p)
                     list_fail.append(p)
 

--- a/client/virt/tests/netstress_kill_guest.py
+++ b/client/virt/tests/netstress_kill_guest.py
@@ -61,7 +61,7 @@ def run_netstress_kill_guest(test, params, env):
 
         try:
             utils.run(firewall_flush)
-        except:
+        except Exception:
             logging.warning("Could not flush firewall rules on guest")
 
         try:
@@ -81,7 +81,7 @@ def run_netstress_kill_guest(test, params, env):
 
         try:
             session_serial.cmd(clean_cmd)
-        except:
+        except Exception:
             pass
         session_serial.cmd(params.get("netserver_cmd") % "/tmp")
 
@@ -101,7 +101,7 @@ def run_netstress_kill_guest(test, params, env):
                 pid = int(utils.system_output("pidof tcpdump"))
                 logging.debug("Stopping the background tcpdump")
                 os.kill(pid, signal.SIGSTOP)
-            except:
+            except Exception:
                 pass
 
         try:

--- a/client/virt/tests/nic_promisc.py
+++ b/client/virt/tests/nic_promisc.py
@@ -32,7 +32,7 @@ def run_nic_promisc(test, params, env):
         while transfer_thread.isAlive():
             session_serial.cmd("ip link set %s promisc on" % ethname)
             session_serial.cmd("ip link set %s promisc off" % ethname)
-    except:
+    except Exception:
         transfer_thread.join(suppress_exception=True)
         raise
     else:

--- a/client/virt/tests/nicdriver_unload.py
+++ b/client/virt/tests/nicdriver_unload.py
@@ -54,7 +54,7 @@ def run_nicdriver_unload(test, params, env):
             session_serial.cmd("modprobe -r %s" % driver)
             session_serial.cmd("modprobe %s" % driver)
             session_serial.cmd("ifconfig %s up" % ethname)
-    except:
+    except Exception:
         for thread in threads:
             thread.join(suppress_exception=True)
             raise

--- a/client/virt/tests/softlockup.py
+++ b/client/virt/tests/softlockup.py
@@ -39,11 +39,11 @@ def run_softlockup(test, params, env):
         logging.info("Kill stress and monitor on guest")
         try:
             session.cmd(kill_stress_cmd)
-        except:
+        except Exception:
             pass
         try:
             session.cmd(kill_monitor_cmd)
-        except:
+        except Exception:
             pass
 
 
@@ -105,7 +105,7 @@ def run_softlockup(test, params, env):
         # Opening firewall ports on guest
         try:
             session.cmd("iptables -F")
-        except:
+        except Exception:
             pass
 
         # Get required files and copy them from host to guest

--- a/client/virt/tests/whql_client_install.py
+++ b/client/virt/tests/whql_client_install.py
@@ -110,7 +110,7 @@ def run_whql_client_install(test, params, env):
         try:
             session.cmd(cmd)
             break
-        except:
+        except Exception:
             pass
         time.sleep(5)
     else:

--- a/client/virt/virt_env_process.py
+++ b/client/virt/virt_env_process.py
@@ -254,7 +254,7 @@ def preprocess(test, params, env):
     if os.path.exists("/dev/kvm"):
         try:
             kvm_version = open("/sys/module/kvm/version").read().strip()
-        except:
+        except Exception:
             kvm_version = os.uname()[2]
     else:
         kvm_version = "Unknown"

--- a/client/virt/virt_test_utils.py
+++ b/client/virt/virt_test_utils.py
@@ -255,7 +255,7 @@ def migrate(vm, env=None, mig_timeout=3600, mig_protocol="tcp",
 
                 if (dest_host == 'localhost') and offline:
                     dest_vm.monitor.cmd("cont")
-        except:
+        except Exception:
             if dest_host == 'localhost':
                 dest_vm.destroy()
             raise
@@ -710,7 +710,7 @@ def raw_ping(command, timeout, session, output_func):
         else:
             try:
                 status = int(re.findall("\d+", o2)[0])
-            except:
+            except Exception:
                 status = -1
 
         return status, output
@@ -778,5 +778,5 @@ def get_linux_ifname(session, mac_address):
         ethname = re.findall("(\w+)\s+Link.*%s" % mac_address, output,
                              re.IGNORECASE)[0]
         return ethname
-    except:
+    except Exception:
         return None

--- a/client/virt/virt_utils.py
+++ b/client/virt/virt_utils.py
@@ -431,7 +431,7 @@ def pid_exists(pid):
     try:
         os.kill(pid, 0)
         return True
-    except:
+    except Exception:
         return False
 
 
@@ -444,7 +444,7 @@ def safe_kill(pid, signal):
     try:
         os.kill(pid, signal)
         return True
-    except:
+    except Exception:
         return False
 
 
@@ -710,7 +710,7 @@ def remote_login(client, host, port, username, password, prompt, linesep="\n",
     session = aexpect.ShellSession(cmd, linesep=linesep, prompt=prompt)
     try:
         _remote_login(session, username, password, prompt, timeout)
-    except:
+    except Exception:
         session.close()
         raise
     if log_filename:
@@ -1419,7 +1419,7 @@ class Thread(threading.Thread):
         try:
             try:
                 self._retval = self._target(*self._args, **self._kwargs)
-            except:
+            except Exception:
                 self._e = sys.exc_info()
                 raise
         finally:
@@ -1749,7 +1749,7 @@ class PciAssignable(object):
                     logging.error("Failed to release device %s to host", pci_id)
                 else:
                     logging.info("Released device %s successfully", pci_id)
-        except:
+        except Exception:
             return
 
 


### PR DESCRIPTION
Now all the exception will be caught include KeyboardInterrupt exception,
it causes some autotest process ignore ctrl-c action. We'd better use
the following format to catch all exception.
try:
    ...
except Exception:
    ...

For more details please refer to
http://docs.python.org/library/exceptions.html

Signed-off-by: Qingtang Zhou qzhou@redhat.com
