### PR TITLE
web: Show jobs from all users by default

### DIFF
--- a/frontend/client/src/autotest/afe/JobOwnerFilter.java
+++ b/frontend/client/src/autotest/afe/JobOwnerFilter.java
@@ -45,7 +45,7 @@ public class JobOwnerFilter extends FieldFilter
         parentPanel.add(allUsersRadio);
         parentPanel.add(selectUserPanel);
 
-        selectUserRadio.setValue(true);
+        allUsersRadio.setValue(true);
     }
 
     @Override


### PR DESCRIPTION
This is a solution for issue #112.

By default, when we look at the job list, only the jobs
of the current user are displayed, but most of the time
we want to check out all the users' jobs (say, for jobs
scheduled outside the web interface, for example). So
change the default to display jobs for all users.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
