### PR TITLE
Extending SPICE coverage

### DIFF
--- a/client/virt/base.cfg.sample
+++ b/client/virt/base.cfg.sample
@@ -76,10 +76,11 @@ vcpu_thread_pattern = "thread_id=(\d+)"
 
 # Guest Display type (vnc, sdl, spice, or nographic)
 display = vnc
-# If using a spice display, specific spice options
-qxl = on
-qxl_dev_nr = 1
-spice = disable-ticketing
+
+# Guest VGA type (cirrus,  std, vmware, qxl, xenfb, none)
+vga = std
+
+###
 # Capture contents of display during each test
 take_regular_screendumps = yes
 keep_screendumps_on_error = yes
@@ -88,6 +89,50 @@ screendump_delay = 5
 encode_video_files = yes
 
 
+
+#### SPICE related options valid if display == spice,
+#### you should set vga = qxl to get SPICE in use
+qxl_dev_nr = 1
+qxl_dev_memory = 33554432
+spice_port = 3001
+spice_password = 123456
+spice_addr = 0
+
+spice_ssl = no
+spice_tls_port = 3002
+spice_tls_ciphers = DEFAULT
+spice_gen_x509 = yes
+
+# x509_dir uses passphrase less key by default (defined in x509_secure)
+# spice_x509_dir = no will enable x509_key_file, x509_cert_file and
+# x509_cacert_file
+spice_x509_dir = yes
+
+spice_x509_prefix = /tmp/spice_x509d
+spice_x509_key_file = server-key.pem
+spice_x509_cacert_file = ca-cert.pem
+spice_x509_cert_file = server-cert.pem
+spice_x509_key_password = testPassPhrase
+spice_x509_secure = no
+spice_x509_cacert_subj = /C=CZ/L=BRNO/O=SPICE/CN=my CA
+spice_x509_server_subj = /C=CZ/L=BRNO/O=SPICE/CN=my Server
+spice_secure_channels = main, inputs
+
+# Less common options
+# image compression opts (auto_glz, auto_lz, quic, glz, lz, off)
+spice_image_compression = auto_glz
+# jpeg wan compression opts (auto, never, always)
+spice_jpeg_wan_compression = auto
+# zlib-glz wan compression opts (auto, never, always)
+spice_zlib_glz_wan_compression = auto
+# streaming-video opts (off, all, filter)
+spice_streaming_video = all
+# agent mouse opts (on, off)
+spice_agent_mouse = on
+# playback compression opts (on, off)
+spice_playback_compression = on
+spice_ipv4 = yes
+spice_ipv6 = no
 
 ##### Less-common and default parameters expected by some tests,
 ##### do not modify unless you know what you're doing.

--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -47,6 +47,7 @@ class VM(virt_vm.BaseVM):
             self.process = None
             self.serial_console = None
             self.redirs = {}
+            self.spice_options = {}
             self.vnc_port = 5900
             self.monitors = []
             self.pci_assignable = None
@@ -58,7 +59,6 @@ class VM(virt_vm.BaseVM):
             self.vhost_threads = []
 
 
-        self.spice_port = 8000
         self.name = name
         self.params = params
         self.root_dir = root_dir
@@ -457,25 +457,135 @@ class VM(virt_vm.BaseVM):
         def add_pcidevice(help, host):
             return " -pcidevice host='%s'" % host
 
-        def add_spice(help, port, param):
-            if has_option(help,"spice"):
-                return " -spice port=%s,%s" % (port, param)
-            else:
-                return ""
+        def add_spice(spice_options):
+            """
+            processes spice parameters
+            @param help
+            @param spice_options - dict with spice keys/values
+            """
+            spice_opts = [] # will be used for ",".join()
+            tmp = None
 
