### PR TITLE
Unset drive_cache for xen hvm installation.

### DIFF
--- a/client/tests/libvirt/tests.cfg.sample
+++ b/client/tests/libvirt/tests.cfg.sample
@@ -43,6 +43,7 @@ variants:
         qemu_img_binary = /usr/bin/qemu-img
         hvm_or_pv = hvm
         take_regular_screendumps = no
+        drive_cache =
         only raw
         only rtl8139
         only ide


### PR DESCRIPTION
Commit b6bb71130 fix using drive_cache option. However, this is not
supported by xen qemu and so breaks xen hvm installation.

This patch unset drive_cache for xen hvm unattended installation.

Signed-off-by: Miroslav Rezanina mrezanin@redhat.com
