### PR TITLE
Add test for removing guest

### DIFF
--- a/client/tests/libvirt/tests.cfg.sample
+++ b/client/tests/libvirt/tests.cfg.sample
@@ -18,7 +18,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.16.64
-        only unattended_install.cdrom, boot, reboot, shutdown
+        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
 
     # Runs virt-install, f16 64 as a 64 bit PV guest OS, install, boot, shutdown
     - @libvirt_xenpv_f16_quick:
@@ -34,7 +34,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.16.64
-        only unattended_install.cdrom, boot, reboot, shutdown
+        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
 
     # Runs virt-install, f16 64 as a 64 bit HVM (full virt) guest OS,
     # install, boot, shutdown
@@ -52,7 +52,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.16.64
-        only unattended_install.cdrom, boot, reboot, shutdown
+        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
 
     # Runs virt-install, RHEL 6.0 64 bit guest OS, install, boot, shutdown
     - @libvirt_rhel60_quick:
@@ -66,7 +66,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only RHEL.6.0.x86_64
-        only unattended_install.cdrom, boot, reboot, shutdown
+        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
 
     - @libvirt_windows:
         virt_install_binary = /usr/bin/virt-install
@@ -85,7 +85,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Win7.64.sp1
-        only unattended_install.cdrom, boot, reboot, shutdown
+        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
 
 # Choose your test list from the testsets defined
 only libvirt_f16_quick

--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -1755,6 +1755,20 @@ variants:
 
     # Do not define test variants below shutdown
 
+    - remove_guest: install setup image_copy unattended_install.cdrom
+        type = remove_guest
+        shutdown_method = shell
+        kill_vm = yes
+        kill_vm_gracefully = no
+        force_remove_vm = yes
+        start_vm = no
+        restart_vm = no
+        variants:
+            - without_disk:
+                remove_image = no
+            - with_disk:
+                remove_image = yes
+
 whql.support_vm_install, whql.client_install.support_vm:
     image_name += -supportvm
 

--- a/client/virt/tests/remove_guest.py
+++ b/client/virt/tests/remove_guest.py
@@ -1,0 +1,11 @@
+import logging, time
+from autotest_lib.client.common_lib import error
+from autotest_lib.client.virt import virt_utils
+
+
+@error.context_aware
+def run_remove_guest(test, params, env):
+    """
+    everything is done by client.virt module
+    """
+


### PR DESCRIPTION
Running libvirt test with sample configuration create guest that stays
in system after the test. This complicate running test again. For xen is
this issue bigger complication as it does not allow to run pv and hvm test
in one run (second of them will fail as name exists).

This patch adds simple test 'remove_guest' that take care of removing guest
from system. This test is added to sample configuration of libvirt too.

Signed-off-by: Miroslav Rezanina mrezanin@redhat.com
