### PR TITLE
Add kernel installation test in client side and virt side

### DIFF
--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -1725,6 +1725,39 @@ variants:
                 test_control_file = 9p-ci.control
                 test_timeout = 1800
 
+    - kernel_install:
+        only Linux
+        type = kernel_install
+        variants:
+            ## Example for other installation methods
+            #- koji:
+            #    install_type = koji
+            #    kernel_dep_pkgs = "linux-firmware module-init-tools"
+            #    kernel_koji_tag = f16-updates
+            #- rpm:
+            #    install_type = rpm
+                 # These 2 parameters can be url.
+            #    kernel_rpm_path = "kernel-3.1.7-1.fc16.x86_64"
+            #    kernel_deps_rpms = "linux-firmware-20110731-2.fc16.noarch"
+            #    file_checklist = kernel_rpm_path kernel_deps_rpms
+            #- git:
+            #    install_type = git
+            #    kernel_git_repo = ""
+            #    kernel_git_repo_base = ""
+            #    kernel_git_branch = ""
+            #    kernel_git_commit = ""
+            #    kernel_patch_list = ""
+            #    kernel_config = ""
+            #    kerne_config_list = ""
+            - @tar:
+                install_type = tar
+                kernel_src_pkg = "http://www.kernel.org/pub/linux/kernel/v3.0/linux-3.2.tar.bz2"
+                # Remember to update this config file to your own.
+                kernel_config = "/boot/config-3.2.7-1.fc16.x86_64"
+                kernel_patch_list = "http://www.kernel.org/pub/linux/kernel/v3.0/patch-3.2.7.bz2"
+                file_checklist = kerne_src_pkg kernel_config kernel_patch_list
+                kernel_tag = "3.2.7"
+
     - shutdown: install setup image_copy unattended_install.cdrom
         type = shutdown
         shutdown_method = shell


### PR DESCRIPTION
 These 2 tests is used to install kernel in guest directly, they support 4 kinds of installation method.
- rpm: install guest kernel with a local/remote rpm package.
- koji/brew: download packages via koji/brew and install kernel in guest.
- git: checkout a git repo and compile kernel.
- tar: compile kernel from a tarball and install it in guest.

Qingtang Zhou (3):
  client test: Add kernel install case in autotest
  KVM Test: kernel_install.py: Add a kernel installation test
  KVM Test: Add config for guest kernel install test

Yiqiao Pu (1):
  Virt: Add tag in run_sub_test

 client/tests/kernelinstall/control          |   23 +++
 client/tests/kernelinstall/kernelinstall.py |  153 ++++++++++++++++++++
 client/tests/kvm/tests/kernel_install.py    |  200 +++++++++++++++++++++++++++
 client/virt/subtests.cfg.sample             |   33 +++++
 client/virt/virt_test_utils.py              |    6 +-
 5 files changed, 414 insertions(+), 1 deletions(-)
 create mode 100644 client/tests/kernelinstall/control
 create mode 100644 client/tests/kernelinstall/kernelinstall.py
 create mode 100644 client/tests/kvm/tests/kernel_install.py
