### PR TITLE
Virt: fix kvm_vm.VM.add_cdrom() when format=None

### DIFF
--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -281,7 +281,7 @@ class VM(virt_vm.BaseVM):
                     dev += ",port=%d" % (int(index) + 1)
                     format = "none"
                     index = None
-                if format.startswith("scsi-"):
+                if format is not None and format.startswith("scsi-"):
                     # handles scsi-{hd, cd, disk, block, generic} targets
                     name = "virtio-scsi-cd%s" % index
                     dev += (" -device %s,drive=%s,bus=virtio_scsi_pci.0" %


### PR DESCRIPTION
virtio-scsi commit a9ea704a5f262b03d020f853c24d8b2117afc6a3
introduced a condition that fails when no "cd_format" option is
passed in the configuration file, which happens in the default
qemu_kvm_f16_quick test set.

Signed-off-by: Cleber Rosa crosa@redhat.com
