### PR TITLE
virt: Set floppy for UnattendedInstallConfig in unattended install

### DIFF
--- a/client/virt/tests/unattended_install.py
+++ b/client/virt/tests/unattended_install.py
@@ -391,8 +391,9 @@ class UnattendedInstallConfig(object):
             self.nfs_mount = tempfile.mkdtemp(prefix='nfs_',
                                               dir=self.tmpdir)
 
-        if getattr(self, 'floppy_name'):
-            self.floppy = os.path.join(root_dir, self.floppy_name)
+        setattr(self, 'floppy', self.floppy_name)
+        if getattr(self, 'floppy'):
+            self.floppy = os.path.join(root_dir, self.floppy)
             if not os.path.isdir(os.path.dirname(self.floppy)):
                 os.makedirs(os.path.dirname(self.floppy))
 


### PR DESCRIPTION
Set up floppy for UnattendedInstallConfig object. Otherwise the
cases run unattended_install without floppy will raise an
AttributeError.

Signed-off-by: Yiqiao Pu ypu@redhat.com
