### PR TITLE
Adding async jobs

### DIFF
--- a/client/common_lib/base_utils.py
+++ b/client/common_lib/base_utils.py
@@ -4,7 +4,7 @@
 import os, pickle, random, re, resource, select, shutil, signal, StringIO
 import socket, struct, subprocess, sys, time, textwrap, traceback, urlparse
 import warnings, smtplib, logging, urllib2
-from threading import Thread, Event
+from threading import Thread, Event, Lock
 try:
     import hashlib
 except ImportError:
@@ -118,6 +118,118 @@ class BgJob(object):
     def _reset_sigpipe(self):
         signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
+class AsyncJob(BgJob):
+    def __init__(self, command, stdout_tee=None, stderr_tee=None, verbose=True,
+                 stdin=None, stderr_level=DEFAULT_STDERR_LEVEL, kill_func=None):
+        super(AsyncJob, self).__init__(command, stdout_tee=stdout_tee,
+            stderr_tee=stderr_tee, verbose=verbose, stdin=stdin,
+            stderr_level=stderr_level)
+
+        #start time for CmdResult
+        self.start_time = time.time()
+
+        if kill_func is None:
+            self.kill_func = self._kill_self_process
+        else:
+            self.kill_func = kill_func
+
+        #we're going to make some threads to drain the stdout and stderr
+        def drainer(input, output, lock):
+            """
+            input is a pipe and output is file-like. if lock is non-None, then
+            we assume output isn't threadsafe
+            """
+            try:
+                while True:
+                    tmp = os.read(input.fileno(), 1024)
+                    if tmp == '':
+                        break
+                    if lock is not None:
+                        lock.acquire()
+                    for f in filter(lambda x: x is not None, output):
+                        f.write(tmp)
+                    if lock is not None:
+                        lock.release()
+            except:
+                pass
+
+        self.stdout_lock = Lock()
+        self.stdout_file = StringIO.StringIO()
+        self.stdout_thread = Thread(target=drainer, name=("%s-stdout"%command),
+                 args=(self.sp.stdout, (self.stdout_file, self.stdout_tee),
+                       self.stdout_lock))
+        self.stdout_thread.daemon = True
+
+        self.stderr_lock = Lock()
+        self.stderr_file = StringIO.StringIO()
+        self.stderr_thread = Thread(target=drainer, name=("%s-stderr"%command),
+                 args=(self.sp.stderr, (self.stderr_file, self.stderr_tee),
+                       self.stderr_lock))
+        self.stderr_thread.daemon = True
+
+        self.stdout_thread.start()
+        self.stderr_thread.start()
+
+    def output_prepare(self, stdout_file=None, stderr_file=None):
+        raise NotImplementedError("This object automatically prepares its own "
+            "output")
+
+    def process_output(self, stdout=True, final_read=False):
+        raise NotImplementedError("This object has background threads "
+            "automatically polling the process. Use the locked accessors")
+
+    def get_stdout(self):
+        self.stdout_lock.acquire()
+        tmp = self.stdout_file.getvalue()
+        self.stdout_lock.release()
+        return tmp
+
+    def get_stderr(self):
+        self.stderr_lock.acquire()
+        tmp = self.stderr_file.getvalue()
+        self.stderr_lock.release()
+        return tmp
+
+    def cleanup(self):
+        raise NotImplementedError("This must be waited for to get a result")
+
+    def _kill_self_process(self):
+        try:
+            os.kill(self.sp.pid, signal.SIGTERM)
+        except OSError:
+            pass #don't care if the process is already gone, since that was the goal
+
+    def wait_for(self, timeout=None):
+        if timeout is None:
+            self.sp.wait()
+
+        if timeout > 0:
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                self.result.exit_status = self.sp.poll()
+                if self.result.exit_status is not None:
+                    break
+        #first need to kill the threads and process, then no more locking
+        #issues for superclass's cleanup function
+        self.kill_func()
+
+        #we need to fill in parts of the result that aren't done automatically
+        try:
+            pid, self.result.exit_status = os.waitpid(self.sp.pid, 0)
+        except OSError:
+            self.result.exit_status = self.sp.poll()
+        self.result.duration = time.time() - self.start_time
+        assert self.result.exit_status is not None
+
+        #make sure we've got stdout and stderr
+        self.stdout_thread.join(1)
+        self.stderr_thread.join(1)
+        assert not self.stdout_thread.is_alive()
+        assert not self.stderr_thread.is_alive()
+
+        super(AsyncJob, self).cleanup()
+
+        return self.result
 
 def ip_to_long(ip):
     # !L is a long in network byte order

--- a/client/tests/asynctest/asynctest.py
+++ b/client/tests/asynctest/asynctest.py
@@ -1,0 +1,19 @@
+import os, re, time
+
+from autotest_lib.client.bin import utils, test
+
+class asynctest(test.test):
+    version = 1
+
+    def run_once(self):
+        #We create 2 processes to show that progress continues on each independently
+        x = utils.AsyncJob("sleep 1 && echo hi && sleep 1 && echo hi && sleep 1 && echo hi && sleep 1")
+        y = utils.AsyncJob("sleep 100")
+        time.sleep(2)
+        print "Process 1 stdout is now %s" % x.get_stdout()
+        res = x.wait_for()
+        print "Process 1 result object is: %s" % res
+
+        t = time.time()
+        y.wait_for(timeout=1)
+        print "Process 2 took %d to be killed" % (time.time()-t)

