### PR TITLE
kvm-autotest: Allow migration of multiple machines.

### DIFF
--- a/client/tests/kvm/tests/migration_multi_host.py
+++ b/client/tests/kvm/tests/migration_multi_host.py
@@ -19,8 +19,9 @@ def run_migration_multi_host(test, params, env):
         def migration_scenario(self):
             srchost = self.params.get("hosts")[0]
             dsthost = self.params.get("hosts")[1]
+            vms = params.get("vms").split()
 
-            self.migrate_wait(["vm1"], srchost, dsthost)
+            self.migrate_wait(vms, srchost, dsthost)
 
     mig = TestMultihostMigration(test, params, env)
     mig.run()


### PR DESCRIPTION
Change migration_multi_host test to migrate all vms on same time.

Signed-off-by: Jiří Župka jzupka@redhat.com
