### PR TITLE
KVM test: Use customized command to fetch the version of kvm and its userspace

### DIFF
--- a/client/virt/base.cfg.sample
+++ b/client/virt/base.cfg.sample
@@ -305,6 +305,10 @@ netdev_peer_re = "\s{2,}(.*?): .*?\\\s(.*?):"
 # for RHEL6 host, the regex should be:
 # netdev_peer_re = "\s{2,}(.*?):.*?peer=(.*?)\n"
 
+# To check the kvm and qemu-kvm version in host
+kvm_ver_cmd = "modinfo kvm|grep vermagic|awk '{print $2}'"
+kvm_userspace_ver_cmd = "grep -q el5 /proc/version && rpm -qa | grep ^kvm-83-.* || rpm -qa | grep qemu-kvm | head -n 1"
+
 image_clone_commnad = 'cp --reflink=auto %s %s'
 image_remove_commnad = 'rm -rf %s'
 

--- a/client/virt/virt_env_process.py
+++ b/client/virt/virt_env_process.py
@@ -296,24 +296,20 @@ def preprocess(test, params, env):
         params["cpu_model"] = env.get("cpu_model")
 
     # Get the KVM kernel module version and write it as a keyval
-    if os.path.exists("/dev/kvm"):
-        try:
-            kvm_version = open("/sys/module/kvm/version").read().strip()
-        except Exception:
-            kvm_version = os.uname()[2]
+    if not os.path.exists("/dev/kvm"):
+        logging.debug("KVM module not loaded")
+    kvm_ver_cmd = params.get("kvm_ver_cmd")
+    if kvm_ver_cmd is not None:
+        kvm_version = commands.getoutput(kvm_ver_cmd)
     else:
         kvm_version = "Unknown"
-        logging.debug("KVM module not loaded")
     logging.debug("KVM version: %s" % kvm_version)
     test.write_test_keyval({"kvm_version": kvm_version})
 
     # Get the KVM userspace version and write it as a keyval
-    qemu_path = virt_utils.get_path(test.bindir, params.get("qemu_binary",
-                                                           "qemu"))
-    version_line = commands.getoutput("%s -help | head -n 1" % qemu_path)
-    matches = re.findall("[Vv]ersion .*?,", version_line)
-    if matches:
-        kvm_userspace_version = " ".join(matches[0].split()[1:]).strip(",")
+    kvm_userspace_ver_cmd = params.get("kvm_userspace_ver_cmd")
+    if kvm_userspace_ver_cmd is not None:
+        kvm_userspace_version = commands.getoutput(kvm_userspace_ver_cmd)
     else:
         kvm_userspace_version = "Unknown"
     logging.debug("KVM userspace version: %s" % kvm_userspace_version)


### PR DESCRIPTION
We need to run the test for different kinds of host, so we need to use
customized command to fetch their version for rhel5 or rhel6. This patch
let use the "kvm_ver_cmd" and "kvm_userspace_ver_cmd" to get the version for
kvm or kvm userspace.

I have made the kvm_ver_cmd and kvm_userspace_ver_cmd to be self adapted for
both RHEL5 and RHEL6.

changes from v1:
- update the kvm version command by using modinfo kvm

Signed-off-by: Jason Wang jasowang@redhat.com
