### PR TITLE
Xml utils

### DIFF
--- a/client/shared/ElementPath.py
+++ b/client/shared/ElementPath.py
@@ -1,0 +1,198 @@
+#
+# ElementTree
+# $Id: ElementPath.py 1858 2004-06-17 21:31:41Z Fredrik $
+#
+# limited xpath support for element trees
+#
+# history:
+# 2003-05-23 fl   created
+# 2003-05-28 fl   added support for // etc
+# 2003-08-27 fl   fixed parsing of periods in element names
+#
+# Copyright (c) 2003-2004 by Fredrik Lundh.  All rights reserved.
+#
+# fredrik@pythonware.com
+# http://www.pythonware.com
+#
+# --------------------------------------------------------------------
+# The ElementTree toolkit is
+#
+# Copyright (c) 1999-2004 by Fredrik Lundh
+#
+# By obtaining, using, and/or copying this software and/or its
+# associated documentation, you agree that you have read, understood,
+# and will comply with the following terms and conditions:
+#
+# Permission to use, copy, modify, and distribute this software and
+# its associated documentation for any purpose and without fee is
+# hereby granted, provided that the above copyright notice appears in
+# all copies, and that both that copyright notice and this permission
+# notice appear in supporting documentation, and that the name of
+# Secret Labs AB or the author not be used in advertising or publicity
+# pertaining to distribution of the software without specific, written
+# prior permission.
+#
+# SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD
+# TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANT-
+# ABILITY AND FITNESS.  IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR
+# BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
+# DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+# WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+# ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
+# OF THIS SOFTWARE.
+# --------------------------------------------------------------------
+
+# Licensed to PSF under a Contributor Agreement.
+# See http://www.python.org/2.4/license for licensing details.
+
+##
+# Implementation module for XPath support.  There's usually no reason
+# to import this module directly; the <b>ElementTree</b> does this for
+# you, if needed.
+##
+
+import re
+
+xpath_tokenizer = re.compile(
+    "(::|\.\.|\(\)|[/.*:\[\]\(\)@=])|((?:\{[^}]+\})?[^/:\[\]\(\)@=\s]+)|\s+"
+    ).findall
+
+class xpath_descendant_or_self:
+    pass
+
+##
+# Wrapper for a compiled XPath.
+
+class Path:
+
+    ##
+    # Create an Path instance from an XPath expression.
+
+    def __init__(self, path):
+        tokens = xpath_tokenizer(path)
+        # the current version supports 'path/path'-style expressions only
+        self.path = []
+        self.tag = None
+        if tokens and tokens[0][0] == "/":
+            raise SyntaxError("cannot use absolute path on element")
+        while tokens:
+            op, tag = tokens.pop(0)
+            if tag or op == "*":
+                self.path.append(tag or op)
+            elif op == ".":
+                pass
+            elif op == "/":
+                self.path.append(xpath_descendant_or_self())
+                continue
+            else:
+                raise SyntaxError("unsupported path syntax (%s)" % op)
+            if tokens:
+                op, tag = tokens.pop(0)
+                if op != "/":
+                    raise SyntaxError(
+                        "expected path separator (%s)" % (op or tag)
+                        )
+        if self.path and isinstance(self.path[-1], xpath_descendant_or_self):
+            raise SyntaxError("path cannot end with //")
+        if len(self.path) == 1 and isinstance(self.path[0], type("")):
+            self.tag = self.path[0]
+
+    ##
+    # Find first matching object.
+
+    def find(self, element):
+        tag = self.tag
+        if tag is None:
+            nodeset = self.findall(element)
+            if not nodeset:
+                return None
+            return nodeset[0]
+        for elem in element:
+            if elem.tag == tag:
+                return elem
+        return None
+
+    ##
+    # Find text for first matching object.
+
+    def findtext(self, element, default=None):
+        tag = self.tag
+        if tag is None:
+            nodeset = self.findall(element)
+            if not nodeset:
+                return default
+            return nodeset[0].text or ""
+        for elem in element:
+            if elem.tag == tag:
+                return elem.text or ""
+        return default
+
+    ##
+    # Find all matching objects.
+
+    def findall(self, element):
+        nodeset = [element]
+        index = 0
+        while 1:
+            try:
+                path = self.path[index]
+                index = index + 1
+            except IndexError:
+                return nodeset
+            set = []
+            if isinstance(path, xpath_descendant_or_self):
+                try:
+                    tag = self.path[index]
+                    if not isinstance(tag, type("")):
+                        tag = None
+                    else:
+                        index = index + 1
+                except IndexError:
+                    tag = None # invalid path
+                for node in nodeset:
+                    new = list(node.getiterator(tag))
+                    if new and new[0] is node:
+                        set.extend(new[1:])
+                    else:
+                        set.extend(new)
+            else:
+                for node in nodeset:
+                    for node in node:
+                        if path == "*" or node.tag == path:
+                            set.append(node)
+            if not set:
+                return []
+            nodeset = set
+
+_cache = {}
+
+##
+# (Internal) Compile path.
+
+def _compile(path):
+    p = _cache.get(path)
+    if p is not None:
+        return p
+    p = Path(path)
+    if len(_cache) >= 100:
+        _cache.clear()
+    _cache[path] = p
+    return p
+
+##
+# Find first matching object.
+
+def find(element, path):
+    return _compile(path).find(element)
+
+##
+# Find text for first matching object.
+
+def findtext(element, path, default=None):
+    return _compile(path).findtext(element, default)
+
+##
+# Find all matching objects.
+
+def findall(element, path):
+    return _compile(path).findall(element)

