### PR TITLE
[kvm-autotest] tests.cgroup: Add cpuset_mems_switching test

### DIFF
--- a/client/tests/kvm/tests/cgroup.py
+++ b/client/tests/kvm/tests/cgroup.py
@@ -1951,15 +1951,13 @@ def run_cgroup(test, params, env):
                          "processes might occur.")
             sessions[0].sendline('dd if=/dev/zero of=/dev/null bs=%dM '
                                  'iflag=fullblock' % size)
-            time.sleep(2)
 
             i = 0
-            sessions[1].cmd('killall -SIGUSR1 dd')
+            sessions[1].cmd('killall -SIGUSR1 dd ; true')
             t_stop = time.time() + test_time
             while time.time() < t_stop:
                 i += 1
                 assign_vm_into_cgroup(vm, cgroup, i % 2)
-            time.sleep(2)
             sessions[1].cmd('killall -SIGUSR1 dd; true')
             try:
                 out = sessions[0].read_until_output_matches(

--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -1369,6 +1369,7 @@ variants:
                 # cgroup_memory_limit_kb = 2097152
             - memory_move:
                 cgroup_test = "memory_move"
+                restart_vm = "yes"
                 # cgroup_test_time, cgroup_memory_move_mb
                 # cgroup_memory_move_mb = 2048
 


### PR DESCRIPTION
Hi,

This patchset adds new cpuset_mems_switching test and fixes some issues of memory_move test.

Regards,
Lukáš Doktor
