### PR TITLE
Make contrib/install-autotest-server.sh really working automagically.

### DIFF
--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -7,6 +7,7 @@ LOG="/tmp/$BASENAME-$DATETIMESTAMP.log"
 ATPASSWD=
 MYSQLPW=
 INSTALL_PACKAGES_ONLY=0
+export LANG=en_US.utf8
 
 print_log() {
 echo $(date "+%H:%M:%S") $1 '|' $2 | tee -a $LOG
@@ -22,7 +23,7 @@ Currently supported systems: Fedora 16 and RHEL 6.2.
 GENERAL OPTIONS:
    -h      Show this message
    -u      Autotest user password
-   -d      Autotest MySQL database password
+   -d      MySQL database root password
 
 INSTALLATION STEP SELECTION:
    -p      Only install packages
@@ -226,7 +227,7 @@ print_log "INFO" "Installing autotest"
 if [ "$(grep "^autotest:" /etc/passwd)" = "" ]
 then
     print_log "INFO" "Adding user autotest"
-    useradd autotest
+    useradd -b /usr/local autotest
     print_log "INFO" "Setting autotest user password"
     echo "$ATPASSWD
 $ATPASSWD" | passwd --stdin autotest >> $LOG


### PR DESCRIPTION
There are three small bits I changed when making https://github.com/autotest/autotest/wiki/KVMAutotest-GetStartedServer working:

1) care has to be taken for locale (issue #335)
2) help for the install-autotest-server.sh script is slightly misleading (-d doesn't ask for autotest passoword but for the root one)
3) why do we create /home/autotest, cannot we use /usr/local/auotest directly as $HOME?