--- a/client/shared/ElementTree.py
+++ b/client/shared/ElementTree.py
@@ -33,6 +33,8 @@
 # 2004-08-23 fl   take advantage of post-2.1 expat features
 # 2005-02-01 fl   added iterparse implementation
 # 2005-03-02 fl   fixed iterparse support for pre-2.2 versions
+# 2012-06-29 cevich@redhat.com Made all classes new-style
+# 2012-07-02 cevich@redhat.com Include dist. ElementPath
 #
 # Copyright (c) 1999-2005 by Fredrik Lundh.  All rights reserved.
 #
@@ -111,37 +113,17 @@ __all__ = [
 
 import string, sys, re
 
-class _SimpleElementPath:
-    # emulate pre-1.2 find/findtext/findall behaviour
-    def find(self, element, tag):
-        for elem in element:
-            if elem.tag == tag:
-                return elem
-        return None
-    def findtext(self, element, tag, default=None):
-        for elem in element:
-            if elem.tag == tag:
-                return elem.text or ""
-        return default
-    def findall(self, element, tag):
-        if tag[:3] == ".//":
-            return element.getiterator(tag[3:])
-        result = []
-        for elem in element:
-            if elem.tag == tag:
-                result.append(elem)
-        return result
-
 try:
-    import ElementPath
+    import autotest.common as common
 except ImportError:
-    # FIXME: issue warning in this case?
-    ElementPath = _SimpleElementPath()
+    import common
+
+import autotest.client.shared.ElementPath as ElementPath
 
 # TODO: add support for custom namespace resolvers/default namespaces
 # TODO: add improved support for incremental parsing
 
-VERSION = "1.2.6"
+VERSION = "1.2.6b"
 
 ##
 # Internal element class.  This class defines the Element interface,
@@ -156,7 +138,7 @@ VERSION = "1.2.6"
 # @see Comment
 # @see ProcessingInstruction
 
-class _ElementInterface:
+class _ElementInterface(object):
     # <tag attrib>text<child/>...</tag>tail
 
     ##
@@ -514,7 +496,7 @@ PI = ProcessingInstruction
 #     an URI, and this argument is interpreted as a local name.
 # @return An opaque object, representing the QName.
 
-class QName:
+class QName(object):
     def __init__(self, text_or_uri, tag=None):
         if tag:
             text_or_uri = "{%s}%s" % (text_or_uri, tag)
@@ -537,7 +519,7 @@ class QName:
 # @keyparam file Optional file handle or name.  If given, the
 #     tree is initialized with the contents of this XML file.
 
-class ElementTree:
+class ElementTree(object):
 
     def __init__(self, element=None, file=None):
         assert element is None or iselement(element)
@@ -871,7 +853,7 @@ def parse(source, parser=None):
 #     events are reported.
 # @return A (event, elem) iterator.
 
-class iterparse:
+class iterparse(object):
 
     def __init__(self, source, events=None):
         if not hasattr(source, "read"):
@@ -1001,7 +983,7 @@ fromstring = XML
 # @defreturn string
 
 def tostring(element, encoding=None):
-    class dummy:
+    class dummy(object):
         pass
     data = []
     file = dummy()
@@ -1020,7 +1002,7 @@ def tostring(element, encoding=None):
 # @param element_factory Optional element factory.  This factory
 #    is called to create new Element instances, as necessary.
 
-class TreeBuilder:
+class TreeBuilder(object):
 
     def __init__(self, element_factory=None):
         self._data = [] # data collector
@@ -1108,7 +1090,7 @@ class TreeBuilder:
 # @see #ElementTree
 # @see #TreeBuilder
 
-class XMLTreeBuilder:
+class XMLTreeBuilder(object):
 
     def __init__(self, html=0, target=None):
         try:

--- a/client/shared/xml_utils.py
+++ b/client/shared/xml_utils.py
@@ -3,9 +3,218 @@
     in python 2.4 systems.
 """
 
+import os.path, shutil, tempfile, string
+
 try:
     import autotest.common as common
 except ImportError:
     import common
 
+import logging
+
 from autotest.client.shared import ElementTree
+
+# Used by unittests
+TMPPFX='xml_utils_temp_'
+TMPSFX='.xml'
+
+class TempXMLFile(file):
+    """
+    Temporary XML file removed on instance deletion / unexceptional module exit.
+    """
+
+    def __init__(self, suffix=TMPSFX, prefix=TMPPFX, mode="wb+", buffer=1):
+        """
+        Initialize temporary XML file removed on instance destruction.
+
+        param: suffix: temporary file's suffix
+        param: prefix: temporary file's prefix
+        param: mode: file access mode
+        param: buffer: size of buffer in bytes, 1: line buffered
+        """
+        fd,path = tempfile.mkstemp(suffix=suffix, prefix=prefix)
+        os.close(fd)
+        super(TempXMLFile, self).__init__(path, mode, buffer)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Always remove temporary file on module exit.
+        """
+        self.__del__()
+        super(TempXMLFile, self).__exit__(exc_type, exc_value, traceback)
+
+    def __del__(self):
+        """
+        Remove temporary file on instance delete.
+        """
+        try:
+            os.unlink(self.name)
+        except OSError:
+            pass # don't care
+
+class XMLBackup(TempXMLFile):
+    """Temporary XML backuap, removed on unexceptional destruction."""
+
+    sourcefilename = None
+
+    def __init__(self, sourcefilename):
+        """
+        Initialize a temporary backup from sourcefilename.
+        """
+        super(XMLBackup, self).__init__()
+        self.sourcefilename = sourcefilename
+        self.backup()
+
+    def backup(self):
+        """
+        Overwrite temporary backup with contents of original source.
+        """
+        self.flush()
+        self.seek(0)
+        shutil.copyfileobj(file(self.sourcefilename, "rb"), super(XMLBackup,self))
+        self.seek(0)
+
+    def restore(self):
+        """
+        Overwrite original source with contents of temporary backup
+        """
+        self.flush()
+        self.seek(0)
+        shutil.copyfileobj(super(XMLBackup,self), file(self.sourcefilename, "wb+"))
+        self.seek(0)
+
+    def _info(self):
+        logging.info("Retaining backup of %s in %s", self.sourcefilename,
+                                                     self.name)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """
+        Remove temporary backup on unexceptional module exit.
+        """
+        if exc_type is None and exc_value is None and traceback is None:
+            super(XMLBackup, self).__del__()
+        else:
+            self._info()
+
+    def __del__(self):
+        """
+        Remove temporary file on instance delete.
+        """
+        self._info()
+
+class XMLBase(ElementTree.ElementTree, XMLBackup):
+    """ElementTree backed by a file copy of source"""
+
+    # Automaticaly remove temp file instance destruction
+    tempsource = None
+
+    def __init__(self, xml):
+        """
+        Initialize from a string or filename containing XML source.
+
+        param: xml: A filename or string containing XML
+        """
+        # xml param could be xml string or readable filename
+        if not self.readablefile(xml):
+            self.tempsource = TempXMLFile()
+            self.tempsource.write(xml)
+            # Prevent source modification
+            self.tempsource.close()
+            xml = self.tempsource.name
+        # xml guaranteed to be a filename
+        XMLBackup.__init__(self, sourcefilename=xml)
+        ElementTree.ElementTree.__init__(self, element=None, file=xml)
+        # Ensure parsed content matches file content
+        self.write()
+        self.flush()
+
+    @classmethod
+    def readablefile(cls, filename):
+        """
+        Returns True/False if filename exists and is readable
+        """
+        try:
+            test = file(filename, "rb")
+            test.close()
+            return True
+        except (OSError, IOError):
+            return False
+
+    def write(self, filename=None, encoding="UTF-8"):
+        """
+        Write current XML tree to filename, or self.name if None.
+        """
+        if filename is None:
+            filename = self.name
+        ElementTree.ElementTree.write(self, filename, encoding)
+
+    def read(self, xml):
+        self.__del__()
+        self.__init__(xml)
+
+class Sub(object):
+    """String substituter using string.Template"""
+
+    def __init__(self, **mapping):
+        """Initialize substitution mapping."""
+        self._mapping = mapping
+
+    def substitute(self, text):
+        """
+        Use string.safe_substitute on text and return the result
+
+        @param: text: string to substitute
+        """
+        return string.Template(text).safe_substitute(**self._mapping)
+
+
+class TemplateXMLTreeBuilder(ElementTree.XMLTreeBuilder, Sub):
+    """Resolve XML templates into temporary file-backed ElementTrees"""
+
+    BuilderClass = ElementTree.TreeBuilder
+
+    def __init__(self, **mapping):
+        """
+        Initialize parser that substitutes keys with values in data
+
+        @param: **mapping: values to be substituted for ${key} in XML input
+        """
+        Sub.__init__(self, **mapping)
+        ElementTree.XMLTreeBuilder.__init__(self, target=self.BuilderClass())
+
+    def feed(self, data):
+        ElementTree.XMLTreeBuilder.feed(self, self.substitute(data))
+
+
+class TemplateXML(XMLBase):
+    """Template-sourced XML ElementTree backed by temporary file."""
+
+    ParserClass = TemplateXMLTreeBuilder
+
+    def __init__(self, xml, **mapping):
+        """
+        Initialize from a XML string or filename, and string.template mapping.
+
+        @param: xml: A filename or string containing XML
+        @param: **mapping: keys/values to feed with XML to string.template
+        """
+        self.parser = self.ParserClass(**mapping)
+        # ElementTree.init calls self.parse()
+        super(TemplateXML, self).__init__(xml)
+        # XMLBase.__init__ calls self.write() after super init
+
+    def parse(self, source):
+        """
+        Parse source XML file or filename using TemplateXMLTreeBuilder
+
+        @param: source: XML file or filename
+        @param: parser: ignored
+        """
+        return super(XMLBase, self).parse(source, self.parser)
+
+    def restore(self):
+        """
+        Raise an IOError to protect the original template source.
+        """
+        raise(IOError, "Protecting template source, disallowing restore to %s" %
+                        self.sourcefilename)

--- a/client/shared/xml_utils_unittest.py
+++ b/client/shared/xml_utils_unittest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-import unittest
+import unittest, tempfile, os, glob
 
 try:
     import autotest.common as common
@@ -10,10 +10,263 @@ except ImportError:
 from autotest.client.shared import xml_utils, ElementTree
 
 
-class test_xml_utils(unittest.TestCase):
+class xml_test_data(unittest.TestCase):
+
+    def setUp(self):
+        # Compacted to save excess scrolling
+        self.TEXT_REPLACE_KEY="TEST_XML_TEXT_REPLACE"
+        self.XMLSTR="""<?xml version='1.0' encoding='UTF-8'?><capabilities><host>
+        <uuid>4d515db1-9adc-477d-8195-f817681e72e6</uuid><cpu><arch>x86_64</arch>
+        <model>Westmere</model><vendor>Intel</vendor><topology sockets='1'
+        cores='2' threads='2'/><feature name='rdtscp'/><feature name='x2apic'/>
+        <feature name='xtpr'/><feature name='tm2'/><feature name='est'/>
+        <feature name='vmx'/><feature name='ds_cpl'/><feature name='monitor'/>
+        <feature name='pbe'/><feature name='tm'/><feature name='ht'/><feature
+        name='ss'/><feature name='acpi'/><feature name='ds'/><feature
+        name='vme'/></cpu><migration_features><live/><uri_transports>
+        <uri_transport>tcp</uri_transport></uri_transports>
+        </migration_features><topology><cells num='1'><cell id='0'><cpus
+        num='4'><cpu id='0'/><cpu id='1'/><cpu id='2'/><cpu id='3'/></cpus>
+        </cell></cells></topology><secmodel><model>selinux</model><doi>0</doi>
+        </secmodel></host><guest><os_type>hvm</os_type><arch name='i686'>
+        <wordsize>32</wordsize><emulator>$TEST_XML_TEXT_REPLACE</emulator>
+        <machine>rhel6.2.0</machine><machine canonical='rhel6.2.0'>pc</machine>
+        <machine>rhel6.1.0</machine><machine>rhel6.0.0</machine><machine>
+        rhel5.5.0</machine><machine>rhel5.4.4</machine><machine>rhel5.4.0
+        </machine><domain type='qemu'></domain><domain type='kvm'><emulator>
+        /usr/libexec/qemu-kvm</emulator></domain></arch><features><cpuselection
+        /><deviceboot/><pae/><nonpae/><acpi default='on' toggle='yes'/><apic
+        default='on' toggle='no'/></features></guest></capabilities>"""
+        (fd, self.XMLFILE) = tempfile.mkstemp(suffix=xml_utils.TMPSFX,
+                                              prefix=xml_utils.TMPPFX)
+        os.write(fd, self.XMLSTR)
+        os.close(fd)
+        self.canonicalize_test_xml()
+
+    def tearDown(self):
+        for filename in glob.glob(os.path.join('/tmp', "%s*%s" %
+                                               (xml_utils.TMPPFX, xml_utils.TMPSFX)
+                                              )):
+            os.unlink(filename)
+
+    def canonicalize_test_xml(self):
+        et = ElementTree.parse(self.XMLFILE)
+        et.write(self.XMLFILE, encoding="UTF-8")
+        f = file(self.XMLFILE)
+        self.XMLSTR = f.read()
+        f.close()
+
+
+class test_ElementTree(xml_test_data):
 
     def test_bundled_elementtree(self):
         self.assertEqual(xml_utils.ElementTree.VERSION, ElementTree.VERSION)
+
+
+class test_TempXMLFile(xml_test_data):
+
+    def test_prefix_sufix(self):
+        filename = os.path.basename(self.XMLFILE)
+        self.assert_(filename.startswith(xml_utils.TMPPFX))
+        self.assert_(filename.endswith(xml_utils.TMPSFX))
+
+    def test_test_TempXMLFile_canread(self):
+        tmpf = xml_utils.TempXMLFile()
+        tmpf.write(self.XMLSTR)
+        tmpf.seek(0)
+        stuff = tmpf.read()
+        self.assertEqual(stuff, self.XMLSTR)
+        del tmpf
+
+    def test_TempXMLFile_implicit(self):
+        def out_of_scope_tempxmlfile():
+            tmpf = xml_utils.TempXMLFile()
+            return tmpf.name
+        self.assertRaises(OSError, os.stat, out_of_scope_tempxmlfile())
+
+
+    def test_TempXMLFile_explicit(self):
+        tmpf = xml_utils.TempXMLFile()
+        tmpf_name = tmpf.name
+        # Assert this does NOT raise an exception
+        os.stat(tmpf_name)
+        del tmpf
+        self.assertRaises(OSError, os.stat, tmpf_name)
+
+
+class test_XMLBackup(xml_test_data):
+
+    class_to_test = xml_utils.XMLBackup
+
+    def is_same_contents(self, filename):
+        f = file(filename, "rb")
+        s = f.read()
+        return s == self.XMLSTR
+
+    def test_backup_filename(self):
+        xmlbackup = self.class_to_test(self.XMLFILE)
+        self.assertEqual(xmlbackup.sourcefilename, self.XMLFILE)
+
+    def test_backup_file(self):
+        xmlbackup = self.class_to_test(self.XMLFILE)
+        self.assertTrue(self.is_same_contents(xmlbackup.name))
+
+    def test_rebackup_file(self):
+        xmlbackup = self.class_to_test(self.XMLFILE)
+        oops = file(xmlbackup.name, "wb")
+        oops.write("foobar")
+        oops.close()
+        self.assertFalse(self.is_same_contents(xmlbackup.name))
+        xmlbackup.backup()
+        self.assertTrue(self.is_same_contents(xmlbackup.name))
+
+    def test_restore_file(self):
+        xmlbackup = self.class_to_test(self.XMLFILE)
+        # nuke source
+        os.unlink(xmlbackup.sourcefilename)
+        xmlbackup.restore()
+        self.assertTrue(self.is_same_contents(xmlbackup.name))
+
+    def test_remove_backup_file(self):
+        xmlbackup = self.class_to_test(self.XMLFILE)
+        filename = xmlbackup.name
+        os.unlink(filename)
+        del xmlbackup
+        self.assertRaises(OSError, os.unlink, filename)
+
+    def test_TempXMLBackup_implicit(self):
+        def out_of_scope_xmlbackup():
+            tmpf = self.class_to_test(self.XMLFILE)
+            return tmpf.name
+        filename = out_of_scope_xmlbackup()
+        #  DOES NOT delete
+        self.assertTrue(self.is_same_contents(filename))
+        os.unlink(filename)
+
+    def test_TempXMLBackup_exception_exit(self):
+        tmpf = self.class_to_test(self.XMLFILE)
+        filename = tmpf.name
+        # simulate exception exit DOES NOT DELETE
+        tmpf.__exit__(Exception, "foo", "bar")
+        self.assertTrue(self.is_same_contents(filename))
+        os.unlink(filename)
+
+    def test_TempXMLBackup_unexception_exit(self):
+        tmpf = self.class_to_test(self.XMLFILE)
+        filename = tmpf.name
+        # simulate normal exit DOES DELETE
+        tmpf.__exit__(None, None, None)
+        self.assertRaises(OSError, os.unlink, filename)
+
+
+class test_XMLBase(test_XMLBackup):
+
+    class_to_test = xml_utils.XMLBase
+
+    def test_init_str(self):
+        xml = self.class_to_test(self.XMLSTR)
+        self.assert_(xml.tempsource is not None)
+
+    def test_init_xml(self):
+        xml = self.class_to_test(self.XMLFILE)
+        self.assert_(xml.tempsource is None)
+
+    def test_restore_from_string(self):
+        xmlbackup = self.class_to_test(self.XMLSTR)
+        os.unlink(xmlbackup.sourcefilename)
+        xmlbackup.restore()
+        self.assertTrue(self.is_same_contents(xmlbackup.tempsource.name))
+
+    def test_restore_from_file(self):
+        xmlbackup = self.class_to_test(self.XMLFILE)
+        os.unlink(xmlbackup.sourcefilename)
+        xmlbackup.restore()
+        self.assertTrue(self.is_same_contents(xmlbackup.name))
+
+    def test_write_default(self):
+        xmlbackup = self.class_to_test(self.XMLFILE)
+        wordsize = xmlbackup.find('guest/arch/wordsize')
+        self.assertTrue(wordsize is not None)
+        self.assertEqual(int(wordsize.text), 32)
+        wordsize.text = str(64)
+        xmlbackup.write()
+        self.assertFalse(self.is_same_contents(xmlbackup.name))
+
+    def test_write_other(self):
+        xmlbackup = self.class_to_test(self.XMLFILE)
+        otherfile = xml_utils.TempXMLFile()
+        xmlbackup.write(otherfile)
+        otherfile.close()
+        self.assertTrue(self.is_same_contents(otherfile.name))
+
+    def test_write_other_changed(self):
+        xmlbackup = self.class_to_test(self.XMLSTR)
+        otherfile = xml_utils.TempXMLFile()
+        wordsize = xmlbackup.find('guest/arch/wordsize')
+        wordsize.text = str(64)
+        xmlbackup.write(otherfile)
+        otherfile.close()
+        xmlbackup.write(self.XMLFILE)
+        xmlbackup.close()
+        self.canonicalize_test_xml()
+        self.assertTrue(self.is_same_contents(otherfile.name))
+
+    def test_read_other_changed(self):
+        xmlbackup = self.class_to_test(self.XMLSTR)
+        wordsize = xmlbackup.find('guest/arch/wordsize')
+        wordsize.text = str(64)
+        otherfile = xml_utils.TempXMLFile()
+        xmlbackup.write(otherfile)
+        otherfile.close()
+        xmlbackup.backup()
+        self.assertTrue(self.is_same_contents(xmlbackup.name))
+        xmlbackup.read(otherfile.name)
+        self.assertFalse(self.is_same_contents(otherfile.name))
+        xmlbackup.write(self.XMLFILE)
+        self.assertFalse(self.is_same_contents(otherfile.name))
+        self.canonicalize_test_xml()
+        self.assertTrue(self.is_same_contents(otherfile.name))
+
+
+class test_templatized_xml(xml_test_data):
+
+    def setUp(self):
+        self.MAPPING = {"foo":"bar", "bar":"baz", "baz":"foo"}
+        self.FULLREPLACE = """<$foo $bar="$baz">${baz}${foo}${bar}</$foo>"""
+        self.RESULTCHECK = """<bar baz="foo">foobarbaz</bar>"""
+        super(test_templatized_xml, self).setUp()
+
+    def test_sub(self):
+        sub = xml_utils.Sub(**self.MAPPING)
+        self.assertEqual(sub.substitute(self.FULLREPLACE), self.RESULTCHECK)
+
+    def test_MappingTreeBuilder_standalone(self):
+        txtb = xml_utils.TemplateXMLTreeBuilder(**self.MAPPING)
+        txtb.feed(self.FULLREPLACE)
+        et = txtb.close()
+        result = ElementTree.tostring(et)
+        self.assertEqual(result, self.RESULTCHECK)
+
+    def test_TemplateXMLTreeBuilder_nosub(self):
+        txtb = xml_utils.TemplateXMLTreeBuilder()
+        # elementree pukes on identifiers starting with $
+        txtb.feed(self.RESULTCHECK)
+        et = txtb.close()
+        result = ElementTree.tostring(et)
+        self.assertEqual(result, self.RESULTCHECK)
+
+    def test_TemplateXML(self):
+        tx = xml_utils.TemplateXML(self.FULLREPLACE, **self.MAPPING)
+        et = ElementTree.ElementTree(None, tx.name)
+        check = ElementTree.tostring(et.getroot())
+        self.assertEqual(check, self.RESULTCHECK)
+
+    def test_restore_fails(self):
+        testmapping = {self.TEXT_REPLACE_KEY:"foobar"}
+        xmlbackup = xml_utils.TemplateXML(self.XMLFILE, **testmapping)
+        # Unless the backup was initialized from a string (into a temp file)
+        # assume the source is read-only and should be protected.
+        self.assertRaises(IOError, xmlbackup.restore)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This includes original patch I sent to ML, introducing TempXMLFile, XMLBackup, XMLBase.  In addition I found that in order to support proper and uniform XPath support, we need  to bundle another ElementTree sub-module: ElementPath.  This is key because it allows users to access elements structurally.  I've updated the unittests to make use of this but they also serve as a good example of how this can be used.  For example, assume you have an ElementTree containing the 'virsh capabilities' XML output and you want to change the architecture of a guest:

xml.find('guest/arch/wordsize').text = 32

Much easier than doing the same thing with minidom.
