### PR TITLE
Extending SPICE support

### DIFF
--- a/client/virt/base.cfg.sample
+++ b/client/virt/base.cfg.sample
@@ -76,10 +76,11 @@ vcpu_thread_pattern = "thread_id=(\d+)"
 
 # Guest Display type (vnc, sdl, spice, or nographic)
 display = vnc
-# If using a spice display, specific spice options
-qxl = on
-qxl_dev_nr = 1
-spice = disable-ticketing
+
+# Guest VGA type (cirrus,  std, vmware, qxl, xenfb, none)
+vga = std
+
+###
 # Capture contents of display during each test
 take_regular_screendumps = yes
 keep_screendumps_on_error = yes
@@ -88,6 +89,50 @@ screendump_delay = 5
 encode_video_files = yes
 
 
+
+#### SPICE related options valid if display == spice,
+#### you should set vga = qxl to get SPICE in use
+qxl_dev_nr = 1
+qxl_dev_memory = 33554432
+spice_port = 3001
+spice_password = 123456
+spice_addr = 0
+
+spice_ssl = no
+spice_tls_port = 3002
+spice_tls_ciphers = DEFAULT
+spice_gen_x509 = yes
+
+# x509_dir uses passphrase less key by default (defined in x509_secure)
+# spice_x509_dir = no will enable x509_key_file, x509_cert_file and
+# x509_cacert_file
+spice_x509_dir = yes
+
+spice_x509_prefix = /tmp/spice_x509d
+spice_x509_key_file = server-key.pem
+spice_x509_cacert_file = ca-cert.pem
+spice_x509_cert_file = server-cert.pem
+spice_x509_key_password = testPassPhrase
+spice_x509_secure = no
+spice_x509_cacert_subj = /C=CZ/L=BRNO/O=SPICE/CN=my CA
+spice_x509_server_subj = /C=CZ/L=BRNO/O=SPICE/CN=my Server
+spice_secure_channels = main, inputs
+
+# Less common options
+# image compression opts (auto_glz, auto_lz, quic, glz, lz, off)
+spice_image_compression = auto_glz
+# jpeg wan compression opts (auto, never, always)
+spice_jpeg_wan_compression = auto
+# zlib-glz wan compression opts (auto, never, always)
+spice_zlib_glz_wan_compression = auto
+# streaming-video opts (off, all, filter)
+spice_streaming_video = all
+# agent mouse opts (on, off)
+spice_agent_mouse = on
+# playback compression opts (on, off)
+spice_playback_compression = on
+spice_ipv4 = yes
+spice_ipv6 = no
 
 ##### Less-common and default parameters expected by some tests,
 ##### do not modify unless you know what you're doing.

--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -47,6 +47,7 @@ class VM(virt_vm.BaseVM):
             self.process = None
             self.serial_console = None
             self.redirs = {}
+            self.spice_options = {}
             self.vnc_port = 5900
             self.monitors = []
             self.pci_assignable = None
@@ -58,7 +59,6 @@ class VM(virt_vm.BaseVM):
             self.vhost_threads = []
 
 
-        self.spice_port = 8000
         self.name = name
         self.params = params
         self.root_dir = root_dir
@@ -457,25 +457,117 @@ class VM(virt_vm.BaseVM):
         def add_pcidevice(help, host):
             return " -pcidevice host='%s'" % host
 
-        def add_spice(help, port, param):
-            if has_option(help,"spice"):
-                return " -spice port=%s,%s" % (port, param)
-            else:
-                return ""
+        def add_spice(spice_options, port_range=(3000, 3199),
+             tls_port_range=(3200, 3399)):
+            """
+            processes spice parameters
+            @param help
+            @param spice_options - dict with spice keys/values
+            """
+            spice_opts = [] # will be used for ",".join()
+            tmp = None
 
