### PR TITLE
apache: add conditional aliases to the apache config files

### DIFF
--- a/apache/conf/afe-directives
+++ b/apache/conf/afe-directives
@@ -1,4 +1,29 @@
-Alias /afe "/usr/local/autotest/frontend/client/www/autotest.AfeClient"
+RewriteEngine On
+
+# This rule is meant for autotest installations under a single directory,
+# such as when pulling the code from git or from a tarball
+RewriteCond /usr/local/autotest/frontend/client/www/autotest.AfeClient -d
+RewriteRule /afe(.*) /usr/local/autotest/frontend/client/www/autotest.AfeClient$1
+
+# This rule is meant for autotest installations from a package such as RPM
+RewriteCond /usr/share/autotest/frontend/client/www/autotest.AfeClient -d
+RewriteRule /afe(.*) /usr/share/autotest/frontend/client/www/autotest.AfeClient$1
+
+# These rules are fallbacks when autotest web client is installed along
+# the autotest server files, following the same layout as it is currently
+# in the source tree, that is, the "client" directory inside "frontent"
+RewriteCond /usr/lib/python2.7/site-packages/autotest/frontend/client/www/autotest.AfeClient -d
+RewriteRule /afe(.*) /usr/lib/python2.7/site-packages/autotest/frontend/client/www/autotest.AfeClient$1
+
+RewriteCond /usr/lib/python2.6/site-packages/autotest/frontend/client/www/autotest.AfeClient -d
+RewriteRule /afe(.*) /usr/lib/python2.6/site-packages/autotest/frontend/client/www/autotest.AfeClient$1
+
+RewriteCond /usr/lib/python2.5/site-packages/autotest/frontend/client/www/autotest.AfeClient -d
+RewriteRule /afe(.*) /usr/lib/python2.5/site-packages/autotest/frontend/client/www/autotest.AfeClient$1
+
+RewriteCond /usr/lib/python2.4/site-packages/autotest/frontend/client/www/autotest.AfeClient -d
+RewriteRule /afe(.*) /usr/lib/python2.4/site-packages/autotest/frontend/client/www/autotest.AfeClient$1
+
 <Location "/afe">
     DirectoryIndex AfeClient.html
 </Location>

--- a/apache/conf/django-directives
+++ b/apache/conf/django-directives
@@ -1,7 +1,7 @@
 <IfModule !prefork.c>
     # Django requires the prefork MPM, so just fail with this bogus directive
     # if it's not loaded. See
-    # http://test.kernel.org/autotest/AutotestServerInstall for more info.
+    # https://github.com/autotest/autotest/wiki/AutotestServerInstall for more info.
     ERROR__DJANGO_REQUIRES_THE_PREFORK_MPM
 </IfModule>
 
@@ -34,5 +34,5 @@ RewriteRule /media(.*) /usr/lib/python2.7/site-packages/django/contrib/admin/med
     # to mod_python's system python site-packages directory.
     # This way our code can depend on library versions other than
     # those available as packages on various OS distributions.
-    PythonPath "['/usr/local/autotest/site-packages', '/usr/local/autotest'] + sys.path"
+    PythonPath "['/usr/local/autotest/site-packages', '/usr/local/autotest', '/usr/lib/python2.7/site-packages/autotest', '/usr/lib/python2.6/site-packages/autotest', '/usr/lib/python2.5/site-packages/autotest', '/usr/lib/python2.4/site-packages/autotest'] + sys.path"
 </Location>

