### PR TITLE
Added cd_format = usb2 to the sample.

### DIFF
--- a/client/virt/base.cfg.sample
+++ b/client/virt/base.cfg.sample
@@ -21,6 +21,7 @@ virsh_network = network=default
 images = image1
 # List of optical device object names
 cdroms = cd1
+cd_format = usb2
 
 # USB controller object names (whitespace seperated)
 usbs = usb1


### PR DESCRIPTION
Adding predefined cd_format type avoids this Attribute error in unattended-install test.

   File "/usr/local/autotest/virt/kvm_vm.py", line 284, in add_cdrom
      if format.startswith("scsi-"):
  AttributeError: 'NoneType' object has no attribute 'startswith'