-        def add_qxl_vga(help, qxl, vga, qxl_dev_nr=None):
-            str = ""
-            if has_option(help, "qxl"):
-                if qxl and qxl_dev_nr is not None:
-                    str += " -qxl %s" % qxl_dev_nr
-                if has_option(help, "vga") and vga and vga != "qxl":
-                    str += " -vga %s" % vga
-            elif has_option(help, "vga"):
-                if qxl:
-                    str += " -vga qxl"
-                elif vga:
-                    str += " -vga %s" % vga
-            return str
+            def optget(opt):
+                """a helper function"""
+                return spice_options.get(opt)
+
+            def set_yes_no_value(key, yes_value=None, no_value=None):
+                """just a helper function"""
+                tmp = optget(key)
+                if tmp == "no" and no_value:
+                    spice_opts.append(no_value)
+
+                elif tmp == "yes" and yes_value:
+                    spice_opts.append(yes_value)
+
+            def set_value(opt_string, key, fallback=None):
+                """just a helper function"""
+                tmp = optget(key)
+
+                if not tmp and fallback:
+                    spice_opts.append(fallback)
+                else:
+                    spice_opts.append(opt_string % tmp)
+            s_port = str(virt_utils.find_free_port(*port_range))
+            set_value("port=%s", "spice_port", "port=%s" % s_port)
+
+            set_value("password=%s", "spice_password", "disable-ticketing")
+            set_value("addr=%s", "spice_addr")
+
+            if optget("spice_ssl") == "yes":
+                # SSL only part
+                t_port = str(virt_utils.find_free_port(*tls_port_range))
+                set_value("tls-port=%s", "spice_tls_port",
+                          "tls-port=%s" % t_port)
+
+                prefix = optget("spice_x509_prefix")
+                if optget("spice_gen_x509") == "yes":
+                    c_subj = optget("spice_x509_cacert_subj")
+                    s_subj = optget("spice_x509_server_subj")
+                    passwd = optget("spice_x509_key_password")
+                    secure = optget("spice_x509_secure")
+
+                    virt_utils.create_x509_dir(prefix, c_subj, s_subj, passwd,
+                                               secure)
+
+                tmp = optget("spice_x509_dir")
+                if tmp == "yes":
+                    spice_opts.append("x509-dir=%s" % (prefix))
+
+                elif tmp == "no":
+                    cacert = optget("spice_x509_cacert_file")
+                    server_key = optget("spice_x509_key_file")
+                    server_cert = optget("spice_x509_cert_file")
+                    keyfile_str = ("x509-key-file=%s,x509-cacert-file=%s,"
+                                   "x509-cert-file=%s" %
+                                   (os.path.join(prefix, server_key),
+                                   os.path.join(prefix, cacert),
+                                   os.path.join(prefix, server_cert)))
+                    spice_opts.append(keyfile_str)
+
+                set_yes_no_value("spice_x509_secure",
+                    yes_value="x509-key-password=%s" %
+                        (optget("spice_x509_key_password")))
+
+                tmp = optget("spice_secure_channels")
+                if tmp:
+                    for item in tmp.split(","):
+                        spice_opts.append("tls-channel=%s" % (item.strip()))
+
+            # Less common options
+            set_value("image-compression=%s", "spice_image_compression")
+            set_value("jpeg-wan-compression=%s", "spice_jpeg_wan_compression")
+            set_value("zlib-glz-wan-compression=%s",
+                      "spice_zlib_glz_wan_compression")
+            set_value("streaming-video=%s", "spice_streaming_video")
+            set_value("agent-mouse=%s", "spice_agent_mouse")
+            set_value("playback-compression=%s", "spice_playback_compression")
+
+            set_yes_no_value("spice_ipv4", yes_value="ipv4")
+            set_yes_no_value("spice_ipv6", yes_value="ipv6")
+
+            return " -spice %s" % (",".join(spice_opts))
+
+        def add_qxl(qxl_nr, qxl_memory=None):
+            """
+            adds extra qxl devices + sets memory to -vga qxl and extra qxls
+            @param qxl_nr total number of qxl devices
+            @param qxl_memory sets memory to individual devices
+            """
+            qxl_str = ""
+            vram_help = ""
+
+            if qxl_memory:
+                vram_help = "vram_size=%d" % qxl_memory
+                qxl_str += " -global qxl-vga.%s" % (vram_help)
+
+            for index in range(1, qxl_nr):
+                qxl_str += " -device qxl,id=video%d,%s"\
+                        % (index, vram_help)
+            return qxl_str
+
+        def add_vga(vga):
+            return " -vga %s" % vga
 
         def add_kernel(help, filename):
             return " -kernel '%s'" % filename