--- a/apache/conf/embedded-spreadsheet-directives
+++ b/apache/conf/embedded-spreadsheet-directives
@@ -1,1 +1,25 @@
-Alias /embedded_spreadsheet "/usr/local/autotest/frontend/client/www/autotest.EmbeddedSpreadsheetClient"
+RewriteEngine On
+
+# This rule is meant for autotest installations under a single directory,
+# such as when pulling the code from git or from a tarball
+RewriteCond /usr/local/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet -d
+RewriteRule /embedded_spreadsheet(.*) /usr/local/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet$1
+
+# This rule is meant for autotest installations from a package such as RPM
+RewriteCond /usr/share/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet -d
+RewriteRule /embedded_spreadsheet(.*) /usr/share/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet$1
+
+# These rules are fallbacks when autotest web client is installed along
+# the autotest server files, following the same layout as it is currently
+# in the source tree, that is, the "client" directory inside "frontent"
+RewriteCond /usr/lib/python2.7/site-packages/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet -d
+RewriteRule /embedded_spreadsheet(.*) /usr/lib/python2.7/site-packages/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet$1
+
+RewriteCond /usr/lib/python2.6/site-packages/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet -d
+RewriteRule /embedded_spreadsheet(.*) /usr/lib/python2.6/site-packages/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet$1
+
+RewriteCond /usr/lib/python2.5/site-packages/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet -d
+RewriteRule /embedded_spreadsheet(.*) /usr/lib/python2.5/site-packages/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet$1
+
+RewriteCond /usr/lib/python2.4/site-packages/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet -d
+RewriteRule /embedded_spreadsheet(.*) /usr/lib/python2.4/site-packages/autotest/frontend/client/www/autotest.EmbeddedSpreadsheet$1

--- a/apache/conf/embedded-tko-directives
+++ b/apache/conf/embedded-tko-directives
@@ -1,1 +1,25 @@
-Alias /embedded_tko "/usr/local/autotest/frontend/client/www/autotest.EmbeddedTkoClient"
+RewriteEngine On
+
+# This rule is meant for autotest installations under a single directory,
+# such as when pulling the code from git or from a tarball
+RewriteCond /usr/local/autotest/frontend/client/www/autotest.EmbeddedTkoClient -d
+RewriteRule /embedded_tko(.*) /usr/local/autotest/frontend/client/www/autotest.EmbeddedTkoClient$1
+
+# This rule is meant for autotest installations from a package such as RPM
+RewriteCond /usr/share/autotest/frontend/client/www/autotest.EmbeddedTkoClient -d
+RewriteRule /embedded_tko(.*) /usr/share/autotest/frontend/client/www/autotest.EmbeddedTkoClient$1
+
+# These rules are fallbacks when autotest web client is installed along
+# the autotest server files, following the same layout as it is currently
+# in the source tree, that is, the "client" directory inside "frontent"
+RewriteCond /usr/lib/python2.7/site-packages/autotest/frontend/client/www/autotest.EmbeddedTkoClient -d
+RewriteRule /embedded_tko(.*) /usr/lib/python2.7/site-packages/autotest/frontend/client/www/autotest.EmbeddedTkoClient$1
+
+RewriteCond /usr/lib/python2.6/site-packages/autotest/frontend/client/www/autotest.EmbeddedTkoClient -d
+RewriteRule /embedded_tko(.*) /usr/lib/python2.6/site-packages/autotest/frontend/client/www/autotest.EmbeddedTkoClient$1
+
+RewriteCond /usr/lib/python2.5/site-packages/autotest/frontend/client/www/autotest.EmbeddedTkoClient -d
+RewriteRule /embedded_tko(.*) /usr/lib/python2.5/site-packages/autotest/frontend/client/www/autotest.EmbeddedTkoClient$1
+
+RewriteCond /usr/lib/python2.4/site-packages/autotest/frontend/client/www/autotest.EmbeddedTkoClient -d
+RewriteRule /embedded_tko(.*) /usr/lib/python2.4/site-packages/autotest/frontend/client/www/autotest.EmbeddedTkoClient$1

