### PR TITLE
virt test: Make cpus check pattern configurable

### DIFF
--- a/client/virt/base.cfg.sample
+++ b/client/virt/base.cfg.sample
@@ -69,6 +69,10 @@ drive_cache = none
 monitors = humanmonitor1
 # Default monitor type (protocol), if multiple types to be used
 monitor_type = human
+# Pattern to get vcpu threads from monitor.
+#    human monitor: thread_id=(\d+)
+#    qmp monitor: u'thread_id':\s+(\d+)
+vcpu_thread_pattern = "thread_id=(\d+)"
 
 # Guest Display type (vnc, sdl, spice, or nographic)
 display = vnc

--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -1155,7 +1155,9 @@ class VM(virt_vm.BaseVM):
             logging.debug("VM appears to be alive with PID %s", self.get_pid())
 
             o = self.monitor.info("cpus")
-            self.vcpu_threads = re.findall("thread_id=(\d+)", o)
+            vcpu_thread_pattern = params.get("vcpu_thread_pattern",
+                                               "thread_id=(\d+)")
+            self.vcpu_threads = re.findall(vcpu_thread_pattern, str(o))
             o = commands.getoutput("ps aux")
             self.vhost_threads = re.findall("\w+\s+(\d+)\s.*\[vhost-%s\]" %
                                             self.get_pid(), o)


### PR DESCRIPTION
The cpus info output from monitor is different between human monitor
and qmp monitor, so make it configurable to fit different cases.

Signed-off-by: Yiqiao Pu ypu@redhat.com
