### PR TITLE
One patch to fix the update issue of macaddr pool

### DIFF
--- a/client/virt/virt_env_process.py
+++ b/client/virt/virt_env_process.py
@@ -403,14 +403,20 @@ def _update_address_cache(address_cache, line):
             address_cache["last_seen"] = matches[0]
     if re.search("Client.Ethernet.Address", line, re.IGNORECASE):
         matches = re.findall(r"\w*:\w*:\w*:\w*:\w*:\w*", line)
-        if matches and address_cache.get("last_seen"):
-            mac_address = matches[0].lower()
+        if matches:
+            address_cache["last_mac"] = matches[0]
+    if re.search("DHCP-Message", line, re.IGNORECASE):
+        matches = re.findall(r"ACK", line)
+        if matches and address_cache.get("last_seen") and
+                address_cache.get("last_mac"):
+            mac_address = address_cache.get("last_mac").lower()
             if time.time() - address_cache.get("time_%s" % mac_address, 0) > 5:
                 logging.debug("(address cache) Adding cache entry: %s ---> %s",
                               mac_address, address_cache.get("last_seen"))
             address_cache[mac_address] = address_cache.get("last_seen")
             address_cache["time_%s" % mac_address] = time.time()
             del address_cache["last_seen"]
+            del address_cache["last_mac"]
 
 
 def _take_screendumps(test, params, env):


### PR DESCRIPTION
Currently, tcpdump can capture both dhcp Offer and ACK packets,
macaddr cache will be updated in those to condition,
dhcp Offer packet doesn't mean the IP is already allocated to
dhcp client.

Signed-off-by: Amos Kong akong@redhat.com
