### PR TITLE
Virt: make installer survive but warn about parallel build failures

### DIFF
--- a/client/virt/tests/build.py
+++ b/client/virt/tests/build.py
@@ -1,3 +1,4 @@
+from autotest_lib.client.common_lib import error
 from autotest_lib.client.virt import installer
 from autotest_lib.client.virt import base_installer
 
@@ -13,14 +14,29 @@ def run_build(test, params, env):
     srcdir = params.get("srcdir", test.srcdir)
     params["srcdir"] = srcdir
 
+    # Flag if a installer minor failure ocurred
+    minor_failure = False
+    minor_failure_reasons = []
+
     try:
         for name in params.get("installers", "").split():
             installer_obj = installer.make_installer(name, params, test)
             installer_obj.install()
+            if installer_obj.minor_failure == True:
+                minor_failure = True
+                reason = "%s_%s: %s" % (installer_obj.name,
+                                        installer_obj.mode,
+                                        installer_obj.minor_failure_reason)
+                minor_failure_reasons.append(reason)
             env.register_installer(installer_obj)
+
     except Exception, e:
         # if the build/install fails, don't allow other tests
         # to get a installer.
         msg = "Virtualization software install failed: %s" % (e)
         env.register_installer(base_installer.FailedInstaller(msg))
         raise
+
+    if minor_failure:
+        raise error.TestWarn("Minor (worked around) failures during build "
+                             "test: %s" % ", ".join(minor_failure_reasons))


### PR DESCRIPTION
Sometimes we find that Makefiles do not correctly describe dependencies
between different parts of the source code, and thus fail to build in
a parallelized fashion.

This patch aims to make the build test resilient to these failures,
by falling back to a single job make, but still not completely silent
about them.

Tests with these types of failures will set warnings. The 'minor failure'
concept introduced here may also be used by other minor, worked around,
installer failures.

Signed-off-by: Cleber Rosa crosa@redhat.com
