### PR TITLE
Tighten install server integration2

### DIFF
--- a/frontend/afe/rpc_interface.py
+++ b/frontend/afe/rpc_interface.py
@@ -207,6 +207,7 @@ def get_hosts(multiple_labels=(), exclude_only_if_needed_labels=False,
                                        for attribute in host_obj.attribute_list)
         if remote.install_server_is_configured():
             host_dict['profiles'] = server.find_profile({"comment":"*" + host_dict['platform'] + "*"})
+            host_dict['profiles'].insert(0, 'Do_not_install')
             host_dict['current_profile'] = server.find_system({"name":host_dict['hostname']},True)[0]['profile']
         else:
             host_dict['profiles'] = ['N/A']

--- a/server/frontend.py
+++ b/server/frontend.py
@@ -180,6 +180,7 @@ class AFE(RpcClient):
             server = xmlrpclib.ServerProxy(remote.get_install_server_info().get('xmlrpc_url', None))
             for host in hosts:
                 host['profiles'] = server.find_profile({"comment":"*" + host['platform'] + "*"})
+                host['profiles'].insert(0, 'Do_not_install')
                 host['current_profile'] = server.find_system({"name":host['hostname']},True)[0]['profile']
         else:
             for host in hosts:

--- a/server/hosts/remote.py
+++ b/server/hosts/remote.py
@@ -84,6 +84,8 @@ class RemoteHost(base_classes.Host):
         if install_server_is_configured():
             if profile is None:
                 profile = self.profile
+            if profile == 'Do_not_install':
+                return
             ServerInterface = self.INSTALL_SERVER_MAPPING[server_info['type']]
             server_interface = ServerInterface(**server_info)
             server_interface.install_host(self, profile=profile,


### PR DESCRIPTION
Hi,

So one gap in the current implementation of the install server
functionality I noticed is that the end-user still has to fiddle with
the backend cobbler server when they want to install a different than
the currently selected profile. It seems like the end user should be
able to select the profile to use on a host-by-host basis.

Some implementation notes:

The link between autotest and cobbler is established by the platform of the autotest host being found in the comment field for the profile in cobbler. This is because the architectures in Cobbler are not necessarily the same as the platforms in Autotest and I can't think of a good way to manage them together.

In my environment, I always want to reinstall the machine before running any tests, so I've modified the default client and server control files to run machine_install as below. I'm going to test removing these changes and instead using the presence of the install server and a valid profile as instruction to reinstall the machine in the job.

diff --git a/frontend/afe/control_file.py b/frontend/afe/control_file.py
index d9df3e6..7f33717 100644
--- a/frontend/afe/control_file.py
+++ b/frontend/afe/control_file.py
@@ -85,6 +85,7 @@ def step_init():
     # a host object we use solely for the purpose of finding out the booted
     # kernel version, we use machines[0] since we already check that the same
     # kernel has been booted on all machines

\+    step0()
     if len(kernel_list) > 1:
         kernel_host = hosts.create_host(machines[0])
@@ -107,6 +108,12 @@ def step_init():

 job.automatic_test_tag = kernel_host.get_kernel_ver()
 step_test()

+def step0():
+    def run(machine):
+        host = hosts.create_host(machine, initialize=False)
+        job.run_test('reinstall', host=host, disable_sysinfo=True)
+
+    job.parallel_simple(run, machines)

 def step_test():
 """ % CLIENT_KERNEL_TEMPLATE
diff --git a/server/control_segments/client_wrapper b/server/control_segments/client_wrapper
index 08e6018..c4c71cb 100644
--- a/server/control_segments/client_wrapper
+++ b/server/control_segments/client_wrapper
@@ -3,6 +3,7 @@ at = autotest_remote.Autotest()

 def run_client(machine):
     host = hosts.create_host(machine)
     +host.machine_install(timeout=3600)
     host.log_kernel()
     at.run(control, host=host)

Changed since v1 (pull request #254):
- Fixed bugs in clone
- Fixed bugs in reinstall
- More testing

1/11: hosts/remote: add install_server_is_configured
2/11: database: add profile column to afe_host_queue_entries table
3/11: frontend: add XMLRPC lookup of profile information from install server to get_hosts
4/11: frontend: add profiles parameter to job creation interfaces
5/11: hosts: add installable_host class
6/11: autoserv: append profile selection to hostname parameter
7/11: frontend/afe: add current profile to host view
8/11: frontend/afe: add profile used to job view
9/11: frontend/afe: add listbox widget support
10/11: frontend/afe: add profile to host tables
11/11: fronted/afe: add support for do_not_install profile
