### PR TITLE
Virt: enable the use of MALLOC_PERTURB_

### DIFF
--- a/client/tests/kvm/base.cfg.sample
+++ b/client/tests/kvm/base.cfg.sample
@@ -126,3 +126,7 @@ login_timeout = 360
 
 # NFS directory of guest images
 images_good = fileserver.foo.com:/autotest/images_good
+
+# Whether to run the qemu binary with malloc perturb set.
+# On by default, set to 'no' to disable it
+malloc_perturb = yes

--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -429,6 +429,9 @@ class VM(virt_vm.BaseVM):
 
         # Start constructing the qemu command
         qemu_cmd = ""
+        # Enable the use of glibc's malloc_perturb feature
+        if params.get("malloc_perturb", "yes") == "yes":
+            qemu_cmd += "MALLOC_PERTURB_=1 "
         # Set the X11 display parameter if requested
         if params.get("x11_display"):
             qemu_cmd += "DISPLAY=%s " % params.get("x11_display")


### PR DESCRIPTION
MALLOC_PERTURB_ can help to find bugs such as user-after-free,
generating core dumps when a bug is detected. This sets the qemu
binary to run with MALLOC_PERTURB_ set by default.

qemu-img should also be run with MALLOC_PERTURB_ set, but IMHO
we need a more central API to manipulate image files, and this
will probably be the best place to set MALLOC_PERTURB_.

This partially adresses issue #54.

Signed-off-by: Cleber Rosa crosa@redhat.com
