### PR TITLE
virt: introduced import method for guest install

### DIFF
--- a/client/virt/libvirt_vm.py
+++ b/client/virt/libvirt_vm.py
@@ -702,6 +702,12 @@ class VM(virt_vm.BaseVM):
             else:
                 return ""
 
+        def add_import(help):
+            if has_option(help, "import"):
+                return " --import"
+            else:
+                return ""
+
         def add_drive(help, filename, pool=None, vol=None, device=None,
                       bus=None, perms=None, size=None, sparse=False,
                       cache=None, format=None):
@@ -886,6 +892,9 @@ class VM(virt_vm.BaseVM):
                                  pxeboot_link)
                     shutil.rmtree(pxeboot_link)
                 os.symlink(kernel_dir, pxeboot_link)
+
+        elif params.get("medium") == "import":
+            virt_install_cmd += add_import(help)
 
         if location:
             virt_install_cmd += add_location(help, location)
@@ -1075,6 +1084,8 @@ class VM(virt_vm.BaseVM):
 
         # Verify the md5sum of the ISO images
         for cdrom in params.objects("cdroms"):
+            if params.get("medium") == "import":
+                break
             cdrom_params = params.object_params(cdrom)
             iso = cdrom_params.get("cdrom")
             if ((self.driver_type == 'xen') and

--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -74,6 +74,10 @@ variants:
             - kernel_initrd:
                 only Linux
                 medium = kernel_initrd
+            - import:
+                medium = import
+                force_create_image = no
+                create_image = no
 
     - qemu_iotests:
         type = qemu_iotests

--- a/client/virt/tests/unattended_install.py
+++ b/client/virt/tests/unattended_install.py
@@ -885,6 +885,11 @@ class UnattendedInstallConfig(object):
             cleanup(self.nfs_mount)
 
 
+    def setup_import(self):
+        self.unattended_file = None
+        self.params['kernel_params'] = None
+
+
     def setup(self):
         """
         Configure the environment for unattended install.
@@ -902,6 +907,8 @@ class UnattendedInstallConfig(object):
             self.setup_url()
         elif self.medium == "nfs":
             self.setup_nfs()
+        elif self.medium == "import":
+            self.setup_import()
         else:
             raise ValueError("Unexpected installation method %s" %
                              self.medium)
@@ -958,6 +965,15 @@ def run_unattended_install(test, params, env):
         if params.get("wait_no_ack", "no") == "no" and\
             post_finish_str in finish_signal:
             break
+
+        # Due to libvirt automaticly start guest after import
+        # we only need to wait for successful login.
+        if params.get("medium") == "import":
+            try:
+                vm.login()
+                break
+            except (virt_utils.LoginError, Exception), e:
+                pass
 
         if migrate_background:
             vm.migrate(timeout=mig_timeout, protocol=mig_protocol)


### PR DESCRIPTION
Introduced new import method for unattended install for libvirt.

When you want to run multiple test over one virtual machine or you already have existing disk image and for this you can use import method.
