### PR TITLE
Patches for qemu-system-arm and some other stuff

### DIFF
--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -441,6 +441,8 @@ class VM(virt_vm.BaseVM):
         if os.path.isdir(library_path):
             library_path = os.path.abspath(library_path)
             qemu_cmd += "LD_LIBRARY_PATH=%s " % library_path
+        if params.get("qemu_audio_drv"):
+            qemu_cmd += "QEMU_AUDIO_DRV=%s " % params.get("qemu_audio_drv")
         # Add the qemu binary
         qemu_cmd += qemu_binary
         # Add the VM's name


### PR DESCRIPTION
Hello,

For my tests, i need to use a qemu-system-arm binary. (With a vexpress_a9 board).

I added some stuff which can be interesting to have in main branch.

First one is a 'none' network device. It is used to avoid autotest building a specific parameter for network. The network card of the vexpress board don't need special configuration and can be used as it is build. (mostly it is a pain to use because it s linked on the system bus and not a PCI or other kind of bus)

I added this to my guest-hw.cfg:
variants:
    - @lan9118:
        #using the lan9118 driver will disable the
        #-device and -netdev parameters!!!
        nic_model = none
        nic_mode = none

Second one is a patch to use default devices of qemu. Same as before. The lack of PCI bus for the vexpress board force to use a system with fixed-memory initialisation and IRQ. We will prefer to let it do what it want.

I added this in tests.cfg for my installation:
defaults = yes

Last one is more simple and less specific. It is just a switch to use a user-defined audio backend for qemu. I simply set it as the default oss is buggy on my pc but alsa work.

Subtests.cfg can be defined like such:
variants:
    - @defaudiodrv:
    - alsa:
        qemu_audio_drv = alsa
    - oss:
        qemu_audio_drv = oss

Let me know if you have some information.

Also if you like, i could try to make more patch on how i integrate my vexpress board in autotest. I use quite much extra_params. Mostly to define the kernel bootcmd, network redirection and board definition. It could be more easy to integrate this in normal configuration style.

I didn't pushed my .cfg file as it is quite specific and not so linked to the 'kvm' test. I can do if you wish to have a sample on how to use.
