### PR TITLE
virt_http_server.py: disable name resolution

### DIFF
--- a/client/virt/virt_http_server.py
+++ b/client/virt/virt_http_server.py
@@ -99,6 +99,18 @@ class HTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         return path
 
 
+    def address_string(self):
+        '''
+        This HTTP server does not care about name resolution for the requests
+
+        The first reason is that most of the times our clients are going to be
+        virtual machines without a proper name resolution setup. Also, by not
+        resolving names, we should be a bit faster and be resilient about
+        misconfigured or resilient name servers.
+        '''
+        return self.client_address[0]
+
+
     def log_message(self, format, *args):
         logging.debug("builtin http server handling request from %s: %s" %
                       (self.address_string(), format%args))


### PR DESCRIPTION
Name resolution is not important for the virt http server, and its
use may bring some complications, including performance.

So, let us follow httpd's default by disabling name resolution.

Signed-off-by: Cleber Rosa crosa@redhat.com
