### PR TITLE
libvirt: Support libvirt on RHEL 5 KVM hypervisor

### DIFF
--- a/client/tests/kvm/tests.cfg.sample
+++ b/client/tests/kvm/tests.cfg.sample
@@ -73,7 +73,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.16.64
-        only unattended_install.cdrom, boot, shutdown
+        only unattended_install.cdrom.extra_cdrom_ks, boot, shutdown
         # qemu needs -enable-kvm on the cmdline
         extra_params += ' -enable-kvm'
 
@@ -91,7 +91,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.16.64
-        only unattended_install.cdrom, boot, shutdown
+        only unattended_install.cdrom.extra_cdrom_ks, boot, shutdown
 
     # Runs qemu-kvm, f16 64 bit guest OS, install, starts qemu-kvm
     # with 9P support and runs 9P CI tests
@@ -107,7 +107,7 @@ variants:
         only smallpages
         only 9p_export
         only Fedora.16.64
-        only unattended_install.cdrom, boot, 9p.9p_ci, shutdown
+        only unattended_install.cdrom.extra_cdrom_ks, boot, 9p.9p_ci, shutdown
 
     # Runs your own guest image (qcow2, can be adjusted), all migration tests
     # (on a core2 duo laptop with HD and 4GB RAM, F15 host took 3 hours to run)

--- a/client/tests/libvirt/tests.cfg.sample
+++ b/client/tests/libvirt/tests.cfg.sample
@@ -19,7 +19,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.16.64
-        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
+        only unattended_install.cdrom.extra_cdrom_ks, boot, reboot, shutdown, remove_guest.with_disk
 
     # Runs virt-install, f16 64 as a 64 bit PV guest OS, install, boot, shutdown
     - @libvirt_xenpv_f16_quick:
@@ -35,7 +35,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.16.64
-        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
+        only unattended_install.cdrom.http_ks, boot, reboot, shutdown, remove_guest.with_disk
 
     # Runs virt-install, f16 64 as a 64 bit HVM (full virt) guest OS,
     # install, boot, shutdown
@@ -53,7 +53,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only Fedora.16.64
-        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
+        only unattended_install.cdrom.in_cdrom_ks, boot, reboot, shutdown, remove_guest.with_disk
 
     # Runs virt-install, RHEL 6.0 64 bit guest OS, install, boot, shutdown
     - @libvirt_rhel60_quick:
@@ -68,7 +68,7 @@ variants:
         only no_pci_assignable
         only smallpages
         only RHEL.6.0.x86_64
-        only unattended_install.cdrom, boot, reboot, shutdown, remove_guest.with_disk
+        only unattended_install.cdrom.extra_cdrom_ks, boot, reboot, shutdown, remove_guest.with_disk
 
     - @libvirt_windows:
         virt_install_binary = /usr/bin/virt-install

--- a/client/virt/guest-os.cfg.sample
+++ b/client/virt/guest-os.cfg.sample
@@ -16,12 +16,6 @@ variants:
         mem_chk_cmd = dmidecode -t 17 | awk -F: '/Size/ {print $2}'
         mem_chk_cur_cmd = grep MemTotal /proc/meminfo
         cpu_chk_cmd = grep -c processor /proc/cpuinfo
-        unattended_install:
-            # If you want to use floppy to hold kickstarts,
-            # comment the 3 lines below
-            cdroms += " unattended"
-            drive_index_unattended = 1
-            drive_index_cd1 = 2
         timedrift:
             extra_params += " -no-kvm-pit-reinjection"
             time_command = date +'TIME: %a %m/%d/%Y %H:%M:%S.%N'

--- a/client/virt/libvirt_vm.py
+++ b/client/virt/libvirt_vm.py
@@ -876,8 +876,7 @@ class VM(virt_vm.BaseVM):
         elif params.get("medium") == 'cdrom':
             if params.get("use_libvirt_cdrom_switch") == 'yes':
                 virt_install_cmd += add_cdrom(help, params.get("cdrom_cd1"))
-            elif ((self.driver_type == 'xen') and
-                  (params.get('hvm_or_pv') == 'hvm')):
+            elif params.get("unattended_delivery_method") == "integrated":
                 virt_install_cmd += add_cdrom(help,
                                               params.get("cdrom_unattended"))
             else:
@@ -959,7 +958,8 @@ class VM(virt_vm.BaseVM):
                                   image_params.get("drive_cache"),
                                   image_params.get("image_format"))
 
-        if self.driver_type == 'qemu':
+        if params.get('unattended_delivery_method') != 'integrated' and \
+          not (self.driver_type == 'xen' and params.get('hvm_or_pv') == 'pv'):
             for cdrom in params.objects("cdroms"):
                 cdrom_params = params.object_params(cdrom)
                 iso = cdrom_params.get("cdrom")

--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -43,6 +43,28 @@ variants:
         # Set migrate_background to yes to run migration in parallel
         # migrate_background = yes
 
+        # Way of delivering ks file into the guest
+        variants:
+            # Additional iso with kickstart is attached into the guest
+            - extra_cdrom_ks:
+                only Linux
+                unattended_delivery_method = cdrom
+                cdroms += " unattended"
+                drive_index_unattended = 1
+                drive_index_cd1 = 2
+            # Kickstart is packed into the installation iso
+            - in_cdrom_ks:
+                only Linux, unattended_install.cdrom
+                unattended_delivery_method = integrated
+            # Autotest starts simple http server providing kickstart 
+            - http_ks:
+                only Linux
+                unattended_delivery_method = url
+            # Image with kickstart is attached into the guest as floppy drive
+            - floppy_ks:
+                only Linux
+                unattended_delivery_method = floppy
+
         variants:
             # Install guest from cdrom
             - cdrom:


### PR DESCRIPTION
As RHEL 5 contains old version of libvirt, it does not support all features autotest uses for libvirt testing.

This request does not contains all bits needed to run libvirt test on RHEL5. Missing is hack for not using model option for network configuration as this should be solved by Chris's network rewrite of networking. However, it can be added to pull request in case of interest.

This pull request solves problem 2 and 4 in issue #216 and with removing model option allows running libvirt_f16_quick test.