-        def add_qxl_vga(help, qxl, vga, qxl_dev_nr=None):
-            str = ""
-            if has_option(help, "qxl"):
-                if qxl and qxl_dev_nr is not None:
-                    str += " -qxl %s" % qxl_dev_nr
-                if has_option(help, "vga") and vga and vga != "qxl":
-                    str += " -vga %s" % vga
-            elif has_option(help, "vga"):
-                if qxl:
-                    str += " -vga qxl"
-                elif vga:
-                    str += " -vga %s" % vga
-            return str
+            def optget(opt):
+                """a helper function"""
+                return spice_options.get(opt)
+
+            tmp = optget("spice_port")
+            if not (tmp):
+                tmp = virt_utils.find_free_port(3000, 3199)
+
+            spice_opts.append("port=%d" % (int(tmp)))
+
+            tmp = optget("spice_password")
+            if tmp:
+                spice_opts.append("password=%s" % (tmp))
+            else:
+                spice_opts.append("disable-ticketing")
+
+            tmp = optget("spice_addr")
+            if tmp:
+                spice_opts.append("addr=%s" % (tmp))
+
+            if optget("spice_ssl") == "yes":
+                # SSL only part
+
+                tmp = optget("spice_tls_ciphers")
+                if tmp:
+                    spice_opts.append("tls-ciphers=%s" % (tmp))
+
+                tmp = optget("spice_tls_port")
+                if not tmp:
+                    tmp = virt_utils.find_free_port(3200, 3399)
+
+                spice_opts.append("tls-port=%d" % (int(tmp)))
+
+                prefix = optget("spice_x509_prefix")
+                if optget("spice_gen_x509") == "yes":
+                    c_subj = optget("spice_x509_cacert_subj")
+                    s_subj = optget("spice_x509_server_subj")
+                    passwd = optget("spice_x509_key_password")
+                    secure = optget("spice_x509_secure")
+
+                    virt_utils.create_x509_dir(prefix, c_subj, s_subj, passwd, \
+                        secure)
+
+                tmp = optget("spice_x509_dir")
+                if tmp == "yes":
+                    spice_opts.append("x509-dir=%s" % (prefix))
+
+                elif tmp == "no":
+                    cacert = optget("spice_x509_cacert_file")
+                    server_key = optget("spice_x509_key_file")
+                    server_cert = optget("spice_x509_cert_file")
+                    spice_opts.append("x509-key-file=%s,x509-cacert-file=%s,"\
+                    "x509-cert-file=%s" % (os.path.join(prefix, server_key), \
+                    os.path.join(prefix, cacert), \
+                    os.path.join(prefix, server_cert)))
+
+                if optget("spice_x509_secure") == "yes":
+                    spice_opts.append("x509-key-password=%s" % \
+                        (optget("spice_x509_key_password")))
+
+                tmp = optget("spice_secure_channels")
+                if tmp:
+                    for item in tmp.split(","):
+                        spice_opts.append("tls-channel=%s" % (item.strip()))
+
+            # Less common options
+            tmp = optget("spice_image_compression")
+            if tmp:
+                spice_opts.append("image-compression=%s" % (tmp))
+
+            tmp = optget("spice_jpeg_wan_compression")
+            if tmp:
+                spice_opts.append("jpeg-wan-compression=%s" % (tmp))
+
+            tmp = optget("spice_zlib_glz_wan_compression")
+            if tmp:
+                spice_opts.append("zlib-glz-wan-compression=%s" % (tmp))
+
+            tmp = optget("spice_streaming_video")
+            if tmp:
+                spice_opts.append("streaming-video=%s" % (tmp))
+
+            tmp = optget("spice_agent_mouse=%s" % (tmp))
+            if tmp:
+                spice_opts.append("agent-mouse=%s" % (tmp))
+
+            tmp = optget("playback_compression")
+            if tmp:
+                spice_opts.append("plaback-compression=%s" % (tmp))
+
+            if optget("spice_ipv4") == "yes":
+                spice_opts.append("ipv4")
+
+            if optget("spice_ipv6") == "yes":
+                spice_opts.append("ipv6")
+
+            return " -spice %s" % (",".join(spice_opts))
+
+        def add_qxl(qxl_nr, qxl_memory):
+            """
+            adds extra qxl devices + sets memory to -vga qxl and extra qxls
+            @param help
+            @param qxl_nr total number of qxl devices
+            @param qxl_memory sets memory to individual devices
+            """
+            mystr = ""
+            start_addr = 0x5
+            vram_help = ""
+
+            if qxl_memory:
+                vram_help = "vram_size=%d" % (qxl_memory)
+                mystr += " -global qxl-vga.%s" % (vram_help)
+
+            for index in range(1, qxl_nr):
+                mystr += " -device qxl,id=video%d,bus=pci.0,addr=%s,%s"\
+                        % (index, hex(start_addr + index), vram_help)
+            return mystr
+
+        def add_vga(vga):
+            return " -vga %s" % vga
 
         def add_kernel(help, filename):
             return " -kernel '%s'" % filename
@@ -606,7 +716,6 @@ class VM(virt_vm.BaseVM):
         defaults = params.get("defaults", "no")
         if has_option(help,"nodefaults") and defaults != "yes":
             qemu_cmd += " -nodefaults"
-            qemu_cmd += " -vga std"
         # Add monitors
         for monitor_name in params.objects("monitors"):
             monitor_params = params.object_params(monitor_name)
@@ -796,18 +905,16 @@ class VM(virt_vm.BaseVM):
         elif params.get("display") == "nographic":
             qemu_cmd += add_nographic(help)
         elif params.get("display") == "spice":
-            qemu_cmd += add_spice(help, self.spice_port, params.get("spice"))
+            qemu_cmd += add_spice(vm.spice_options)
 
-        qxl = ""
-        vga = ""
-        if params.get("qxl"):
-            qxl = params.get("qxl")
-        if params.get("vga"):
-            vga = params.get("vga")
-        if qxl or vga:
-            if params.get("display") == "spice":
-                qxl_dev_nr = params.get("qxl_dev_nr", None)
-                qemu_cmd += add_qxl_vga(help, qxl, vga, qxl_dev_nr)
+        vga = params.get("vga", None)
+        if vga:
+            qemu_cmd += add_vga(vga)
+
+            if vga == "qxl":
+                qxl_dev_memory = int(params.get("qxl_dev_memory", 0))
+                qxl_dev_nr = int(params.get("qxl_dev_nr", 1))
+                qemu_cmd += add_qxl(qxl_dev_nr, qxl_dev_memory)
 
         if params.get("uuid") == "random":
             qemu_cmd += add_uuid(help, vm.uuid)
