### PR TITLE
rv_connect: Prevent killing jobs with disown

### DIFF
--- a/client/virt/tests/rv_connect.py
+++ b/client/virt/tests/rv_connect.py
@@ -69,6 +69,14 @@ def print_rv_version(client_session, rv_binary):
     logging.info("spice-gtk version: %s",
             client_session.cmd(rv_binary + " --spice-gtk-version"))
 
+def get_pid(job_string):
+    """
+    Returns PID of process given in string returned from job execution
+    @param job_string '[job_number] job_PID'
+    @return PID
+    """
+    return job_string.split("] ")[1]
+
 def launch_gnome_session(client_session):
     """
     Launches gnome session inside client_session
@@ -79,6 +87,8 @@ def launch_gnome_session(client_session):
     which is not done by default in pure Xorg
     """
     cmd = "nohup gnome-session --display=:0.0 &> /dev/null &"
+    job_output = client_session.cmd(cmd)
+    cmd = "disown -h %s" % get_pid(job_output)
     return client_session.cmd(cmd)
 
 def launch_xorg(client_session):
@@ -170,6 +180,8 @@ def launch_rv(client_vm, guest_vm, params):
     print_rv_version(client_session, rv_binary)
 
     logging.info("Launching %s on the client (virtual)", cmd)
+    job_output = client_session.cmd(cmd)
+    cmd = "disown -h %s" % get_pid(job_output)
     client_session.cmd(cmd)
 
     # client waits for user entry (authentication) if spice_password is set
@@ -179,8 +191,6 @@ def launch_rv(client_vm, guest_vm, params):
 
     wait_timeout() # Wait for conncetion to establish
     verify_established(client_session, host_ip, host_port, rv_binary)
-
-
 
 def run_rv_connect(test, params, env):
     """


### PR DESCRIPTION
Because gnome-session with nohup closed after closing connection,
there is need to use disown for gnome-session and remote-viewer jobs.
New method addred get_pid() which returns PID of job. This PID
is used for disown.
After that remote-viewer is alive after reconnection.

Signed-off-by: Vaclav Ehrlich vehrlich@redhat.com
