### PR TITLE
Make test source directories configurable

### DIFF
--- a/global_config.ini
+++ b/global_config.ini
@@ -49,6 +49,8 @@ sql_debug_mode: False
 autotest_top_path: /usr/local/autotest
 # The path for tests tmp directory
 test_tmp_dir:
+# The path for tests bin/src directory
+test_src_dir:
 
 [AUTOSERV]
 # Autotest potential install paths


### PR DESCRIPTION
This patch adds test_src_dir option in COMMON section in
global_config.ini that, when set, would be assign to self.bindir of
base_test class.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
Signed-off-by: Martin Krizek mkrizek@redhat.com