--- a/client/tests/asynctest/control
+++ b/client/tests/asynctest/control
@@ -1,0 +1,11 @@
+TIME="SHORT"
+AUTHOR = "David Greenbrg <david.greenberg@twosigma.com>"
+DOC = """
+This test demonstrates how the asynchronous local job api works.
+"""
+NAME = 'asynctest'
+TEST_CLASS = 'self'
+TEST_CATEGORY = 'Functional'
+TEST_TYPE = 'client'
+
+job.run_test('asynctest')

--- a/server/hosts/factory.py
+++ b/server/hosts/factory.py
@@ -20,7 +20,7 @@ def create_host(
         from autotest_lib.server.hosts import paramiko_host
         classes = [paramiko_host.ParamikoHost]
     elif SSH_ENGINE == 'raw_ssh':
-        classes = [ssh_host.SSHHost]
+        classes = [ssh_host.SSHHost, ssh_host.AsyncSSHMixin]
     else:
         raise error.AutoServError("Unknown SSH engine %s. Please verify the "
                                   "value of the configuration key 'ssh_engine' "

--- a/server/hosts/ssh_host.py
+++ b/server/hosts/ssh_host.py
@@ -10,7 +10,7 @@ You should import the "hosts" package instead of importing each type of host.
         SSHHost: a remote machine with a ssh access
 """
 
-import sys, re, traceback, logging
+import sys, re, traceback, logging, subprocess, os
 from autotest_lib.client.common_lib import error, pxssh
 from autotest_lib.server import utils
 from autotest_lib.server.hosts import abstract_ssh
@@ -242,3 +242,56 @@ class SSHHost(abstract_ssh.AbstractSSHHost):
                 self.ssh_ping()
             except error.AutoservSshPingHostError:
                 self.setup_ssh_key()
+
+
+class AsyncSSHMixin(object):
+    def __init__(self, *args, **kwargs):
+        super(AsyncSSHMixin, self).__init__(*args, **kwargs)
+
+    def run_async(self, command, stdout_tee=None, stderr_tee=None, args=(),
+                  connect_timeout=30, options='', verbose=True,
+                  stderr_level=utils.DEFAULT_STDERR_LEVEL,
+                  cmd_outside_subshell=''):
+        """
+        Run a command on the remote host. Returns an AsyncJob object to
+        interact with the remote process.
+
+        This is mostly copied from SSHHost.run and SSHHost._run
+        """
+        if verbose:
+            logging.debug("Running (async ssh) '%s'" % command)
+
+        # Start a master SSH connection if necessary.
+        self.start_master_ssh()
+
+        self.send_file(os.path.join(self.job.clientdir, "common_lib", "hosts",
+                        "scripts", "run_helper.py"),
+                       os.path.join(self.job.tmpdir, "run_helper.py"))
+
+        env = " ".join("=".join(pair) for pair in self.env.iteritems())
+
+        ssh_cmd = self.ssh_command(connect_timeout, options)
+        if not env.strip():
+            env = ""
+        else:
+            env = "export %s;" % env
+        for arg in args:
+            command += ' "%s"' % utils.sh_escape(arg)
+        full_cmd = '{ssh_cmd} "{env} {cmd}"'.format(
+            ssh_cmd=ssh_cmd, env=env,
+            cmd=utils.sh_escape("%s (%s '%s')" % (cmd_outside_subshell,
+                            os.path.join(self.job.tmpdir, "run_helper.py"),
+                            utils.sh_escape(command))))
+
+        job = utils.AsyncJob(full_cmd, stdout_tee=stdout_tee,
+                              stderr_tee=stderr_tee, verbose=verbose,
+                              stderr_level=stderr_level,
+                              stdin=subprocess.PIPE)
+
+        def kill_func():
+            #this triggers the remote kill
+            utils.nuke_subprocess(job.sp)
+
+        job.kill_func = kill_func
+
+        return job


### PR DESCRIPTION
This change adds asynchronicity to autotest. Essentially, it allows several programs to be started, their output to be monitored, and for them to be killed manually, none of which block the main thread.

It extends BgJob to allow the job to run an external command in the background, and it uses threads to manage the communication. It allows for safe retrieval of the stdout and stderr while the process is executing and after it finishes.

It also adds a mixin to SSHHost to allow remote asynchronous SSH jobs. The usage case for this is that you're testing an application that runs on a cluster and is composed of several daemons. With this, you can easily start all the daemons in the correct order, possibly waiting for them to complete initialization before starting the next daemon, and then you can observe the output and kill the daemons if they aren't designed to be shutdown (i.e. the should run forever until ctrl-c'ed).

I think that these will need to be placed into other files, and possibly have other work done on them, but I'd like to start the dialogue.
