### PR TITLE
virt: Support for indirect image_name definition

### DIFF
--- a/client/virt/base.cfg.sample
+++ b/client/virt/base.cfg.sample
@@ -248,3 +248,5 @@ netdev_peer_re = "\s{2,}(.*?): .*?\\\s(.*?):"
 
 image_clone_commnad = 'cp --reflink=auto %s %s'
 image_remove_commnad = 'rm -rf %s'
+
+indirect_image_blacklist = "/dev/hda.* /dev/sda.* /dev/sg0 /dev/md0"


### PR DESCRIPTION
Hi,

this patch adds support for indirect image_name specification. The purpose is to set wildcard + offset instead of the exact name.

I'm using it for testing devices I add in the test. Eg. I use pre_script = "modprobe scsi_debug" which adds new /dev/sg? device. I know it's the last device so I can set the wildcard "/dev/sg?" and offset '-1'.

To prevent data loss I added blacklist with support for re which protects /dev/sda.\* /dev/hda.\* ...

For details please see the patch.

Regards,
Lukáš Doktor
