### PR TITLE
[kvm-autotest] tests.cgroup: Add CpuShare test

### DIFF
--- a/client/tests/cgroup/cgroup_common.py
+++ b/client/tests/cgroup/cgroup_common.py
@@ -201,6 +201,8 @@ class Cgroup(object):
         value = str(value)
         if pwd == None:
             pwd = self.root
+        if isinstance(pwd, int):
+            pwd = self.cgroups[pwd]
         try:
             open(pwd+prop, 'w').write(value)
         except Exception, inst:
@@ -280,8 +282,8 @@ class CgroupModules(object):
                 try:
                     utils.system('umount %s -l' % self.modules[1][i])
                 except Exception, failure_detail:
-                    logging.warn("CGM: Couldn't unmount %s directory: %s"
-                                 % (self.modules[1][i], failure_detail))
+                    logging.warn("CGM: Couldn't unmount %s directory: %s",
+                                 self.modules[1][i], failure_detail)
         try:
             shutil.rmtree(self.mountdir)
         except Exception:
@@ -308,7 +310,7 @@ class CgroupModules(object):
             # Is it already mounted?
             i = False
             for mount in mounts:
-                if mount[3].find(module) != -1:
+                if  module in mount[3].split(','):
                     self.modules[0].append(module)
                     self.modules[1].append(mount[1] + '/')
                     self.modules[2].append(False)


### PR DESCRIPTION
- Adds base _TestCpuShare
- Adds TestCpuShare10 - cpu.shares ratio is 1:10
- Adds TestCpuShare50 - cpu.shares ratio is 1:1
- cgroup_common - incorrect lookup for mounted cgroups
- kvm cgroup - sort the executed tests (per expression)
- minor bugfixies

Tests the cpu.share cgroup capability. It creates n cgroups accordingly
to self.speeds variable and sufficient VMs to symetricaly test three
different scenerios:

1) #threads == #CPUs
2) #threads + 1 == #CPUs, +1thread have the lowest priority (or equal)
3) #threads \* #cgroups == #CPUs

Scheduler shouldn't slow down VMs on unoccupied CPUs. With thread
overcommit the scheduler should stabilize accordingly to speeds
value.

Signed-off-by: Lukas Doktor ldoktor@redhat.com
