### PR TITLE
virt/base.cfg: removed obsolete variable priv_bridge_ports

### DIFF
--- a/client/virt/base.cfg.sample
+++ b/client/virt/base.cfg.sample
@@ -203,8 +203,7 @@ keep_video_files_on_error = yes
 # Default remote shell port (SSH under linux)
 shell_port = 22
 # If you need more ports to be available for comm between host and guest,
-# please add them here
-priv_bridge_ports = 53 67
+# please see http://wiki.libvirt.org/page/Networking#Fedora.2FRHEL_Bridging
 
 # Default scheduler params
 used_cpus = 1


### PR DESCRIPTION
- I've searched for usage of this variable within code and found out
  that lmr already removed our private bridge implementation. So if
  you want it use libvirt + e.g. iptables rules.
- I also modified comment so it will point everybody to libvirt wiki
