### PR TITLE
KVM test: Repairs multiname flags bug in cpuflag test.

### DIFF
--- a/client/tests/kvm/tests/cpuflags.py
+++ b/client/tests/kvm/tests/cpuflags.py
@@ -389,13 +389,13 @@ def run_cpuflags(test, params, env):
 
             if all_host_supported_flags == "yes":
                 for fadd in flags.cpumodel_unsupport_flags:
-                    cpuf_model += ",+" + fadd
+                    cpuf_model += ",+" + str(fadd)
             else:
                 for fadd in extra_flags:
-                    cpuf_model += ",+" + fadd
+                    cpuf_model += ",+" + str(fadd)
 
             for fdel in flags.host_unsupported_flags:
-                cpuf_model += ",-" + fdel
+                cpuf_model += ",-" + str(fdel)
 
             if all_host_supported_flags == "yes":
                 guest_flags = flags.all_possible_guest_flags
@@ -443,7 +443,7 @@ def run_cpuflags(test, params, env):
 
             # Add unsupported flags.
             for fadd in flags.host_all_unsupported_flags:
-                cpuf_model += ",+" + fadd
+                cpuf_model += ",+" + str(fadd)
 
             vnc_port = virt_utils.find_free_port(5900, 6100) - 5900
             cmd = "%s -cpu %s -vnc :%d" % (qemu_binary, cpuf_model, vnc_port)
@@ -479,7 +479,7 @@ def run_cpuflags(test, params, env):
 
             # Add unsupported flags.
             for fadd in flags.host_all_unsupported_flags:
-                cpuf_model += ",+" + fadd
+                cpuf_model += ",+" + str(fadd)
 
             vnc_port = virt_utils.find_free_port(5900, 6100) - 5900
             cmd = "%s -cpu %s -vnc :%d" % (qemu_binary, cpuf_model, vnc_port)
@@ -514,10 +514,10 @@ def run_cpuflags(test, params, env):
 
             # Add unsupported flags.
             for fadd in flags.cpumodel_unsupport_flags:
-                cpuf_model += ",+" + fadd
+                cpuf_model += ",+" + str(fadd)
 
             for fdel in flags.host_unsupported_flags:
-                cpuf_model += ",-" + fdel
+                cpuf_model += ",-" + str(fdel)
 
             (self.vm, _) = start_guest_with_cpuflags(cpuf_model, smp)
 
@@ -583,10 +583,10 @@ def run_cpuflags(test, params, env):
 
             # Add unsupported flags.
             for fadd in flags.cpumodel_unsupport_flags:
-                cpuf_model += ",+" + fadd
+                cpuf_model += ",+" + str(fadd)
 
             for fdel in flags.host_unsupported_flags:
-                cpuf_model += ",-" + fdel
+                cpuf_model += ",-" + str(fdel)
 
             (self.vm, _) = start_guest_with_cpuflags(cpuf_model, smp)
 
@@ -667,10 +667,10 @@ def run_cpuflags(test, params, env):
             cpuf_model = cpu_model
 
             for fadd in extra_flags:
-                cpuf_model += ",+" + fadd
+                cpuf_model += ",+" + str(fadd)
 
             for fdel in flags.host_unsupported_flags:
-                cpuf_model += ",-" + fdel
+                cpuf_model += ",-" + str(fdel)
 
             install_path = "/tmp"
 

--- a/client/virt/deps/test_cpu_flags/stress.c
+++ b/client/virt/deps/test_cpu_flags/stress.c
@@ -45,6 +45,7 @@ void stress(inst in) {
 		b[i] = rand();
 	}
 	omp_set_num_threads(in.num_threads);
+	printf("Stress round.\n");
 	#pragma omp parallel
 	while (1){
 		AddTwo(a, b, in.num_threads); // call AddTwo function}
@@ -68,7 +69,6 @@ void stress(inst in) {
 			xop();
 		if (in.sse4a)
 			sse4a();
-		printf("Stress round.\n");
 	}
 	free(a);
 	free(b);

--- a/client/virt/virt_utils.py
+++ b/client/virt/virt_utils.py
@@ -1339,13 +1339,19 @@ class Flag(str):
         else:
             return False
 
+    def __str__(self):
+        return self.split("|")[0]
+
+    def __repr__(self):
+        return self.split("|")[0]
+
     def __hash__(self, *args, **kwargs):
         return 0
 
 
 kvm_map_flags_to_test = {
             Flag('avx')                        :set(['avx']),
-            Flag('sse3')                       :set(['sse3']),
+            Flag('sse3|pni')                   :set(['sse3']),
             Flag('ssse3')                      :set(['ssse3']),
             Flag('sse4.1|sse4_1|sse4.2|sse4_2'):set(['sse4']),
             Flag('aes')                        :set(['aes','pclmul']),


### PR DESCRIPTION
Repairs qemu -cpu command line creation. Instead of
sse4_2|sse4.2 it insert only sse4_2 to qemu -cpu
command line.

And adds work-around aexpect bug to stress.c.
aexpect Expect.read_nonblocking reads data even if timeout expired and
process started in shell produces lots of data to output.

Signed-off-by: Jiří Župka jzupka@redhat.com
