### PR TITLE
Xml utils

### DIFF
--- a/client/shared/xml_utils.py
+++ b/client/shared/xml_utils.py
@@ -1,5 +1,6 @@
 """
-Wrapper module to load native or included ElementTree module.
+    Utility module standardized on ElementTree 2.6 to minimize dependencies
+    in python 2.4 systems.
 """
 
 try:
@@ -7,7 +8,4 @@ try:
 except ImportError:
     import common
 
-try:
-    from xml.etree.ElementTree import *
-except ImportError:
-    from autotest_lib.client.shared.ElementTree import *
+from autotest.client.shared import ElementTree

--- a/client/shared/xml_utils_unittest.py
+++ b/client/shared/xml_utils_unittest.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python
+
+import unittest
+
+try:
+    import autotest.common as common
+except ImportError:
+    import common
+
+from autotest.client.shared import xml_utils, ElementTree
+
+
+class test_xml_utils(unittest.TestCase):
+
+    def test_bundled_elementtree(self):
+        self.assertEqual(xml_utils.ElementTree.VERSION, ElementTree.VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Small update to lock xml_utils onto bundled 2.6 ElementTree.  Then we'll need to police code submissions to make sure they only:

from autotest.client.shared import ElementTree
or
import autotest.client.shared.xml_utils
or
import xml.dom.minidom