@@ -606,7 +698,6 @@ class VM(virt_vm.BaseVM):
         defaults = params.get("defaults", "no")
         if has_option(help,"nodefaults") and defaults != "yes":
             qemu_cmd += " -nodefaults"
-            qemu_cmd += " -vga std"
         # Add monitors
         for monitor_name in params.objects("monitors"):
             monitor_params = params.object_params(monitor_name)
@@ -796,18 +887,16 @@ class VM(virt_vm.BaseVM):
         elif params.get("display") == "nographic":
             qemu_cmd += add_nographic(help)
         elif params.get("display") == "spice":
-            qemu_cmd += add_spice(help, self.spice_port, params.get("spice"))
+            qemu_cmd += add_spice(vm.spice_options)
 
-        qxl = ""
-        vga = ""
-        if params.get("qxl"):
-            qxl = params.get("qxl")
-        if params.get("vga"):
-            vga = params.get("vga")
-        if qxl or vga:
-            if params.get("display") == "spice":
-                qxl_dev_nr = params.get("qxl_dev_nr", None)
-                qemu_cmd += add_qxl_vga(help, qxl, vga, qxl_dev_nr)
+        vga = params.get("vga", None)
+        if vga:
+            qemu_cmd += add_vga(vga)
+
+            if vga == "qxl":
+                qxl_dev_memory = int(params.get("qxl_dev_memory", 0))
+                qxl_dev_nr = int(params.get("qxl_dev_nr", 1))
+                qemu_cmd += add_qxl(qxl_dev_nr, qxl_dev_memory)
 
         if params.get("uuid") == "random":
             qemu_cmd += add_uuid(help, vm.uuid)
@@ -983,9 +1072,25 @@ class VM(virt_vm.BaseVM):
             if params.get("display") == "vnc":
                 self.vnc_port = virt_utils.find_free_port(5900, 6100)
 
-            # Find available spice port, if needed
-            if params.get("spice"):
-                self.spice_port = virt_utils.find_free_port(8000, 8100)
+            # Get all SPICE options
+            if params.get("display") == "spice":
+                spice_keys = (
+                "spice_port", "spice_password", "spice_addr", "spice_ssl",
+                "spice_tls_port", "spice_tls_ciphers", "spice_gen_x509",
+                "spice_x509_dir", "spice_x509_prefix", "spice_x509_key_file",
+                "spice_x509_cacert_file", "spice_x509_key_password",
+                "spice_x509_secure", "spice_x509_cacert_subj",
+                "spice_x509_server_subj", "spice_secure_channels",
+                "spice_image_compression", "spice_jpeg_wan_compression",
+                "spice_zlib_glz_wan_compression", "spice_streaming_video",
+                "spice_agent_mouse", "spice_playback_compression",
+                "spice_ipv4", "spice_ipv6", "spice_x509_cert_file",
+                )
+
+                for skey in spice_keys:
+                    value = params.get(skey, None)
+                    if value:
+                        self.spice_options[skey] = value
 
             # Find random UUID if specified 'uuid = random' in config file
             if params.get("uuid") == "random":


### PR DESCRIPTION
The past SPICE support was covering only old qemu-kvm and it's not working any more with recent qemu

Added SPICE features (configurable qemu-kvm options):
- QXL: configurable memory for qxl
- SSL :x509-dir, x509-key-file, x509-cacert-file, x509-cert-file, x509-key-password, tls-port, tls-ciphers, secure-channels
- SSL: added virt_utils.create_x509_dir() which creates required certificates for x509 options
- Compression: image-compression, jpeg-wan-compression, zlib-glz-wan-compression, playback-compression
- Networking: ipv4, ipv6, addr
- Other: agent-mouse

Modified:
- QXL: replaced old way of defining number of qxl devices qxl=n -> -device qxl
- QXL is now being trough in kvm_vm.add_vga()
- VGA: vga = std is now defined in base.cfg.sample (removed from -nodefaults in kvm_vm.py)
- drop add_qxl_vga() into favor of add_vga() (+ add_qxl() in case that user defined qxl memory or extra qxl devices)

(Sorry for previous issues with pull requests)
