### PR TITLE
virt: work around deprecation (and removal) of koji pkgurl config

### DIFF
--- a/client/virt/virt_utils.py
+++ b/client/virt/virt_utils.py
@@ -2039,9 +2039,16 @@ class KojiClient(object):
         info = self.get_pkg_info(pkg)
         rpms = self.get_pkg_rpm_info(pkg, arch)
         rpm_urls = []
+
+        if self.config_options.has_key('pkgurl'):
+            base_url = self.config_options['pkgurl']
+        else:
+            base_url = "%s/%s" % (self.config_options['topurl'],
+                                  'packages')
+
         for rpm in rpms:
             rpm_name = koji.pathinfo.rpm(rpm)
-            url = ("%s/%s/%s/%s/%s" % (self.config_options['pkgurl'],
+            url = ("%s/%s/%s/%s/%s" % (base_url,
                                        info['package_name'],
                                        info['version'], info['release'],
                                        rpm_name))


### PR DESCRIPTION
Koji/Brew has deprecated the use of the pkgurl configuration option,
so try to detect if that is present in the configuration, and if not,
use topurl instead.

Signed-off-by: Cleber Rosa crosa@redhat.com
