### PR TITLE
Replacing the obsolete env variable of bridge with the new one: netdst.

### DIFF
--- a/client/virt/tests/rv_connect.py
+++ b/client/virt/tests/rv_connect.py
@@ -123,7 +123,7 @@ def launch_rv(client_vm, guest_vm, params):
     @param params
     """
     rv_binary = params.get("rv_binary", "remote-viewer")
-    host_ip = virt_utils.get_ip_address_by_interface(params.get("bridge"))
+    host_ip = virt_utils.get_ip_address_by_interface(params.get("netdst"))
     host_port = None
     display = params.get("display")
     cmd = rv_binary + " --display=:0.0"


### PR DESCRIPTION
The bridge variant was removed, which rv_connect used. Updating rv_connect to point to the new variant netdst.

Signed-off-by: Vimal Patel vipatel@redhat.com