--- a/apache/conf/new-tko-directives
+++ b/apache/conf/new-tko-directives
@@ -1,4 +1,29 @@
-Alias /new_tko "/usr/local/autotest/frontend/client/www/autotest.TkoClient"
+RewriteEngine On
+
+# This rule is meant for autotest installations under a single directory,
+# such as when pulling the code from git or from a tarball
+RewriteCond /usr/local/autotest/frontend/client/www/autotest.TkoClient -d
+RewriteRule /new_tko(.*) /usr/local/autotest/frontend/client/www/autotest.TkoClient$1
+
+# This rule is meant for autotest installations from a package such as RPM
+RewriteCond /usr/share/autotest/frontend/client/www/autotest.TkoClient -d
+RewriteRule /new_tko(.*) /usr/share/autotest/frontend/client/www/autotest.TkoClient$1
+
+# These rules are fallbacks when autotest web client is installed along
+# the autotest server files, following the same layout as it is currently
+# in the source tree, that is, the "client" directory inside "frontent"
+RewriteCond /usr/lib/python2.7/site-packages/autotest/frontend/client/www/autotest.TkoClient -d
+RewriteRule /new_tko(.*) /usr/lib/python2.7/site-packages/autotest/frontend/client/www/autotest.TkoClient$1
+
+RewriteCond /usr/lib/python2.6/site-packages/autotest/frontend/client/www/autotest.TkoClient -d
+RewriteRule /new_tko(.*) /usr/lib/python2.6/site-packages/autotest/frontend/client/www/autotest.TkoClient$1
+
+RewriteCond /usr/lib/python2.5/site-packages/autotest/frontend/client/www/autotest.TkoClient -d
+RewriteRule /new_tko(.*) /usr/lib/python2.5/site-packages/autotest/frontend/client/www/autotest.TkoClient$1
+
+RewriteCond /usr/lib/python2.4/site-packages/autotest/frontend/client/www/autotest.TkoClient -d
+RewriteRule /new_tko(.*) /usr/lib/python2.4/site-packages/autotest/frontend/client/www/autotest.TkoClient$1
+
 <Location "/new_tko">
     DirectoryIndex TkoClient.html
 </Location>

--- a/apache/conf/tko-directives
+++ b/apache/conf/tko-directives
@@ -1,19 +1,46 @@
-Alias /results "/usr/local/autotest/results/"
-<Directory /usr/local/autotest/results/>
+RewriteEngine On
+
+# This rule is meant for autotest installations under a single directory,
+# such as when pulling the code from git or from a tarball
+RewriteCond /usr/local/autotest/results -d
+RewriteRule /results(.*) /usr/local/autotest/results$1
+
+# This rule is meant for autotest installations from a package such as RPM
+RewriteCond /var/lib/autotest/results -d
+RewriteRule /results(.*) /var/lib/autotest/results$1
+
+<Location "/results">
     Options Indexes FollowSymLinks MultiViews
-    AllowOverride None
     Order allow,deny
     Allow from all
-    <FilesMatch "\.log$">
-        ForceType "text/plain; authoritative=true"
-    </FilesMatch>
-</Directory>
+</Location>
 
-Alias /tko "/usr/local/autotest/tko/"
-<Directory /usr/local/autotest/tko/>
+<LocationMatch "/results.*\.log$">
+    ForceType "text/plain; authoritative=true"
+</LocationMatch>
+
+# This rule is meant for autotest installations under a single directory,
+# such as when pulling the code from git or from a tarball
+RewriteCond /usr/local/autotest/tko -d
+RewriteRule /tko(.*) /usr/local/autotest/tko$1
+
+# These rules serve the tko interface when installed together with autotest
+# libraries on python site-packages. Covers python versions 2.4 through 2.7
+RewriteCond /usr/lib/python2.7/site-packages/autotest/tko -d
+RewriteRule /tko(.*) /usr/lib/python2.7/site-packages/autotest/tko$1
+
+RewriteCond /usr/lib/python2.6/site-packages/autotest/tko -d
+RewriteRule /tko(.*) /usr/lib/python2.6/site-packages/autotest/tko$1
+
+RewriteCond /usr/lib/python2.5/site-packages/autotest/tko -d
+RewriteRule /tko(.*) /usr/lib/python2.5/site-packages/autotest/tko$1
+
+RewriteCond /usr/lib/python2.4/site-packages/autotest/tko -d
+RewriteRule /tko(.*) /usr/lib/python2.4/site-packages/autotest/tko$1
+
+<Location "/tko">
     Options ExecCGI Indexes MultiViews +SymLinksIfOwnerMatch
     DirectoryIndex compose_query.cgi
-    AllowOverride None
     Order allow,deny
     Allow from all
-</Directory>
+</Location>


### PR DESCRIPTION
This is intended to support different installation types of
autotest, either from source or from packages.

Signed-off-by: Martin Krizek mkrizek@redhat.com
Signed-off-by: Cleber Rosa crosa@redhat.com