@@ -983,9 +1090,25 @@ class VM(virt_vm.BaseVM):
             if params.get("display") == "vnc":
                 self.vnc_port = virt_utils.find_free_port(5900, 6100)
 
-            # Find available spice port, if needed
-            if params.get("spice"):
-                self.spice_port = virt_utils.find_free_port(8000, 8100)
+            # Get all SPICE options
+            if params.get("display") == "spice":
+                spice_keys = (
+                "spice_port", "spice_password", "spice_addr", "spice_ssl", \
+                "spice_tls_port", "spice_tls_ciphers", "spice_gen_x509", \
+                "spice_x509_dir", "spice_x509_prefix", "spice_x509_key_file", \
+                "spice_x509_cacert_file", "spice_x509_key_password", \
+                "spice_x509_secure", "spice_x509_cacert_subj", \
+                "spice_x509_server_subj", "spice_secure_channels", \
+                "spice_image_compression", "spice_jpeg_wan_compression", \
+                "spice_zlib_glz_wan_compression", "spice_streaming_video", \
+                "spice_agent_mouse", "spice_playback_compression", \
+                "spice_ipv4", "spice_ipv6", "spice_x509_cert_file", \
+                )
+
+                for skey in spice_keys:
+                    value = params.get(skey, None)
+                    if value:
+                        self.spice_options[skey] = value
 
             # Find random UUID if specified 'uuid = random' in config file
             if params.get("uuid") == "random":

--- a/client/virt/virt_utils.py
+++ b/client/virt/virt_utils.py
@@ -3716,3 +3716,56 @@ class NumaNode(object):
         logging.info("Numa Node record dict:")
         for i in self.cpus:
             logging.info("    %s: %s" % (i, self.dict[i]))
+
+def create_x509_dir(path, cacert_subj, server_subj, passphrase, \
+                    secure = False, bits = 1024, days = 1095):
+    """
+    Creates directory with freshly generated:
+    ca-cart.pem, ca-key.pem, server-cert.pem, server-key.pem,
+
+    @param path: defines path to directory which will be created
+    @param cacert_subj: ca-cert.pem subject
+    @param server_key.csr subject
+    @param passphrase - passphrase to ca-key.pem
+    @param secure = False - defines if the server-key.pem will use a passphrase
+    @param bits = 1024: bit length of keys
+    @param days = 1095: cert expiration
+
+    @raise ValueError: openssl not found or rc != 0
+    @raise OSError: if os.makedirs() failes
+    """
+
+    ssl_cmd = os_dep.command("openssl")
+    path = path + os.path.sep # Add separator to the path
+    shutil.rmtree(path, ignore_errors = True)
+    os.makedirs(path)
+
+    server_key = "server-key.pem.secure"
+    if secure:
+        server_key = "server-key.pem"
+
+    cmd_set = [
+    '%s genrsa -des3 -passout pass:%s -out %sca-key.pem %d' % (ssl_cmd,\
+    passphrase, path, bits),
+    '%s req -new -x509 -days %d -key %sca-key.pem -passin pass:%s -out '\
+    '%sca-cert.pem -subj "%s"' \
+    % (ssl_cmd, days, path, passphrase, path, cacert_subj),
+    '%s genrsa -out %s %d' % (ssl_cmd, path + server_key, bits),
+    '%s req -new -key %s -out %s/server-key.csr '\
+    '-subj "%s"' % (ssl_cmd, path + server_key, path, server_subj),
+    '%s x509 -req -passin pass:%s -days %d -in %sserver-key.csr -CA '\
+    '%sca-cert.pem -CAkey %sca-key.pem -set_serial 01 -out %sserver-cert.pem' \
+     % (ssl_cmd, passphrase, days, path, path, path, path),
+    ]
+
+    if not secure:
+        cmd_set.append('%s rsa -in %s -out %sserver-key.pem' \
+        % (ssl_cmd, path + server_key, path))
+
+    for cmd in cmd_set:
+        status, out = commands.getstatusoutput(cmd)
+        logging.info(cmd)
+
+        if status != 0:
+            logging.error(out)
+            raise ValueError(out)


### PR DESCRIPTION
Splited def add_qxl_vga() into add_qxl() and add_vga() where add_vga() defines -vga option and add_qxl() adds other qxl devices + memory (if defined) to -vga qxl. virt_utils.create_x509_dir() uses openssl command to generate x509-dir required by spice/ssl.

Spice support has been reinvented and it's now covering everything except "plaintext-channel, x509-dh-key-file, sasl (which is not in qemu man page)". virtio-serial related features (spice-agent, smart cards) will be added later as it would be the best to create extend or recreate the current support.

SPICE is not set to be default display nor qxl is set to be the default. I did tested changes without spice/qxl and with random spice options set. And so far it looks good.

Be sure to look at my removal of "-vga std" from nodefaults and setting vga = std in base.cfg.sample
