### PR TITLE
utils/check_patch.py: Typo fix and small improvements

### DIFF
--- a/utils/check_patch.py
+++ b/utils/check_patch.py
@@ -280,7 +280,7 @@ class GitBackend(object):
         try:
             utils.run('git add %s' % file)
         except error.CmdError, e:
-            logging.error("Problem adding file %s to svn: %s", file, e)
+            logging.error("Problem adding file %s to git: %s", file, e)
             sys.exit(1)
 
 


### PR DESCRIPTION
This pull request fixes a typo and introduces two small improvements:
- Does not require `$autotest_root/client/utils` to be in the user's `$PATH`
- Does not require `curl` to download patches (detected while running `check_patch.py` in a mobile phone)
