### PR TITLE
tko: replace legacy help URL with best current wiki doc on tko

### DIFF
--- a/tko/compose_query.cgi
+++ b/tko/compose_query.cgi
@@ -27,7 +27,7 @@ html_header = """\
   <td>Row: </td>
   <td>Condition: </td>
   <td align="center">
-  <a href="http://autotest.kernel.org/wiki/AutotestTKOCondition">Help</a>
+  <a href="https://github.com/autotest/autotest/wiki/UnderstandingTheTkoResultsDatabase">Help</a>
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
Signed-off-by: Cleber Rosa crosa@redhat.com
