### PR TITLE
virt: Close qemu-io shell session after it create

### DIFF
--- a/client/virt/qemu_io.py
+++ b/client/virt/qemu_io.py
@@ -142,7 +142,8 @@ class QemuIOShellSession(QemuIO):
         """
         Close the shell session for qemu-io
         """
-        self.session.close()
+        if not self.create_session:
+            self.session.close()
 
 
 class QemuIOSystem(QemuIO):


### PR DESCRIPTION
The shell session for qemu-io will not create in init step which
will cause the close session through out an error. So close it
after it created.

Signed-off-by: Yiqiao Pu ypu@redhat.com
