### PR TITLE
KVM test: use new functions in cdrom_test

### DIFF
--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -1767,6 +1767,8 @@ variants:
         max_times = 20
         # test whether cdrom is unlocked <300s after boot
         cdrom_test_autounlock = no
+        # test the tray status
+        cdrom_test_tray_status = yes
         # wait before eject $cdrom (let OS initialize cdrom ...)
         workaround_eject_time = 0
 


### PR DESCRIPTION
This patch modifies cdrom_test to use new framework functions.
Also it makes tray-reporting test optional and checks for tray
reporting support.
I reworked the path problems to suit new framework functions.

Regards,
Lukáš
