### PR TITLE
[KVM-autotest] virt.kvm_vm: Add virtio-scsi support

### DIFF
--- a/client/virt/guest-hw.cfg.sample
+++ b/client/virt/guest-hw.cfg.sample
@@ -58,6 +58,14 @@ variants:
         # Some older qemu might need image_boot=yes for virtio images to work.
         # Please uncomment the below if that is the case.
         #image_boot=yes
+    - virtio_scsi:
+        # supported formats are: scsi-hd, scsi-cd, scsi-disk, scsi-block,
+        # scsi-generic
+        # Use drive_format_$DISKNAME = "scsi-generic" to force disk driver
+        # for single disk.
+        # NOTE:  scsi-block and scsi-generic are pass-through physical dev only
+        drive_format=scsi-hd
+        cd_format=scsi-cd
     - ahci:
         drive_format=ahci
         cd_format=ahci


### PR DESCRIPTION
This patch adds support for virtio-scsi devices.

Added block variants:
- virtio_scsi (default)
- virtio_scsi_disk (legacy scsi)
- virtio_scsi_block (only raw /dev/sd\* files)
- virtio_scsi_generic (only raw /dev/sg\* files)

Please keep in mind that virtio-scsi is not yet upstream. To test this patch you have to:
1) have a guest OS with virtio-scsi support ( https://github.com/bonzini/virtio-scsi/commits/master )
2) qemu support for virtio-scsi devices ( git://github.com/bonzini/qemu.git )
3) qemu bios support (http://people.redhat.com/pbonzini/virtio-scsi/ )
NOTE: you can download testing rpm packages for all of the above on Paolo Bonzini's page http://people.redhat.com/pbonzini/virtio-scsi/
NOTE2: without modified qemu bios you won't be able to boot from virtio-scsi device
NOTE3: currently only boot from lun0 is supported
NOTE4: automatic hotplug that doesn't work. You have to initialize the device (echo "scsi add-single-device" 2 0 1 0 > /proc/scsi/scsi )

Also please be aware that virtio_scsi_block and virtio_scsi_generic devices are pass-through targets thus you can specify only /dev/sg (resp. /dev/sd*) devices. Also in my version of qemu it was impossible to set those targets directly from cmd-line, although hot-plug worked fine.

Signed-off-by: Lukas Doktor ldoktor@redhat.com
