### PR TITLE
virt.guest-os.cfg.sample: WinXP variants: sp2, sp3

### DIFF
--- a/client/virt/guest-os.cfg.sample
+++ b/client/virt/guest-os.cfg.sample
@@ -1345,20 +1345,6 @@ variants:
                 variants:
                     - 32:
                         image_name += -32
-                        install:
-                            cdrom_cd1 = isos/windows/WindowsXP-sp2-vlk.iso
-                            md5sum_cd1 = 743450644b1d9fe97b3cf379e22dceb0
-                            md5sum_1m_cd1 = b473bf75af2d1269fec8958cf0202bfd
-                            user = user
-                            steps = steps/WinXP-32.steps
-                        setup:
-                            steps = steps/WinXP-32-rss.steps
-                        unattended_install.cdrom, whql.support_vm_install:
-                            cdrom_cd1 = isos/windows/WindowsXP-sp2-vlk.iso
-                            md5sum_cd1 = 743450644b1d9fe97b3cf379e22dceb0
-                            md5sum_1m_cd1 = b473bf75af2d1269fec8958cf0202bfd
-                            unattended_file = unattended/winxp32.sif
-                            floppy = images/winXP-32/answer.vfd
                         whql.submission:
                             desc_path_desc1 = $\WDK\Logo Type\Device Logo\Windows XP
                             desc_path_desc2 = $\WDK\Logo Type\Systems Logo\Windows XP
@@ -1372,6 +1358,37 @@ variants:
                         multi_disk, usb_multi_disk:
                             list_volume_command = fsutil fsinfo drives
 
+                        variants:
+                            - sp2:
+                                install:
+                                    cdrom_cd1 = isos/windows/WindowsXP-sp2-vlk.iso
+                                    md5sum_cd1 = 743450644b1d9fe97b3cf379e22dceb0
+                                    md5sum_1m_cd1 = b473bf75af2d1269fec8958cf0202bfd
+                                    user = user
+                                    steps = steps/WinXP-32.steps
+                                setup:
+                                    steps = steps/WinXP-32-rss.steps
+                                unattended_install.cdrom, whql.support_vm_install:
+                                    cdrom_cd1 = isos/windows/WindowsXP-sp2-vlk.iso
+                                    md5sum_cd1 = 743450644b1d9fe97b3cf379e22dceb0
+                                    md5sum_1m_cd1 = b473bf75af2d1269fec8958cf0202bfd
+                                    unattended_file = unattended/winxp32.sif
+                                    floppy = images/winXP-32/answer.vfd
+                            - sp3:
+                                install:
+                                    cdrom_cd1 = isos/windows/en_windows_xp_professional_with_service_pack_3_x86_cd_x14-80428.iso
+                                    md5sum_cd1 = f424a52153e6e5ed4c0d44235cf545d5
+                                    md5sum_1m_cd1 = ffe6bd8747f5a90e58710d28529e2c85
+                                    user = user
+                                    steps = steps/WinXP-32.steps
+                                setup:
+                                    steps = steps/WinXP-32-rss.steps
+                                unattended_install.cdrom, whql.support_vm_install:
+                                    cdrom_cd1 = isos/windows/en_windows_xp_professional_with_service_pack_3_x86_cd_x14-80428.iso
+                                    md5sum_cd1 = f424a52153e6e5ed4c0d44235cf545d5
+                                    md5sum_1m_cd1 = ffe6bd8747f5a90e58710d28529e2c85
+                                    unattended_file = unattended/winxp32.sif
+                                    floppy = images/winXP-32/answer.vfd
 
                     - 64:
                         image_name += -64


### PR DESCRIPTION
- WinXP 32 variant now contains variants 
  - sp2 (the old content - few things that I've moved one level up)
  - sp3 WinXP sp3 

WinXP x64 does not seem to have this service pack if any.
