### PR TITLE
Add virtio-serialport and virtio-console support to framework

### DIFF
--- a/client/shared/base_utils.py
+++ b/client/shared/base_utils.py
@@ -642,7 +642,8 @@ class FileFieldMonitor(object):
             for i in range(len(self.log) - 1):
                 self.log[i] = (map(lambda x, y: x - y,
                                    self.log[i + 1], self.log[i]))
-            self.log.pop()
+            if self.log:
+                self.log.pop()
         return (self.value, self.test_time, self.log, self.time_step)
 
 

--- a/client/tests/kvm/tests/virtio_console.py
+++ b/client/tests/kvm/tests/virtio_console.py
@@ -1,431 +1,159 @@
+# TODO: Why VM recreation doesn't work?
 """
-virtio_console test
+Collection of virtio_console and virtio_serialport tests.
 
-@copyright: 2010 Red Hat, Inc.
+@copyright: 2010-2012 Red Hat Inc.
 """
-import array, logging, os, random, re, select, shutil, socket, sys, tempfile
-import threading, time, traceback
 from collections import deque
-from threading import Thread
-
-from autotest.client.shared import error
+import array
+import logging
+import os
+import random
+import select
+import socket
+import threading
+import time
 from autotest.client import utils
-from autotest.client.virt import virt_test_utils, kvm_monitor, virt_env_process
-from autotest.client.virt import aexpect, kvm_virtio_port
+from autotest.client.shared import error
+from autotest.client.virt import kvm_virtio_port, virt_env_process
+from autotest.client.virt import virt_test_utils
 
 
+@error.context_aware
 def run_virtio_console(test, params, env):
     """
     KVM virtio_console test
 
-    1) Starts VMs with the specified number of virtio console devices
-    2) Start smoke test
-    3) Start loopback test
-    4) Start performance test
+    This test contain multiple tests. The name of the executed test is set
+    by 'virtio_console_test' cfg variable. Main function with the set name
+    with prefix 'test_' thus it's easy to find out which functions are
+    tests and which are helpers.
 
-    This test uses an auxiliary script, virtio_console_guest.py, that is copied
-    to guests. This script has functions to send and write data to virtio
-    console ports. Details of each test can be found on the docstrings for the
-    test_* functions.
+    Every test has it's own cfg parameters, please see the actual test's
+    docstring for details.
 
     @param test: kvm test object
     @param params: Dictionary with the test parameters
     @param env: Dictionary with test environment
+    @raise error.TestNAError: if function with test_$testname is not present
     """
-    class SubTest(object):
+    ######################################################################
+    # General helpers
+    ######################################################################
+    def get_vm_with_ports(no_consoles=0, no_serialports=0, spread=None,
+                           quiet=False, strict=False):
         """
-        Collect result of subtest of main test.
-        """
-        def __init__(self):
-            """
-            Initialize object
-            """
-            self.result = []
-            self.passed = 0
-            self.failed = 0
-            self.cleanup_func = None
-            self.cleanup_args = None
-
-
-        def set_cleanup_func(self, func, args):
-            """
-            Set cleanup function which is called when subtest fails.
-
-            @param func: Function which should be called when test fails.
-            @param args: Arguments of cleanup function.
-            """
-            self.cleanup_func = func
-            self.cleanup_args = args
-
-
-        def get_cleanup_func(self):
-            """
-            Returns the tupple of cleanup_func and clenaup_args
-
-            @return: Tupple of self.cleanup_func and self.cleanup_args
-            """
-            return (self.cleanup_func, self.cleanup_args)
-
-
-        def do_test(self, function, args=None, fatal=False, cleanup=True):
-            """
-            Execute subtest function.
-
-            @param function: Object of function.
-            @param args: List of arguments of function.
-            @param fatal: If true exception is forwarded to main test.
-            @param cleanup: If true call cleanup function after crash of test.
-            @return: Return what returned executed subtest.
-            @raise TestError: If collapse of test is fatal raise forward
-                        exception from subtest.
-            """
-            if args is None:
-                args = []
-            res = [None, function.func_name, args]
-            try:
-                logging.info("Starting test %s" % function.func_name)
-                ret = function(*args)
-                res[0] = True
-                logging.info(self.result_to_string(res))
-                self.result.append(res)
-                self.passed += 1
-                return ret
-            except Exception:
-                exc_type, exc_value, exc_traceback = sys.exc_info()
-                logging.error("In function (" + function.func_name + "):")
-                logging.error("Call from:\n" +
-                              traceback.format_stack()[-2][:-1])
-                logging.error("Exception from:\n" +
-                              "".join(traceback.format_exception(
-                                                        exc_type, exc_value,
-                                                        exc_traceback.tb_next)))
-                # Clean up environment after subTest crash
-                res[0] = False
-                logging.info(self.result_to_string(res))
-                self.result.append(res)
-                self.failed += 1
-
-                if cleanup:
-                    try:
-                        self.cleanup_func(*self.cleanup_args)
-                    except Exception:
-                        error.TestFail("Cleanup function crashed as well")
-                if fatal:
-                    raise
-
-
-        def is_failed(self):
-            """
-            @return: If any of subtest not pass return True.
-            """
-            if self.failed > 0:
-                return True
-            else:
-                return False
-
-
-        def get_result(self):
-            """
-            @return: Result of subtests.
-               Format:
-                 tuple(pass/fail,function_name,call_arguments)
-            """
-            return self.result
-
-
-        def result_to_string_debug(self, result):
-            """
-            @param result: Result of test.
-            """
-            sargs = ""
-            for arg in result[2]:
-                sargs += str(arg) + ","
-            sargs = sargs[:-1]
-            if result[0]:
-                status = "PASS"
-            else:
-                status = "FAIL"
-            return ("Subtest (%s(%s)): --> %s") % (result[1], sargs, status)
-
-
-        def result_to_string(self, result):
-            """
-            @param result: Result of test.
-            """
-            if result[0]:
-                status = "PASS"
-            else:
-                status = "FAIL"
-            return ("Subtest (%s): --> %s") % (result[1], status)
-
-
-        def headline(self, msg):
-            """
-            Add headline to result output.
-
-            @param msg: Test of headline
-            """
-            self.result.append([msg])
-
-
-        def _gen_res(self, format_func):
-            """
-            Format result with formatting function
-
-            @param format_func: Func for formating result.
-            """
-            result = ""
-            for res in self.result:
-                if (len(res) == 3):
-                    result += format_func(res) + "\n"
-                else:
-                    result += res[0] + "\n"
-            return result
-
-
-        def get_full_text_result(self):
-            """
-            @return string with text form of result
-            """
-            return self._gen_res(lambda str: self.result_to_string_debug(str))
-
-
-        def get_text_result(self):
-            """
-            @return string with text form of result
-            """
-            return self._gen_res(lambda str: self.result_to_string(str))
-
-
-    def process_stats(stats, scale=1.0):
-        """
-        Process and print the stats.
-
-        @param stats: List of measured data.
-        """
-        if not stats:
-            return None
-        for i in range((len(stats) - 1), 0, -1):
-            stats[i] = stats[i] - stats[i - 1]
-            stats[i] /= scale
-        stats[0] /= scale
-        stats = sorted(stats)
-        return stats
-
-
-    def _init_guest(vm, timeout=10):
-        """
-        Execute virtio_console_guest.py on guest, wait until it is initialized.
-
-        @param vm: Informations about the guest.
-        @param timeout: Timeout that will be used to verify if the script
-                started properly.
-        """
-        logging.debug("compile virtio_console_guest.py on guest %s",
-                      vm[0].name)
-
-        (match, data) = _on_guest("python -OO /tmp/virtio_console_guest.py -c"
-                       "&& echo -n 'PASS: Compile virtio_guest finished' ||"
-                       "echo -n 'FAIL: Compile virtio_guest failed'",
-                        vm, timeout)
-
-        if match != 0:
-            raise error.TestFail("Command console_switch.py on guest %s "
-                                 "failed.\nreturn code: %s\n output:\n%s" %
-                                 (vm[0].name, match, data))
-        logging.debug("Starting virtio_console_guest.py on guest %s",
-                      vm[0].name)
-        vm[1].sendline()
-        (match, data) = _on_guest("python /tmp/virtio_console_guest.pyo &&"
-                       "echo -n 'PASS: virtio_guest finished' ||"
-                       "echo -n 'FAIL: virtio_guest failed'",
-                       vm, timeout)
-        if match != 0:
-            raise error.TestFail("Command console_switch.py on guest %s "
-                                 "failed.\nreturn code: %s\n output:\n%s" %
-                                 (vm[0].name, match, data))
-        # Let the system rest
-        time.sleep(2)
-
-
-    def init_guest(vm, consoles):
-        """
-        Prepares guest, executes virtio_console_guest.py and initializes test.
-
-        @param vm: Informations about the guest.
-        @param consoles: Informations about consoles.
-        """
-        conss = []
-        for mode in consoles:
-            for cons in mode:
-                conss.append(cons.for_guest())
-        _init_guest(vm, 10)
-        on_guest("virt.init(%s)" % (conss), vm, 10)
-
-
-    def _search_kernel_crashlog(vm_port, timeout=2):
-        """
-        Find kernel crash message.
-
-        @param vm_port : Guest output port.
-        @param timeout: Timeout used to verify expected output.
-
-        @return: Kernel crash log or None.
-        """
-        data = vm_port.read_nonblocking(0.1, timeout)
-        match = re.search("BUG:", data, re.MULTILINE)
-        if match is None:
-            return None
-
-        match = re.search(r"BUG:.*---\[ end trace .* \]---",
-                  data, re.DOTALL | re.MULTILINE)
-        if match is None:
-            data += vm_port.read_until_last_line_matches(
-                                ["---\[ end trace .* \]---"], timeout)
-
-        match = re.search(r"(BUG:.*---\[ end trace .* \]---)",
-                  data, re.DOTALL | re.MULTILINE)
-        return match.group(0)
-
-
-
-    def _on_guest(command, vm, timeout=2):
-        """
-        Execute given command inside the script's main loop, indicating the vm
-        the command was executed on.
-
-        @param command: Command that will be executed.
-        @param vm: Informations about the guest.
-        @param timeout: Timeout used to verify expected output.
-
-        @return: Tuple (match index, data, kernel_crash)
-        """
-        logging.debug("Executing '%s' on virtio_console_guest.py loop," +
-                      " vm: %s, timeout: %s", command, vm[0].name, timeout)
-        vm[1].sendline(command)
-        try:
-            (match, data) = vm[1].read_until_last_line_matches(["PASS:",
-                                                                "FAIL:"],
-                                                               timeout)
-
-        except aexpect.ExpectError, e:
-            match = None
-            data = "Cmd process timeout. Data in console: " + e.output
-
-        kcrash_data = _search_kernel_crashlog(vm[3])
-        if kcrash_data is not None:
-            logging.error(kcrash_data)
-            vm[4] = True
-
-        return (match, data)
-
-
-    def on_guest(command, vm, timeout=2):
-        """
-        Wrapper around the _on_guest command which executes the command on
-        guest. Unlike _on_guest command when the command fails it raises the
-        test error.
-
-        @param command: Command that will be executed.
-        @param vm: Informations about the guest.
-        @param timeout: Timeout used to verify expected output.
-
-        @return: Tuple (match index, data)
-        """
-        match, data = _on_guest(command, vm, timeout)
-        if match == 1 or match is None:
-            raise error.TestFail("Failed to execute '%s' on"
-                                 " virtio_console_guest.py, "
-                                 "vm: %s, output:\n%s" %
-                                 (command, vm[0].name, data))
-
-        return (match, data)
-
-
-    def _guest_exit_threads(vm, send_pts, recv_pts):
-        """
-        Safely executes on_guest("virt.exit_threads()") using workaround of
-        the stuck thread in loopback in mode=virt.LOOP_NONE .
-
-        @param vm: Informations about the guest.
-        @param send_pts: list of possible send sockets we need to work around.
-        @param recv_pts: list of possible recv sockets we need to read-out.
-        """
-        # in LOOP_NONE mode it might stuck in read/write
-        match, tmp = _on_guest("virt.exit_threads()", vm, 10)
-        if match is None:
-            logging.debug("Workaround the stuck thread on guest")
-            # Thread is stucked in read/write
-            for send_pt in send_pts:
-                send_pt.sock.sendall(".")
-        elif match != 0:
-            # Something else
-            raise error.TestFail("Unexpected fail\nMatch: %s\nData:\n%s"
-                                 % (match, tmp))
-
-        # Read-out all remaining data
-        for recv_pt in recv_pts:
-            while select.select([recv_pt.sock], [], [], 0.1)[0]:
-                recv_pt.sock.recv(1024)
-
-        # This will cause fail in case anything went wrong.
-        on_guest("print 'PASS: nothing'", vm, 10)
-
-
-    def _vm_create(no_console=3, no_serialport=3, spread=True, quiet=False):
-        # TODO: Add option to suppress logging.warning (for max_console tests)
-        """
-        Creates the VM and connects the specified number of consoles and serial
-        ports.
-        Ports are allocated by 2 per 1 virtio-serial-pci device starting with
-        console. (3+2 => CC|CS|S; 0+2 => SS; 3+4 => CC|CS|SS|S, ...) This way
-        it's easy to test communication on the same or different
-        virtio-serial-pci device.
-        Further in tests the consoles are being picked always from the first
-        available one (3+2: 2xC => CC|cs|s <communication on the same PCI>;
-        2xC,1xS => CC|cS|s <communication between 2 PCI devs)
-
+        Checks whether existing 'main_vm' fits the requirements, modifies
+        it if needed and returns the VM object.
         @param no_console: Number of desired virtconsoles.
         @param no_serialport: Number of desired virtserialports.
-        @return: Tuple with (guest information, consoles information)
-                guest informations = [vm, session, tmp_dir, kcrash]
-                consoles informations = [consoles[], serialports[]]
+        @param spread: Spread consoles across multiple virtio-serial-pcis.
+        @param quiet: Notify user about VM recreation.
+        @param strict: Whether no_consoles have to match or just exceed.
+        @return: vm object matching the requirements.
         """
         # check the number of running VM's consoles
         vm = env.get_vm(params.get("main_vm"))
 
-        _no_serialports = 0
-        _no_consoles = 0
-        for port in vm.virtio_ports:
-            if isinstance(port, kvm_virtio_port.VirtioSerial):
-                _no_serialports += 1
-            else:
-                _no_consoles += 1
+        if not vm:
+            _no_serialports = -1
+            _no_consoles = -1
+        else:
+            _no_serialports = 0
+            _no_consoles = 0
+            for port in vm.virtio_ports:
+                if isinstance(port, kvm_virtio_port.VirtioSerial):
+                    _no_serialports += 1
+                else:
+                    _no_consoles += 1
+        _spread = int(params.get('virtio_port_spread', 2))
+        if spread is None:
+            spread = _spread
+        if strict:
+            if (_no_serialports != no_serialports or
+                    _no_consoles != no_consoles):
+                _no_serialports = -1
+                _no_consoles = -1
         # If not enough ports, modify params and recreate VM
-        if _no_serialports < no_serialport or _no_consoles < no_console:
-            logging.warning("cfg: not enough virtio_ports specified, increase "
-                            "the number of virtio_ports in config.")
+        if (_no_serialports < no_serialports or _no_consoles < no_consoles
+                or spread != _spread):
+            if not quiet:
+                out = "tests reqirements are different from cfg: "
+                if _no_serialports < no_serialports:
+                    out += "serial_ports(%d), " % no_serialports
+                if _no_consoles < no_consoles:
+                    out += "consoles(%d), " % no_consoles
+                if spread != _spread:
+                    out += "spread(%s), " % spread
+                logging.warning(out[:-2] + ". Modify config to speedup tests.")
 
             params['virtio_ports'] = ""
-            if spread is True:  # Compatibility with the original default value
-                params['virtio_port_spread'] = 2
-            elif spread:
+            if spread:
                 params['virtio_port_spread'] = spread
             else:
                 params['virtio_port_spread'] = 0
 
-            for i in xrange(no_console):
+            for i in xrange(max(no_consoles, _no_consoles)):
                 name = "console-%d" % i
                 params['virtio_ports'] += " %s" % name
                 params['virtio_port_type_%s' % name] = "console"
 
-            for i in xrange(no_serialport):
+            for i in xrange(max(no_serialports, _no_serialports)):
                 name = "serialport-%d" % i
                 params['virtio_ports'] += " %s" % name
                 params['virtio_port_type_%s' % name] = "serialport"
 
-        (vm, session, sserial) = _restore_vm()
+            if quiet:
+                logging.debug("Recreating VM with more virtio ports.")
+            else:
+                logging.warning("Recreating VM with more virtio ports.")
+            virt_env_process.preprocess_vm(test, params, env,
+                                            params.get("main_vm"))
+            vm = env.get_vm(params.get("main_vm"))
 
+        vm.verify_kernel_crash()
+        return vm
+
+    def get_vm_with_worker(no_consoles=0, no_serialports=0, spread=None,
+                               quiet=False):
+        """
+        Checks whether existing 'main_vm' fits the requirements, modifies
+        it if needed and returns the VM object and guest_worker.
+        @param no_console: Number of desired virtconsoles.
+        @param no_serialport: Number of desired virtserialports.
+        @param spread: Spread consoles across multiple virtio-serial-pcis.
+        @param quiet: Notify user about VM recreation.
+        @param strict: Whether no_consoles have to match or just exceed.
+        @return: tuple (vm object matching the requirements,
+                        initialized GuestWorker of the vm)
+        """
+        vm = get_vm_with_ports(no_consoles, no_serialports, spread, quiet)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        return vm, guest_worker
+
+    def get_vm_with_single_port(port_type='serialport'):
+        """
+        Wrapper which returns vm, guest_worker and virtio_ports with at lest
+        one port of the type specified by fction parameter.
+        @param port_type: type of the desired virtio port.
+        @return: tuple (vm object with at least 1 port of the port_type,
+                        initialized GuestWorker of the vm,
+                        list of virtio_ports of the port_type type)
+        """
+        if port_type == 'serialport':
+            vm, guest_worker = get_vm_with_worker(no_serialports=1)
+            virtio_ports = get_virtio_ports(vm)[1][0]
+        else:
+            vm, guest_worker = get_vm_with_worker(no_consoles=1)
+            virtio_ports = get_virtio_ports(vm)[0][0]
+        return vm, guest_worker, virtio_ports
+
+    def get_virtio_ports(vm):
+        """
+        Returns separated virtconsoles and virtserialports
+        @param vm: VM object
+        @return: tuple (all virtconsoles, all virtserialports)
+        """
         consoles = []
         serialports = []
         for port in vm.virtio_ports:
@@ -433,200 +161,209 @@ def run_virtio_console(test, params, env):
                 serialports.append(port)
             else:
                 consoles.append(port)
+        return (consoles, serialports)
 
-        kcrash = False
-
-        # FIXME: 3rd parameter was console tmp_dir which is handled by kvm_vm
-        return [vm, session, None, sserial, kcrash], [consoles, serialports]
-
-
-    def _restore_vm():
+    @error.context_aware
+    def cleanup(vm=None, guest_worker=None):
         """
-        Restore old virtual machine when VM is destroyed.
+        Cleanup function.
+        @param vm: VM whose ports should be cleaned
+        @param guest_worker: guest_worker which should be cleaned/exited
         """
-        logging.debug("Booting guest %s", params.get("main_vm"))
-        virt_env_process.preprocess_vm(test, params, env,
-                                        params.get("main_vm"))
+        error.context("Cleaning virtio_ports.", logging.debug)
+        logging.debug("Cleaning virtio_ports")
+        if guest_worker:
+            guest_worker.cleanup()
+        if vm:
+            for port in vm.virtio_ports:
+                port.clean_port()
+                port.close()
+                port.mark_as_clean()
 
-        vm = env.get_vm(params.get("main_vm"))
-
-        vm.verify_kernel_crash()
-
-        sserial = virt_test_utils.wait_for_login(vm, 0,
-                                         float(params.get("boot_timeout", 20)),
-                                         0, 2, serial=True)
-        return [vm, session, sserial]
-
-
-    def topen(vm, port):
+    ######################################################################
+    # Smoke tests
+    ######################################################################
+    def test_open():
         """
-        Open virtioconsole port.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port identifier.
+        Try to open virtioconsole port.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        on_guest("virt.open('%s')" % (port.name), vm, 10)
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        guest_worker.cmd("virt.open('%s')" % (port.name))
         port.open()
+        cleanup(vm, guest_worker)
 
-
-    def tcheck_zero_sym(vm):
+    def test_check_zero_sym():
         """
         Check if port /dev/vport0p0 was created.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        on_guest("virt.check_zero_sym()", vm, 10)
+        if params.get('virtio_console_params') == 'serialport':
+            vm, guest_worker = get_vm_with_worker(no_serialports=1)
+        else:
+            vm, guest_worker = get_vm_with_worker(no_consoles=1)
+        guest_worker.cmd("virt.check_zero_sym()", 10)
+        cleanup(vm, guest_worker)
 
-
-    def tmulti_open(vm, port):
+    def test_multi_open():
         """
-        Multiopen virtioconsole port.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port identifier.
+        Try to open the same port twice.
+        @note: It should pass with virtconsole and fail with virtserialport
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        on_guest("virt.close('%s')" % (port.name), vm, 10)
-        on_guest("virt.open('%s')" % (port.name), vm, 10)
-        (match, data) = _on_guest("virt.open('%s')" % (port.name), vm, 10)
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        guest_worker.cmd("virt.close('%s')" % (port.name), 10)
+        guest_worker.cmd("virt.open('%s')" % (port.name), 10)
+        (match, data) = guest_worker._cmd("virt.open('%s')" % (port.name), 10)
         # Console is permitted to open the device multiple times
-        if port.port_type == "yes": #is console?
-            if match != 0: #Multiopen not pass
+        if port.is_console == "yes":    # is console?
+            if match != 0:  # Multiple open didn't pass
                 raise error.TestFail("Unexpected fail of opening the console"
                                      " device for the 2nd time.\n%s" % data)
         else:
-            if match != 1: #Multiopen not fail:
-                raise error.TestFail("Unexpetded pass of opening the"
+            if match != 1:  # Multiple open didn't fail:
+                raise error.TestFail("Unexpended pass of opening the"
                                      " serialport device for the 2nd time.")
             elif not "[Errno 24]" in data:
                 raise error.TestFail("Multiple opening fail but with another"
                                      " exception %s" % data)
         port.open()
+        cleanup(vm, guest_worker)
 
-
-    def tclose(vm, port):
+    def test_close():
         """
-        Close socket.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port to open.
+        Close the socket on the guest side
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        on_guest("virt.close('%s')" % (port.name), vm, 10)
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        guest_worker.cmd("virt.close('%s')" % (port.name), 10)
         port.close()
+        cleanup(vm, guest_worker)
 
-
-    def tpolling(vm, port):
+    def test_polling():
         """
-        Test try polling function.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
+        Test correct results of poll with different cases.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
         # Poll (OUT)
-        on_guest("virt.poll('%s', %s)" % (port.name, select.POLLOUT), vm,
-                 2)
+        port.open()
+        guest_worker.cmd("virt.poll('%s', %s)" % (port.name, select.POLLOUT),
+                         2)
 
         # Poll (IN, OUT)
         port.sock.sendall("test")
         for test in [select.POLLIN, select.POLLOUT]:
-            on_guest("virt.poll('%s', %s)" % (port.name, test), vm, 10)
+            guest_worker.cmd("virt.poll('%s', %s)" % (port.name, test), 10)
 
         # Poll (IN HUP)
         # I store the socket informations and close the socket
         port.close()
         for test in [select.POLLIN, select.POLLHUP]:
-            on_guest("virt.poll('%s', %s)" % (port.name, test), vm, 10)
+            guest_worker.cmd("virt.poll('%s', %s)" % (port.name, test), 10)
 
         # Poll (HUP)
-        on_guest("virt.recv('%s', 4, 1024, False)" % (port.name), vm, 10)
-        on_guest("virt.poll('%s', %s)" % (port.name, select.POLLHUP), vm,
-                 2)
+        guest_worker.cmd("virt.recv('%s', 4, 1024, False)" % (port.name), 10)
+        guest_worker.cmd("virt.poll('%s', %s)" % (port.name, select.POLLHUP),
+                         2)
 
         # Reconnect the socket
         port.open()
         # Redefine socket in consoles
-        on_guest("virt.poll('%s', %s)" % (port.name, select.POLLOUT), vm,
-                 2)
+        guest_worker.cmd("virt.poll('%s', %s)" % (port.name, select.POLLOUT),
+                         2)
+        cleanup(vm, guest_worker)
 
-
-    def tsigio(vm, port):
+    def test_sigio():
         """
-        Test try sigio function.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
+        Test whether port use generates sigio signals correctly.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        if port.is_open:
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        if port.is_open():
             port.close()
 
         # Enable sigio on specific port
-        on_guest("virt.async('%s', True, 0)" %
-                 (port.name) , vm, 10)
-        on_guest("virt.get_sigio_poll_return('%s')" % (port.name) , vm, 10)
+        guest_worker.cmd("virt.async('%s', True, 0)" % (port.name), 10)
+        guest_worker.cmd("virt.get_sigio_poll_return('%s')" % (port.name), 10)
 
-        #Test sigio when port open
-        on_guest("virt.set_pool_want_return('%s', select.POLLOUT)" %
-                 (port.name), vm, 10)
+        # Test sigio when port open
+        guest_worker.cmd("virt.set_pool_want_return('%s', select.POLLOUT)" %
+                         (port.name), 10)
         port.open()
-        match = _on_guest("virt.get_sigio_poll_return('%s')" %
-                          (port.name) , vm, 10)[0]
+        match = guest_worker._cmd("virt.get_sigio_poll_return('%s')" %
+                                  (port.name), 10)[0]
         if match == 1:
             raise error.TestFail("Problem with HUP on console port.")
 
-        #Test sigio when port receive data
-        on_guest("virt.set_pool_want_return('%s', select.POLLOUT |"
-                 " select.POLLIN)" % (port.name), vm, 10)
+        # Test sigio when port receive data
+        guest_worker.cmd("virt.set_pool_want_return('%s', select.POLLOUT |"
+                         " select.POLLIN)" % (port.name), 10)
         port.sock.sendall("0123456789")
-        on_guest("virt.get_sigio_poll_return('%s')" % (port.name) , vm, 10)
+        guest_worker.cmd("virt.get_sigio_poll_return('%s')" % (port.name), 10)
 
-        #Test sigio port close event
-        on_guest("virt.set_pool_want_return('%s', select.POLLHUP |"
-                 " select.POLLIN)" % (port.name), vm, 10)
+        # Test sigio port close event
+        guest_worker.cmd("virt.set_pool_want_return('%s', select.POLLHUP |"
+                         " select.POLLIN)" % (port.name), 10)
         port.close()
-        on_guest("virt.get_sigio_poll_return('%s')" % (port.name) , vm, 10)
+        guest_worker.cmd("virt.get_sigio_poll_return('%s')" % (port.name), 10)
 
-        #Test sigio port open event and persistence of written data on port.
-        on_guest("virt.set_pool_want_return('%s', select.POLLOUT |"
-                 " select.POLLIN)" % (port.name), vm, 10)
+        # Test sigio port open event and persistence of written data on port.
+        guest_worker.cmd("virt.set_pool_want_return('%s', select.POLLOUT |"
+                         " select.POLLIN)" % (port.name), 10)
         port.open()
-        on_guest("virt.get_sigio_poll_return('%s')" % (port.name) , vm, 10)
+        guest_worker.cmd("virt.get_sigio_poll_return('%s')" % (port.name), 10)
 
-        #Test event when erase data.
-        on_guest("virt.clean_port('%s')" % (port.name), vm, 10)
+        # Test event when erase data.
+        guest_worker.cmd("virt.clean_port('%s')" % (port.name), 10)
         port.close()
-        on_guest("virt.set_pool_want_return('%s', select.POLLOUT)"
-                 % (port.name), vm, 10)
+        guest_worker.cmd("virt.set_pool_want_return('%s', select.POLLOUT)"
+                         % (port.name), 10)
         port.open()
-        on_guest("virt.get_sigio_poll_return('%s')" % (port.name) , vm, 10)
+        guest_worker.cmd("virt.get_sigio_poll_return('%s')" % (port.name), 10)
 
         # Disable sigio on specific port
-        on_guest("virt.async('%s', False, 0)" %
-                 (port.name) , vm, 10)
+        guest_worker.cmd("virt.async('%s', False, 0)" % (port.name), 10)
+        cleanup(vm, guest_worker)
 
-
-    def tlseek(vm, port):
+    def test_lseek():
         """
-        Tests the correct handling of lseek (expected fail)
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
+        Tests the correct handling of lseek
+        @note: lseek should fail
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
         # The virt.lseek returns PASS when the seek fails
-        on_guest("virt.lseek('%s', 0, 0)" % (port.name), vm, 10)
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        guest_worker.cmd("virt.lseek('%s', 0, 0)" % (port.name), 10)
+        cleanup(vm, guest_worker)
 
-
-    def trw_host_offline(vm, port):
+    def test_rw_host_offline():
         """
-        Guest read/write from host when host is disconnected.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
+        Try to read from/write to host on guest when host is disconnected.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        if port.is_open:
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        if port.is_open():
             port.close()
 
-        on_guest("virt.recv('%s', 0, 1024, False)" % port.name, vm, 10)
-        match, tmp = _on_guest("virt.send('%s', 10, True)" % port.name,
-                                                             vm, 10)
+        guest_worker.cmd("virt.recv('%s', 0, 1024, False)" % port.name, 10)
+        match, tmp = guest_worker._cmd("virt.send('%s', 10, True)" % port.name,
+                                       10)
         if match is not None:
             raise error.TestFail("Write on guest while host disconnected "
                                  "didn't time out.\nOutput:\n%s"
@@ -636,25 +373,26 @@ def run_virtio_console(test, params, env):
 
         if (port.sock.recv(1024) < 10):
             raise error.TestFail("Didn't received data from guest")
-        # Now the _on_guest("virt.send('%s'... command should be finished
-        on_guest("print('PASS: nothing')", vm, 10)
+        # Now the cmd("virt.send('%s'... command should be finished
+        guest_worker.cmd("print('PASS: nothing')", 10)
+        cleanup(vm, guest_worker)
 
-
-    def trw_host_offline_big_data(vm, port):
+    def test_rw_host_offline_big_data():
         """
-        Guest read/write from host when host is disconnected.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
+        Try to read from/write to host on guest when host is disconnected
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        if port.is_open:
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        if port.is_open():
             port.close()
 
         port.clean_port()
         port.close()
-        on_guest("virt.clean_port('%s'),1024" % port.name, vm, 10)
-        match, tmp = _on_guest("virt.send('%s', (1024**3)*3, True, "
-                               "is_static=True)" % port.name, vm, 30)
+        guest_worker.cmd("virt.clean_port('%s'),1024" % port.name, 10)
+        match, tmp = guest_worker._cmd("virt.send('%s', (1024**3)*3, True, "
+                               "is_static=True)" % port.name, 30)
         if match is None:
             raise error.TestFail("Write on guest while host disconnected "
                                  "didn't time out.\nOutput:\n%s"
@@ -672,88 +410,23 @@ def run_virtio_console(test, params, env):
             elif rlen != (1024 ** 3 * 3):
                 raise error.TestFail("Not all data was received,"
                                      "only %d from %d" % (rlen, 1024 ** 3 * 3))
-        on_guest("print('PASS: nothing')", vm, 10)
+        guest_worker.cmd("print('PASS: nothing')", 10)
+        cleanup(vm, guest_worker)
 
-
-    def trw_notconnect_guest(vm, port, consoles):
+    def test_rw_blocking_mode():
         """
-        Host send data to guest port and guest not read any data from port.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
-        """
-        vm[0].destroy(gracefully=False)
-        (vm[0], vm[1], vm[3]) = _restore_vm()
-        if not port.is_open:
-            port.open()
-        else:
-            port.close()
-            port.open()
-
-        port.sock.settimeout(20.0)
-
-        loads = utils.SystemLoad([(os.getpid(), 'autotest'),
-                                  (vm[0].get_pid(), 'VM'), 0])
-        loads.start()
-
-        try:
-            sent1 = 0
-            for i in range(1000000):
-                sent1 += port.sock.send("a")
-        except socket.timeout:
-            logging.info("Data sending to closed port timed out.")
-
-        logging.info("Bytes sent to client: %d" % (sent1))
-        logging.info("\n" + loads.get_cpu_status_string()[:-1])
-
-        on_guest('echo -n "PASS:"', vm, 10)
-
-        logging.info("Open and then close port %s" % (port.name))
-        init_guest(vm, consoles)
-        # Test of live and open and close port again
-        _clean_ports(vm, consoles)
-        on_guest("virt.close('%s')" % (port.name), vm, 10)
-
-        # With serialport it is a different behavior
-        on_guest("guest_exit()", vm, 10)
-        port.sock.settimeout(20.0)
-
-        loads.start()
-        try:
-            sent2 = 0
-            for i in range(40000):
-                sent2 = port.sock.send("a")
-        except socket.timeout:
-            logging.info("Data sending to closed port timed out.")
-
-        logging.info("Bytes sent to client: %d" % (sent2))
-        logging.info("\n" + loads.get_cpu_status_string()[:-1])
-        loads.stop()
-        if (sent1 != sent2):
-            logging.warning("Inconsistent behavior: First sent %d bytes and "
-                            "second sent %d bytes" % (sent1, sent2))
-
-        port.sock.settimeout(None)
-        (vm[0], vm[1], vm[3]) = _restore_vm()
-
-        init_guest(vm, consoles)
-        _clean_ports(vm, consoles)
-
-
-    def trw_blocking_mode(vm, port):
-        """
-        Guest read\write data in blocking mode.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
+        Try to read/write data in blocking mode.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
         # Blocking mode
-        if not port.is_open:
-            port.open()
-        on_guest("virt.blocking('%s', True)" % port.name, vm, 10)
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        port.open()
+        guest_worker.cmd("virt.blocking('%s', True)" % port.name, 10)
         # Recv should timed out
-        match, tmp = _on_guest("virt.recv('%s', 10, 1024, False)" %
-                               port.name, vm, 10)
+        match, tmp = guest_worker._cmd("virt.recv('%s', 10, 1024, False)" %
+                               port.name, 10)
         if match == 0:
             raise error.TestFail("Received data even when none was sent\n"
                                  "Data:\n%s" % tmp)
@@ -762,23 +435,23 @@ def run_virtio_console(test, params, env):
                                  (match, tmp))
         port.sock.sendall("1234567890")
         # Now guest received the data end escaped from the recv()
-        on_guest("print('PASS: nothing')", vm, 10)
+        guest_worker.cmd("print('PASS: nothing')", 10)
+        cleanup(vm, guest_worker)
 
-
-    def trw_nonblocking_mode(vm, port):
+    def test_rw_nonblocking_mode():
         """
-        Guest read\write data in nonblocking mode.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
+        Try to read/write data in non-blocking mode.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
         # Non-blocking mode
-        if not port.is_open:
-            port.open()
-        on_guest("virt.blocking('%s', False)" % port.name, vm, 10)
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        port.open()
+        guest_worker.cmd("virt.blocking('%s', False)" % port.name, 10)
         # Recv should return FAIL with 0 received data
-        match, tmp = _on_guest("virt.recv('%s', 10, 1024, False)" %
-                              port.name, vm, 10)
+        match, tmp = guest_worker._cmd("virt.recv('%s', 10, 1024, False)" %
+                              port.name, 10)
         if match == 0:
             raise error.TestFail("Received data even when none was sent\n"
                                  "Data:\n%s" % tmp)
@@ -789,22 +462,30 @@ def run_virtio_console(test, params, env):
             raise error.TestFail("Unexpected fail\nMatch: %s\nData:\n%s" %
                                  (match, tmp))
         port.sock.sendall("1234567890")
-        on_guest("virt.recv('%s', 10, 1024, False)" % port.name, vm, 10)
+        guest_worker.cmd("virt.recv('%s', 10, 1024, False)" % port.name, 10)
+        cleanup(vm, guest_worker)
 
-
-    def tbasic_loopback(vm, send_port, recv_port, data="Smoke test data"):
+    def test_basic_loopback():
         """
-        Easy loop back test with loop over only two ports.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param port: Port used in test.
+        Simple loop back test with loop over two ports.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        if not send_port.is_open:
-            send_port.open()
-        if not recv_port.is_open:
-            recv_port.open()
-        on_guest("virt.loopback(['%s'], ['%s'], 1024, virt.LOOP_NONE)" %
-                     (send_port.name, recv_port.name), vm, 10)
+        if params.get('virtio_console_params') == 'serialport':
+            vm, guest_worker = get_vm_with_worker(no_serialports=2)
+            send_port, recv_port = get_virtio_ports(vm)[1][:2]
+        else:
+            vm, guest_worker = get_vm_with_worker(no_consoles=2)
+            send_port, recv_port = get_virtio_ports(vm)[0][:2]
+
+        data = "Smoke test data"
+        send_port.open()
+        recv_port.open()
+        # Set nonblocking mode
+        send_port.sock.setblocking(0)
+        recv_port.sock.setblocking(0)
+        guest_worker.cmd("virt.loopback(['%s'], ['%s'], 1024, virt.LOOP_NONE)"
+                         % (send_port.name, recv_port.name), 10)
         send_port.sock.sendall(data)
         tmp = ""
         i = 0
@@ -812,128 +493,294 @@ def run_virtio_console(test, params, env):
             i += 1
             ret = select.select([recv_port.sock], [], [], 1.0)
             if ret:
-                tmp += recv_port.sock.recv(1024)
+                try:
+                    tmp += recv_port.sock.recv(1024)
+                except IOError, failure_detail:
+                    logging.warn("Got err while recv: %s", failure_detail)
             if len(tmp) >= len(data):
                 break
         if tmp != data:
             raise error.TestFail("Incorrect data: '%s' != '%s'",
                                  data, tmp)
-        _guest_exit_threads(vm, [send_port], [recv_port])
+        guest_worker.safe_exit_loopback_threads([send_port], [recv_port])
+        cleanup(vm, guest_worker)
 
-
-    def trmmod(vm, consoles):
+    ######################################################################
+    # Loopback tests
+    ######################################################################
+    @error.context_aware
+    def test_loopback():
         """
-        Remove and load virtio_console kernel modules.
+        Virtio console loopback test.
 
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be close before rmmod.
+        Creates loopback on the vm machine between send_pt and recv_pts
+        ports and sends length amount of data through this connection.
+        It validates the correctness of the sent data.
+        @param cfg: virtio_console_params - semicolon separated loopback
+                        scenarios, only $source_console_type and (multiple)
+                        destination_console_types are mandatory.
+                            '$source_console_type@buffer_length:
+                             $destination_console_type1@$buffer_length:...:
+                             $loopback_buffer_length;...'
+        @param cfg: virtio_console_test_time - how long to send the data
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        on_guest("guest_exit()", vm, 5)
+        # PREPARE
+        test_params = params.get('virtio_console_params')
+        if not test_params:
+            raise error.TestFail('No virtio_console_params specified')
+        test_time = int(params.get('virtio_console_test_time', 60))
+        no_serialports = 0
+        no_consoles = 0
+        for param in test_params.split(';'):
+            no_serialports = max(no_serialports, param.count('serialport'))
+            no_consoles = max(no_consoles, param.count('console'))
+        vm, guest_worker = get_vm_with_worker(no_consoles, no_serialports)
 
-        on_guest("rmmod -f virtio_console && echo -n PASS: rmmod "
-                 "|| echo -n FAIL: rmmod", vm, 10)
-        on_guest("modprobe virtio_console "
-                 "&& echo -n PASS: modprobe || echo -n FAIL: modprobe",
-                 vm, 10)
+        (consoles, serialports) = get_virtio_ports(vm)
 
-        init_guest(vm, consoles)
-        try:
-            cname = consoles[0][0].name
-        except (IndexError):
-            cname = consoles[1][0].name
-        on_guest("virt.clean_port('%s'),1024" % cname, vm, 2)
+        for param in test_params.split(';'):
+            if not param:
+                continue
+            error.context("test_loopback: params %s" % param, logging.info)
+            # Prepare
+            param = param.split(':')
+            idx_serialport = 0
+            idx_console = 0
+            buf_len = []
+            if (param[0].startswith('console')):
+                send_pt = consoles[idx_console]
+                idx_console += 1
+            else:
+                send_pt = serialports[idx_serialport]
+                idx_serialport += 1
+            if (len(param[0].split('@')) == 2):
+                buf_len.append(int(param[0].split('@')[1]))
+            else:
+                buf_len.append(1024)
+            recv_pts = []
+            for parm in param[1:]:
+                if (parm.isdigit()):
+                    buf_len.append(int(parm))
+                    break   # buf_len is the last portion of param
+                if (parm.startswith('console')):
+                    recv_pts.append(consoles[idx_console])
+                    idx_console += 1
+                else:
+                    recv_pts.append(serialports[idx_serialport])
+                    idx_serialport += 1
+                if (len(parm[0].split('@')) == 2):
+                    buf_len.append(int(parm[0].split('@')[1]))
+                else:
+                    buf_len.append(1024)
+            # There must be sum(idx_*) consoles + last item as loopback buf_len
+            if len(buf_len) == (idx_console + idx_serialport):
+                buf_len.append(1024)
 
+            for port in recv_pts:
+                port.open()
 
-    def tmax_serial_ports(vm, consoles):
+            send_pt.open()
+
+            if len(recv_pts) == 0:
+                raise error.TestFail("test_loopback: incorrect recv consoles"
+                                     "definition")
+
+            threads = []
+            queues = []
+            for i in range(0, len(recv_pts)):
+                queues.append(deque())
+
+            # Start loopback
+            tmp = "'%s'" % recv_pts[0].name
+            for recv_pt in recv_pts[1:]:
+                tmp += ", '%s'" % (recv_pt.name)
+            guest_worker.cmd("virt.loopback(['%s'], [%s], %d, virt.LOOP_POLL)"
+                             % (send_pt.name, tmp, buf_len[-1]), 10)
+
+            exit_event = threading.Event()
+
+            # TEST
+            thread = kvm_virtio_port.ThSendCheck(send_pt, exit_event, queues,
+                                   buf_len[0])
+            thread.start()
+            threads.append(thread)
+
+            for i in range(len(recv_pts)):
+                thread = kvm_virtio_port.ThRecvCheck(recv_pts[i], queues[i],
+                                                    exit_event, buf_len[i + 1])
+                thread.start()
+                threads.append(thread)
+
+            time.sleep(test_time)
+            exit_event.set()
+            # TEST END
+            logging.debug('Joining th1')
+            threads[0].join()
+            tmp = "%d data sent; " % threads[0].idx
+            for thread in threads[1:]:
+                logging.debug('Joining th%s', thread)
+                thread.join()
+                tmp += "%d, " % thread.idx
+            logging.info("test_loopback: %s data received and verified",
+                         tmp[:-2])
+
+            # Read-out all remaining data
+            for recv_pt in recv_pts:
+                while select.select([recv_pt.sock], [], [], 0.1)[0]:
+                    recv_pt.sock.recv(1024)
+
+            guest_worker.safe_exit_loopback_threads([send_pt], recv_pts)
+
+            del exit_event
+            del threads[:]
+        cleanup(vm, guest_worker)
+
+    def _process_stats(stats, scale=1.0):
         """
-        Test maximum count of ports in guest machine.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be close before rmmod.
+        Process the stats to human readable form.
+        @param stats: List of measured data.
         """
-        logging.debug("Count of serial ports: 30")
-        vm[0].destroy(gracefully=False)
-        (vm, consoles) = _vm_create(0, 30, False)
-        try:
-            init_guest(vm, consoles)
-        except error.TestFail, ints:
-            logging.info("Count of serial ports: 30")
-            raise ints
-        clean_reload_vm(vm, consoles, expected=True)
+        if not stats:
+            return None
+        for i in range((len(stats) - 1), 0, -1):
+            stats[i] = stats[i] - stats[i - 1]
+            stats[i] /= scale
+        stats[0] /= scale
+        stats = sorted(stats)
+        return stats
 
-
-    def tmax_console_ports(vm, consoles):
+    @error.context_aware
+    def test_perf():
         """
-        Test maximum count of ports in guest machine.
+        Tests performance of the virtio_console tunnel. First it sends the data
+        from host to guest and than back. It provides informations about
+        computer utilization and statistic informations about the throughput.
 
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be close before rmmod.
+        @param cfg: virtio_console_params - semicolon separated scenarios:
+                        '$console_type@$buffer_length:$test_duration;...'
+        @param cfg: virtio_console_test_time - default test_duration time
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        logging.debug("Count of console ports: 30")
-        vm[0].destroy(gracefully=False)
-        (vm, consoles) = _vm_create(30, 0, False)
-        try:
-            init_guest(vm, consoles)
-        except error.TestFail, ints:
-            logging.info("Count of console ports: 30")
-            raise ints
-        clean_reload_vm(vm, consoles, expected=True)
+        test_params = params.get('virtio_console_params')
+        if not test_params:
+            raise error.TestFail('No virtio_console_params specified')
+        test_time = int(params.get('virtio_console_test_time', 60))
+        no_serialports = 0
+        no_consoles = 0
+        if test_params.count('serialport'):
+            no_serialports = 1
+        if test_params.count('serialport'):
+            no_consoles = 1
+        vm, guest_worker = get_vm_with_worker(no_consoles, no_serialports)
+        (consoles, serialports) = get_virtio_ports(vm)
+        consoles = [consoles, serialports]
 
+        for param in test_params.split(';'):
+            if not param:
+                continue
+            error.context("test_perf: params %s" % param, logging.info)
+            # Prepare
+            param = param.split(':')
+            duration = test_time
+            if len(param) > 1:
+                try:
+                    duration = float(param[1])
+                except ValueError:
+                    pass
+            param = param[0].split('@')
+            if len(param) > 1 and param[1].isdigit():
+                buf_len = int(param[1])
+            else:
+                buf_len = 1024
+            param = (param[0] == 'serialport')
+            port = consoles[param][0]
 
-    def tmax_mix_serial_conosle_port(vm, consoles):
-        """
-        Test maximim count of ports in guest machine.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be close before rmmod.
-        """
-        logging.debug("Count of ports (serial+console): 30")
-        vm[0].destroy(gracefully=False)
-        (vm, consoles) = _vm_create(15, 15, False)
-        try:
-            init_guest(vm, consoles)
-        except error.TestFail, ints:
-            logging.info("Count of ports (serial+console): 30")
-            raise ints
-        clean_reload_vm(vm, consoles, expected=True)
-
-
-    def tshutdown(vm, consoles):
-        """
-        Try to gently shutdown the machine. Virtio_console shouldn't block this.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be close before rmmod.
-        """
-        ports = []
-        for console in consoles[0]:
-            ports.append(console)
-        for console in consoles[1]:
-            ports.append(console)
-        for port in ports:
             port.open()
-        # If more than one, send data on the other ports
-        for port in ports[1:]:
-            on_guest("virt.close('%s')" % (port.name), vm, 2)
-            on_guest("virt.open('%s')" % (port.name), vm, 2)
-            try:
-                os.system("dd if=/dev/random of='%s' bs=4096 &>/dev/null &"
-                          % port.path)
-            except Exception:
-                pass
-        # Just start sending, it won't finish anyway...
-        _on_guest("virt.send('%s', 1024**3, True, is_static=True)"
-                  % ports[0].name, vm, 1)
 
-        # Let the computer transfer some bytes :-)
-        time.sleep(2)
+            data = ""
+            for _ in range(buf_len):
+                data += "%c" % random.randrange(255)
 
-        # Power off the computer
-        vm[0].destroy(gracefully=True)
-        clean_reload_vm(vm, consoles, expected=True)
+            exit_event = threading.Event()
+            time_slice = float(duration) / 100
 
+            # HOST -> GUEST
+            guest_worker.cmd('virt.loopback(["%s"], [], %d, virt.LOOP_NONE)'
+                             % (port.name, buf_len), 10)
+            thread = kvm_virtio_port.ThSend(port.sock, data, exit_event)
+            stats = array.array('f', [])
+            loads = utils.SystemLoad([(os.getpid(), 'autotest'),
+                                      (vm.get_pid(), 'VM'), 0])
+            loads.start()
+            _time = time.time()
+            thread.start()
+            for _ in range(100):
+                stats.append(thread.idx)
+                time.sleep(time_slice)
+            _time = time.time() - _time - duration
+            logging.info("\n" + loads.get_cpu_status_string()[:-1])
+            logging.info("\n" + loads.get_mem_status_string()[:-1])
+            exit_event.set()
+            thread.join()
 
-    def __tmigrate(vm, consoles, parms, offline=True):
+            # Let the guest read-out all the remaining data
+            while not guest_worker._cmd("virt.poll('%s', %s)"
+                                        % (port.name, select.POLLIN), 10)[0]:
+                time.sleep(1)
+
+            guest_worker.safe_exit_loopback_threads([port], [])
+
+            if (_time > time_slice):
+                logging.error("Test ran %fs longer which is more than one "
+                              "time slice", _time)
+            else:
+                logging.debug("Test ran %fs longer", _time)
+            stats = _process_stats(stats[1:], time_slice * 1048576)
+            logging.debug("Stats = %s", stats)
+            logging.info("Host -> Guest [MB/s] (min/med/max) = %.3f/%.3f/%.3f",
+                         stats[0], stats[len(stats) / 2], stats[-1])
+
+            del thread
+
+            # GUEST -> HOST
+            exit_event.clear()
+            stats = array.array('f', [])
+            guest_worker.cmd("virt.send_loop_init('%s', %d)"
+                             % (port.name, buf_len), 30)
+            thread = kvm_virtio_port.ThRecv(port.sock, exit_event, buf_len)
+            thread.start()
+            loads.start()
+            guest_worker.cmd("virt.send_loop()", 10)
+            _time = time.time()
+            for _ in range(100):
+                stats.append(thread.idx)
+                time.sleep(time_slice)
+            _time = time.time() - _time - duration
+            logging.info("\n" + loads.get_cpu_status_string()[:-1])
+            logging.info("\n" + loads.get_mem_status_string()[:-1])
+            guest_worker.cmd("virt.exit_threads()", 10)
+            exit_event.set()
+            thread.join()
+            if (_time > time_slice):    # Deviation is higher than 1 time_slice
+                logging.error(
+                "Test ran %fs longer which is more than one time slice", _time)
+            else:
+                logging.debug("Test ran %fs longer", _time)
+            stats = _process_stats(stats[1:], time_slice * 1048576)
+            logging.debug("Stats = %s", stats)
+            logging.info("Guest -> Host [MB/s] (min/med/max) = %.3f/%.3f/%.3f",
+                         stats[0], stats[len(stats) / 2], stats[-1])
+
+            del thread
+            del exit_event
+        cleanup(vm, guest_worker)
+
+    ######################################################################
+    # Migration tests
+    ######################################################################
+    @error.context_aware
+    def _tmigrate(use_serialport, no_ports, no_migrations, blocklen, offline):
         """
         An actual migration test. It creates loopback on guest from first port
         to all remaining ports. Than it sends and validates the data.
@@ -944,47 +791,53 @@ def run_virtio_console(test, params, env):
         @param parms: [media, no_migration, send-, recv-, loopback-buffer_len]
         """
         # PREPARE
-        send_pt = consoles[parms[0]][0]
-        recv_pts = consoles[parms[0]][1:]
+        if use_serialport:
+            vm, guest_worker = get_vm_with_worker(no_serialports=no_ports)
+            ports = get_virtio_ports(vm)[1]
+        else:
+            vm, guest_worker = get_vm_with_worker(no_consoles=no_ports)
+            ports = get_virtio_ports(vm)[0]
+
         # TODO BUG: sendlen = max allowed data to be lost per one migration
         # TODO BUG: using SMP the data loss is upto 4 buffers
-        # 2048 = char. dev. socket size, parms[2] = host->guest send buffer size
-        sendlen = 2 * 2 * max(2048, parms[2])
-        if not offline: # TODO BUG: online migration causes more loses
+        # 2048 = char.dev. socket size, parms[2] = host->guest send buffer size
+        sendlen = 2 * 2 * max(kvm_virtio_port.SOCKET_SIZE, blocklen)
+        if not offline:     # TODO BUG: online migration causes more loses
             # TODO: Online migration lose n*buffer. n depends on the console
             # troughput. FIX or analyse it's cause.
             sendlen = 1000 * sendlen
-        for p in recv_pts:
-            if not p.is_open:
-                p.open()
+        for port in ports[1:]:
+            port.open()
 
-        if not send_pt.is_open:
-            send_pt.open()
+        ports[0].open()
 
         threads = []
         queues = []
         verified = []
-        for i in range(0, len(recv_pts)):
+        for i in range(0, len(ports[1:])):
             queues.append(deque())
             verified.append(0)
 
-        tmp = "'%s'" % recv_pts[0].name
-        for recv_pt in recv_pts[1:]:
+        tmp = "'%s'" % ports[1:][0].name
+        for recv_pt in ports[1:][1:]:
             tmp += ", '%s'" % (recv_pt.name)
-        on_guest("virt.loopback(['%s'], [%s], %d, virt.LOOP_POLL)"
-                 % (send_pt.name, tmp, parms[4]), vm, 10)
+        guest_worker.cmd("virt.loopback(['%s'], [%s], %d, virt.LOOP_POLL)"
+                         % (ports[0].name, tmp, blocklen), 10)
 
         exit_event = threading.Event()
 
         # TEST
-        thread = kvm_virtio_port.ThSendCheck(send_pt, exit_event, queues,
-                             parms[2])
+        thread = kvm_virtio_port.ThSendCheck(ports[0], exit_event, queues,
+                                             blocklen,
+                                             migrate_event=threading.Event())
         thread.start()
         threads.append(thread)
 
-        for i in range(len(recv_pts)):
-            thread = kvm_virtio_port.ThRecvCheck(recv_pts[i], queues[i], exit_event,
-                                 parms[3], sendlen=sendlen)
+        for i in range(len(ports[1:])):
+            thread = kvm_virtio_port.ThRecvCheck(ports[1:][i], queues[i],
+                                            exit_event, blocklen,
+                                            sendlen=sendlen,
+                                            migrate_event=threading.Event())
             thread.start()
             threads.append(thread)
 
@@ -998,17 +851,26 @@ def run_virtio_console(test, params, env):
             i += 1
             time.sleep(2)
 
+        for j in range(no_migrations):
+            error.context("Performing migration number %s/%s"
+                          % (j, no_migrations))
+            vm = virt_test_utils.migrate(vm, env, 3600, "exec", 0,
+                                         offline)
+            if not vm:
+                raise error.TestFail("Migration failed")
 
-        for j in range(parms[1]):
-            vm[0] = virt_test_utils.migrate(vm[0], env, 3600, "exec", 0,
-                                             offline)
-            if not vm[1]:
-                raise error.TestFail("Could not log into guest after migration")
-            vm[1] = virt_test_utils.wait_for_login(vm[0], 0,
-                                        float(params.get("boot_timeout", 100)),
-                                        0, 2)
+            # Set new ports to Sender and Recver threads
+            # TODO: get ports in this function and use the right ports...
+            if use_serialport:
+                ports = get_virtio_ports(vm)[1]
+            else:
+                ports = get_virtio_ports(vm)[0]
+            for i in range(len(threads)):
+                threads[i].port = ports[i]
+                threads[i].migrate_event.set()
+
             # OS is sometime a bit dizzy. DL=30
-            _init_guest(vm, 30)
+            #guest_worker.reconnect(vm, timeout=30)
 
             i = 0
             while i < 6:
@@ -1026,16 +888,20 @@ def run_virtio_console(test, params, env):
                 else:
                     raise error.TestFail("Send thread died unexpectedly in "
                                          "migration %d", (j + 1))
-            for i in range(0, len(recv_pts)):
+            for i in range(0, len(ports[1:])):
                 if not threads[i + 1].isAlive():
                     raise error.TestFail("Recv thread %d died unexpectedly in "
                                          "migration %d", i, (j + 1))
                 if verified[i] == threads[i + 1].idx:
                     raise error.TestFail("No new data in %d console were "
-                                         "transfered after migration %d"
-                                         , i, (j + 1))
+                                         "transfered after migration %d",
+                                         i, (j + 1))
                 verified[i] = threads[i + 1].idx
-            logging.info("%d out of %d migration(s) passed" % ((j + 1), parms[1]))
+            logging.info("%d out of %d migration(s) passed", (j + 1),
+                         no_migrations)
+            # If we get to this point let's assume all threads were reconnected
+            for thread in threads:
+                thread.migrate_event.clear()
             # TODO detect recv-thread failure and throw out whole test
 
         # FINISH
@@ -1052,85 +918,54 @@ def run_virtio_console(test, params, env):
             thread.join()
             tmp += "%d, " % thread.idx
         logging.info("test_loopback: %s data received and verified during %d "
-                     "migrations", tmp[:-2], parms[1])
+                     "migrations", tmp[:-2], no_migrations)
 
         # CLEANUP
-        _guest_exit_threads(vm, [send_pt], recv_pts)
+        guest_worker.safe_exit_loopback_threads([ports[0]], ports[1:])
         del exit_event
         del threads[:]
+        cleanup(vm, guest_worker)
 
-
-    def _tmigrate(vm, consoles, parms, offline):
+    def _test_migrate(offline):
         """
-        Wrapper which parses the params for __migrate test.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Field of virtio ports with the minimum of 2 items.
-        @param parms: test parameters, multiple recievers allowed.
-            '[{serialport,console}]:$no_migrations:send_buf_len:recv_buf_len:
-             loopback_buf_len;...'
+        Migration test wrapper, see the actual test_migrate_* tests for details
         """
-        for param in parms.split(';'):
-            if not param:
-                continue
-            if offline:
-                logging.info("test_migrate_offline: params: %s", param)
-            else:
-                logging.info("test_migrate_online: params: %s", param)
-            param = param.split(':')
-            media = 1
-            if param[0].isalpha():
-                if param[0] == "console":
-                    param[0] = 0
-                else:
-                    param[0] = 1
-            else:
-                param = [0] + param
-            for i in range(1, 5):
-                if not param[i].isdigit():
-                    param[i] = 1
-                else:
-                    param[i] = int(param[i])
+        no_migrations = int(params.get("virtio_console_no_migrations", 5))
+        no_ports = int(params.get("virtio_console_no_ports", 2))
+        blocklen = int(params.get("virtio_console_blocklen", 1024))
+        use_serialport = params.get('virtio_console_params') == "serialport"
+        _tmigrate(use_serialport, no_ports, no_migrations, blocklen, offline)
 
-            __tmigrate(vm, consoles, param, offline=offline)
-
-
-    def tmigrate_offline(vm, consoles, parms):
+    def test_migrate_offline():
         """
         Tests whether the virtio-{console,port} are able to survive the offline
         migration.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Field of virtio ports with the minimum of 2 items.
-        @param parms: test parameters, multiple recievers allowed.
-            '[{serialport,console}]:$no_migrations:send_buf_len:recv_buf_len:
-             loopback_buf_len;...'
+        @param cfg: virtio_console_no_migrations - how many times to migrate
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_console_blocklen - send/recv block length
+        @param cfg: virtio_console_no_ports - minimum number of loopback ports
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        _tmigrate(vm, consoles, parms, offline=True)
+        _test_migrate(offline=True)
 
-
-    def tmigrate_online(vm, consoles, parms):
+    def test_migrate_online():
         """
         Tests whether the virtio-{console,port} are able to survive the online
         migration.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Field of virtio ports with the minimum of 2 items.
-        @param parms: test parameters, multiple recievers allowed.
-            '[{serialport,console}]:$no_migrations:send_buf_len:recv_buf_len:
-             loopback_buf_len;...'
+        @param cfg: virtio_console_no_migrations - how many times to migrate
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_console_blocklen - send/recv block length
+        @param cfg: virtio_console_no_ports - minimum number of loopback ports
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        _tmigrate(vm, consoles, parms, offline=False)
+        _test_migrate(offline=False)
 
-
-    def _virtio_dev_create(vm, ports_name, pciid, id, console="no"):
+    def _virtio_dev_add(vm, pci_id, port_id, console="no"):
         """
-        Add virtio serialport device.
-
+        Adds virtio serialport device.
         @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param ports_name: Structure of ports.
-        @param pciid: Id of virtio-serial-pci device.
-        @param id: Id of port.
+        @param pci_id: Id of virtio-serial-pci device.
+        @param port_id: Id of port.
         @param console: if "yes" inicialize console.
         """
         port = "serialport-"
@@ -1138,689 +973,324 @@ def run_virtio_console(test, params, env):
         if console == "yes":
             port = "console-"
             port_type = "virtconsole"
-        port += "%d%d" % (pciid, id)
-        ret = vm[0].monitors[0].cmd("device_add %s,"
-                                    "bus=virtio-serial-pci%d.0,"
+        port += "%d-%d" % (pci_id, port_id)
+        ret = vm.monitors[0].cmd("device_add %s,"
+                                    "bus=virtio_serial_pci%d.0,"
                                     "id=%s,"
                                     "name=%s"
-                                    % (port_type, pciid, port, port))
-        ports_name.append([ port, console])
+                                    % (port_type, pci_id, port, port))
+        if console == "no":
+            vm.virtio_ports.append(kvm_virtio_port.VirtioSerial(port, None))
+        else:
+            vm.virtio_ports.append(kvm_virtio_port.VirtioConsole(port, None))
         if ret != "":
             logging.error(ret)
 
-
-    def _virtio_dev_del(vm, ports_name, pciid, id):
+    def _virtio_dev_del(vm, pci_id, port_id):
         """
-        Del virtio serialport device.
-
+        Removes virtio serialport device.
         @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param ports_name: Structure of ports.
-        @param pciid: Id of virtio-serial-pci device.
-        @param id: Id of port.
+        @param pci_id: Id of virtio-serial-pci device.
+        @param port_id: Id of port.
         """
-        port = filter(lambda x: x[0].endswith("-%d%d" % (pciid, id)),
-                      ports_name)
-        ret = vm[0].monitors[0].cmd("device_del %s"
-                                        % (port[0][0]))
-        ports_name.remove(port[0])
-        if ret != "":
-            logging.error(ret)
+        for port in vm.virtio_ports:
+            if port.name.endswith("-%d-%d" % (pci_id, port_id)):
+                ret = vm.monitors[0].cmd("device_del %s" % (port.name))
+                vm.virtio_ports.remove(port)
+                if ret != "":
+                    logging.error(ret)
+                return
+        raise error.TestFail("Removing port which is not in vm.virtio_ports"
+                             " ...-%d-%d" % (pci_id, port_id))
 
-
-    def thotplug(vm, consoles, console="no", timeout=1):
+    def test_hotplug():
         """
-        Try hotplug function of virtio-consoles ports.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles.
-        @param console: If "yes" inicialize console.
-        @param timeout: Timeout between hotplug operations.
+        Check the hotplug/unplug of virtio-consoles ports.
+        TODO: co vsechno to opravdu testuje?
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_console_pause - pause between monitor commands
         """
-        logging.info("Timeout between hotplug operations t=%fs" % timeout)
-        _reset_vm(vm, consoles, 1, 1)
-        ports_name = []
-        ports_name.append(['serialport-1', 'no'])
-        ports_name.append(['console-0', 'yes'])
+        # TODO: Rewrite this test. It was left as it was before the virtio_port
+        # conversion and looked too messy to repair it during conversion.
+        # TODO: Split this test into multiple variants
+        # TODO: Think about customizable params
+        # TODO: use qtree to detect the right virtio-serial-pci name
+        # TODO: QMP
+        if params.get("virtio_console_params") == "serialport":
+            console = "no"
+        else:
+            console = "yes"
+        pause = int(params.get("virtio_console_pause", 1))
+        logging.info("Timeout between hotplug operations t=%fs", pause)
 
+        vm = get_vm_with_ports(1, 1, spread=0, quiet=True, strict=True)
+        consoles = get_virtio_ports(vm)
+        # send/recv might block for ever, set non-blocking mode
+        consoles[0][0].open()
+        consoles[1][0].open()
+        consoles[0][0].sock.setblocking(0)
+        consoles[1][0].sock.setblocking(0)
         logging.info("Test correct initialization of hotplug ports")
-        for id in range(1, 5): #count of pci device
-            ret = vm[0].monitors[0].cmd("device_add virtio-serial-pci,"
-                                        "id=virtio-serial-pci%d" % (id))
+        for bus_id in range(1, 5):  # count of pci device
+            ret = vm.monitors[0].cmd("device_add virtio-serial-pci,"
+                                        "id=virtio_serial_pci%d" % (bus_id))
             if ret != "":
                 logging.error(ret)
-            for i in range(id * 5 + 5): #max port 30
-                _virtio_dev_create(vm, ports_name, id, i, console)
-                time.sleep(timeout)
-
+            for i in range(bus_id * 5 + 5):     # max ports 30
+                _virtio_dev_add(vm, bus_id, i, console)
+                time.sleep(pause)
         # Test correct initialization of hotplug ports
-        time.sleep(10) # Timeout for port initialization
-        _init_guest(vm, 10)
-        on_guest('virt.init(%s)' % (ports_name), vm, 10)
+        time.sleep(10)  # Timeout for port initialization
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
 
         logging.info("Delete ports when ports are used")
         # Delete ports when ports are used.
-        if not consoles[0][0].is_open:
-            consoles[0][0].open()
-        if not consoles[1][0].is_open:
-            consoles[1][0].open()
-        on_guest("virt.loopback(['%s'], ['%s'], 1024,"
+        guest_worker.cmd("virt.loopback(['%s'], ['%s'], 1024,"
                  "virt.LOOP_POLL)" % (consoles[0][0].name,
-                                      consoles[1][0].name), vm, 10)
+                                      consoles[1][0].name), 10)
         exit_event = threading.Event()
-        send = kvm_virtio_port.ThSend(consoles[0][0].sock, "Data", exit_event, quiet=True)
-        recv = kvm_virtio_port.ThRecv(consoles[1][0].sock, exit_event, quiet=True)
+        send = kvm_virtio_port.ThSend(consoles[0][0].sock, "Data", exit_event,
+                                      quiet=True)
+        recv = kvm_virtio_port.ThRecv(consoles[1][0].sock, exit_event,
+                                      quiet=True)
         send.start()
         time.sleep(2)
         recv.start()
 
         # Try to delete ports under load
-        ret = vm[0].monitors[0].cmd("device_del serialport-1")
-        ret += vm[0].monitors[0].cmd("device_del console-0")
-        ports_name.remove(['serialport-1', 'no'])
-        ports_name.remove(['console-0', 'yes'])
+        ret = vm.monitors[0].cmd("device_del %s" % consoles[1][0].name)
+        ret += vm.monitors[0].cmd("device_del %s" % consoles[0][0].name)
+        vm.virtio_ports = vm.virtio_ports[2:]
         if ret != "":
             logging.error(ret)
 
         exit_event.set()
         send.join()
         recv.join()
-        on_guest("virt.exit_threads()", vm, 10)
-        on_guest('guest_exit()', vm, 10)
+        guest_worker.cmd("virt.exit_threads()", 10)
+        guest_worker.cmd('guest_exit()', 10)
 
         logging.info("Trying to add maximum count of ports to one pci device")
         # Try to add ports
-        for i in range(30): # max port 30
-            _virtio_dev_create(vm, ports_name, 0, i, console)
-            time.sleep(timeout)
-        _init_guest(vm, 10)
-        time.sleep(10)
-        on_guest('virt.init(%s)' % (ports_name), vm, 20)
-        on_guest('guest_exit()', vm, 10)
+        for i in range(30):     # max port 30
+            _virtio_dev_add(vm, 0, i, console)
+            time.sleep(pause)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        guest_worker.cmd('guest_exit()', 10)
 
         logging.info("Trying delete and add again part of ports")
         # Try to delete ports
-        for i in range(25): # max port 30
-            _virtio_dev_del(vm, ports_name, 0, i)
-            time.sleep(timeout)
-        _init_guest(vm, 10)
-        on_guest('virt.init(%s)' % (ports_name), vm, 10)
-        on_guest('guest_exit()', vm, 10)
+        for i in range(25):     # max port 30
+            _virtio_dev_del(vm, 0, i)
+            time.sleep(pause)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        guest_worker.cmd('guest_exit()', 10)
 
         # Try to add ports
-        for i in range(5): # max port 30
-            _virtio_dev_create(vm, ports_name, 0, i, console)
-            time.sleep(timeout)
-        _init_guest(vm, 10)
-        on_guest('virt.init(%s)' % (ports_name), vm, 10)
-        on_guest('guest_exit()', vm, 10)
+        for i in range(5):      # max port 30
+            _virtio_dev_add(vm, 0, i, console)
+            time.sleep(pause)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        guest_worker.cmd('guest_exit()', 10)
 
         logging.info("Trying to add and delete one port 100 times")
         # Try 100 times add and delete one port.
         for i in range(100):
-            _virtio_dev_del(vm, ports_name, 0, 0)
-            time.sleep(timeout)
-            _virtio_dev_create(vm, ports_name, 0, 0, console)
-            time.sleep(timeout)
-        _init_guest(vm, 10)
-        on_guest('virt.init(%s)' % (ports_name), vm, 10)
-        on_guest('guest_exit()', vm, 10)
+            _virtio_dev_del(vm, 0, 0)
+            time.sleep(pause)
+            _virtio_dev_add(vm, 0, 0, console)
+            time.sleep(pause)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        cleanup(guest_worker=guest_worker)
+        # VM is broken (params mismatches actual state)
+        vm.destroy()
 
-
-    def thotplug_no_timeout(vm, consoles, console="no"):
+    @error.context_aware
+    def test_hotplug_virtio_pci():
         """
-        Start hotplug test without any timeout.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be close before rmmod.
-        @param console: If "yes" inicialize console.
+        Tests hotplug/unplug of the virtio-serial-pci bus.
+        @param cfg: virtio_console_pause - pause between monitor commands
+        @param cfg: virtio_console_loops - how many loops to run
         """
-        thotplug(vm, consoles, console, 0)
+        # TODO: QMP
+        # TODO: check qtree for device presense
+        pause = int(params.get("virtio_console_pause", 10))
+        vm = get_vm_with_ports()
+        idx = 1
+        for i in xrange(int(params.get("virtio_console_loops", 2))):
+            error.context("Hotpluging virtio_pci (iteration %d)" % i)
+            ret = vm.monitors[0].cmd("device_add virtio-serial-pci,"
+                                        "id=virtio_serial_pci%d" % (idx))
+            time.sleep(pause)
+            ret += vm.monitors[0].cmd("device_del virtio_serial_pci%d"
+                                         % (idx))
+            time.sleep(pause)
+            if ret != "":
+                raise error.TestFail("Error occured while hotpluging virtio-"
+                                     "pci. Iteration %s, monitor output:\n%s"
+                                     % (i, ret))
 
-
-    def thotplug_virtio_pci(vm, consoles):
+    ######################################################################
+    # Destructive tests
+    ######################################################################
+    def test_rw_notconnect_guest():
         """
-        Test hotplug of virtio-serial-pci.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be close before rmmod.
+        Try to send to/read from guest on host while guest not recvs/sends any
+        data.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        vm[0].destroy(gracefully=False)
-        (vm, consoles) = _vm_create(1, 1, False)
-        id = 1
-        ret = vm[0].monitors[0].cmd("device_add virtio-serial-pci,"
-                                    "id=virtio-serial-pci%d" % (id))
-        time.sleep(10)
-        ret += vm[0].monitors[0].cmd("device_del virtio-serial-pci%d" % (id))
-        time.sleep(10)
-        ret += vm[0].monitors[0].cmd("device_add virtio-serial-pci,"
-                                    "id=virtio-serial-pci%d" % (id))
-        if ret != "":
-            logging.error(ret)
-
-
-    def tloopback(vm, consoles, params):
-        """
-        Virtio console loopback subtest.
-
-        Creates loopback on the vm machine between send_pt and recv_pts
-        ports and sends length amount of data through this connection.
-        It validates the correctness of the data sent.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Field of virtio ports with the minimum of 2 items.
-        @param params: test parameters, multiple recievers allowed.
-            '$source_console_type@buffer_length:
-             $destination_console_type1@$buffer_length:...:
-             $loopback_buffer_length;...'
-        """
-        # PREPARE
-        for param in params.split(';'):
-            if not param:
-                continue
-            logging.info("test_loopback: params: %s", param)
-            param = param.split(':')
-            idx_serialport = 0
-            idx_console = 0
-            buf_len = []
-            if (param[0].startswith('console')):
-                send_pt = consoles[0][idx_console]
-                idx_console += 1
-            else:
-                send_pt = consoles[1][idx_serialport]
-                idx_serialport += 1
-            if (len(param[0].split('@')) == 2):
-                buf_len.append(int(param[0].split('@')[1]))
-            else:
-                buf_len.append(1024)
-            recv_pts = []
-            for parm in param[1:]:
-                if (parm.isdigit()):
-                    buf_len.append(int(parm))
-                    break   # buf_len is the last portion of param
-                if (parm.startswith('console')):
-                    recv_pts.append(consoles[0][idx_console])
-                    idx_console += 1
-                else:
-                    recv_pts.append(consoles[1][idx_serialport])
-                    idx_serialport += 1
-                if (len(parm[0].split('@')) == 2):
-                    buf_len.append(int(parm[0].split('@')[1]))
-                else:
-                    buf_len.append(1024)
-            # There must be sum(idx_*) consoles + last item as loopback buf_len
-            if len(buf_len) == (idx_console + idx_serialport):
-                buf_len.append(1024)
-
-            for p in recv_pts:
-                if not p.is_open:
-                    p.open()
-
-            if not send_pt.is_open:
-                send_pt.open()
-
-            if len(recv_pts) == 0:
-                raise error.TestFail("test_loopback: incorrect recv consoles"
-                                     "definition")
-
-            threads = []
-            queues = []
-            for i in range(0, len(recv_pts)):
-                queues.append(deque())
-
-            tmp = "'%s'" % recv_pts[0].name
-            for recv_pt in recv_pts[1:]:
-                tmp += ", '%s'" % (recv_pt.name)
-            on_guest("virt.loopback(['%s'], [%s], %d, virt.LOOP_POLL)"
-                     % (send_pt.name, tmp, buf_len[-1]), vm, 10)
-
-            exit_event = threading.Event()
-
-            # TEST
-            thread = kvm_virtio_port.ThSendCheck(send_pt, exit_event, queues,
-                                   buf_len[0])
-            thread.start()
-            threads.append(thread)
-
-            for i in range(len(recv_pts)):
-                thread = kvm_virtio_port.ThRecvCheck(recv_pts[i], queues[i], exit_event,
-                                       buf_len[i + 1])
-                thread.start()
-                threads.append(thread)
-
-            time.sleep(60)
-            exit_event.set()
-            threads[0].join()
-            tmp = "%d data sent; " % threads[0].idx
-            for thread in threads[1:]:
-                thread.join()
-                tmp += "%d, " % thread.idx
-            logging.info("test_loopback: %s data received and verified",
-                         tmp[:-2])
-
-            # Read-out all remaining data
-            for recv_pt in recv_pts:
-                while select.select([recv_pt.sock], [], [], 0.1)[0]:
-                    recv_pt.sock.recv(1024)
-
-            _guest_exit_threads(vm, [send_pt], recv_pts)
-
-            del exit_event
-            del threads[:]
-
-
-    def tperf(vm, consoles, params):
-        """
-        Tests performance of the virtio_console tunel. First it sends the data
-        from host to guest and than back. It provides informations about
-        computer utilisation and statistic informations about the troughput.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Field of virtio ports with the minimum of 2 items.
-        @param params: test parameters:
-                '$console_type@$buffer_length:$test_duration;...'
-        """
-        for param in params.split(';'):
-            if not param:
-                continue
-            logging.info("test_perf: params: %s", param)
-            param = param.split(':')
-            duration = 60.0
-            if len(param) > 1:
-                try:
-                    duration = float(param[1])
-                except Exception:
-                    pass
-            param = param[0].split('@')
-            if len(param) > 1 and param[1].isdigit():
-                buf_len = int(param[1])
-            else:
-                buf_len = 1024
-            param = (param[0] == 'serialport')
-            port = consoles[param][0]
-
-            if not port.is_open:
-                port.open()
-
-            data = ""
-            for i in range(buf_len):
-                data += "%c" % random.randrange(255)
-
-            exit_event = threading.Event()
-            time_slice = float(duration) / 100
-
-            # HOST -> GUEST
-            on_guest('virt.loopback(["%s"], [], %d, virt.LOOP_NONE)' %
-                     (port.name, buf_len), vm, 10)
-            thread = kvm_virtio_port.ThSend(port.sock, data, exit_event)
-            stats = array.array('f', [])
-            loads = utils.SystemLoad([(os.getpid(), 'autotest'),
-                                      (vm[0].get_pid(), 'VM'), 0])
-            loads.start()
-            _time = time.time()
-            thread.start()
-            for i in range(100):
-                stats.append(thread.idx)
-                time.sleep(time_slice)
-            _time = time.time() - _time - duration
-            logging.info("\n" + loads.get_cpu_status_string()[:-1])
-            logging.info("\n" + loads.get_mem_status_string()[:-1])
-            exit_event.set()
-            thread.join()
-
-            # Let the guest read-out all the remaining data
-            while not _on_guest("virt.poll('%s', %s)" %
-                                (port.name, select.POLLIN), vm, 10)[0]:
-                time.sleep(1)
-
-            _guest_exit_threads(vm, [port], [])
-
-            if (_time > time_slice):
-                logging.error(
-                "Test ran %fs longer which is more than one time slice", _time)
-            else:
-                logging.debug("Test ran %fs longer", _time)
-            stats = process_stats(stats[1:], time_slice * 1048576)
-            logging.debug("Stats = %s", stats)
-            logging.info("Host -> Guest [MB/s] (min/med/max) = %.3f/%.3f/%.3f",
-                        stats[0], stats[len(stats) / 2], stats[-1])
-
-            del thread
-
-            # GUEST -> HOST
-            exit_event.clear()
-            stats = array.array('f', [])
-            on_guest("virt.send_loop_init('%s', %d)" % (port.name, buf_len),
-                     vm, 30)
-            thread = kvm_virtio_port.ThRecv(port.sock, exit_event, buf_len)
-            thread.start()
-            loads.start()
-            on_guest("virt.send_loop()", vm, 10)
-            _time = time.time()
-            for i in range(100):
-                stats.append(thread.idx)
-                time.sleep(time_slice)
-            _time = time.time() - _time - duration
-            logging.info("\n" + loads.get_cpu_status_string()[:-1])
-            logging.info("\n" + loads.get_mem_status_string()[:-1])
-            on_guest("virt.exit_threads()", vm, 10)
-            exit_event.set()
-            thread.join()
-            if (_time > time_slice): # Deviation is higher than 1 time_slice
-                logging.error(
-                "Test ran %fs longer which is more than one time slice", _time)
-            else:
-                logging.debug("Test ran %fs longer", _time)
-            stats = process_stats(stats[1:], time_slice * 1048576)
-            logging.debug("Stats = %s", stats)
-            logging.info("Guest -> Host [MB/s] (min/med/max) = %.3f/%.3f/%.3f",
-                         stats[0], stats[len(stats) / 2], stats[-1])
-
-            del thread
-            del exit_event
-
-
-    def _clean_ports(vm, consoles):
-        """
-        Read all data from all ports, in both sides of each port.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be clean.
-        """
-        for ctype in consoles:
-            for port in ctype:
-                openned = port.is_open
-                port.clean_port()
-                on_guest("virt.clean_port('%s'),1024" % port.name, vm, 10)
-                if not openned:
-                    port.close()
-                    on_guest("virt.close('%s'),1024" % port.name, vm, 10)
-
-
-    def clean_ports(vm, consoles):
-        """
-        Clean state of all ports and set port to default state.
-        Default state:
-           No data on port or in port buffer.
-           Read mode = blocking.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be clean.
-        """
-        # Check if python is still alive
-        logging.info("CLEANING")
-        match, tmp = _on_guest("is_alive()", vm, 10)
-        if (match is None) or (match != 0):
-            logging.error("Python died/is stucked/have remaining threads")
-            logging.debug(tmp)
-            try:
-                kernel_bug = _search_kernel_crashlog(vm[0].serial_console, 10)
-                if kernel_bug is not None:
-                    logging.error(kernel_bug)
-                    raise error.TestFail("Kernel crash.")
-
-                if vm[4] == True:
-                    raise error.TestFail("Kernel crash.")
-                match, tmp = _on_guest("guest_exit()", vm, 10)
-                if (match is None) or (match == 0):
-                    vm[1].close()
-                    vm[1] = virt_test_utils.wait_for_login(vm[0], 0,
-                                        float(params.get("boot_timeout", 5)),
-                                        0, 10)
-                on_guest("killall -9 python "
-                         "&& echo -n PASS: python killed"
-                         "|| echo -n PASS: python was already dead",
-                         vm, 10)
-
-                init_guest(vm, consoles)
-                _clean_ports(vm, consoles)
-
-            except (error.TestFail, aexpect.ExpectError,
-                    Exception), inst:
-                logging.error(inst)
-                logging.error("Virtio-console driver is irreparably"
-                              " blocked. Every comd end with sig KILL."
-                              "Trying to reboot vm to continue testing...")
-                try:
-                    vm[0].destroy(gracefully=True)
-                    (vm[0], vm[1], vm[3]) = _restore_vm()
-                except (kvm_monitor.MonitorProtocolError):
-                    logging.error("Qemu is blocked. Monitor no longer "
-                                  "communicates")
-                    vm[0].destroy(gracefully=False)
-                    os.system("kill -9 %d" % (vm[0].get_pid()))
-                    (vm[0], vm[1], vm[3]) = _restore_vm()
-                init_guest(vm, consoles)
-                cname = ""
-                try:
-                    cname = consoles[0][0].name
-                except (IndexError):
-                    cname = consoles[1][0].name
-                match = _on_guest("virt.clean_port('%s'),1024" %
-                                  cname, vm, 10)[0]
-
-                if (match is None) or (match != 0):
-                    raise error.TestFail("Virtio-console driver is irreparably "
-                                         "blocked. Every comd ended with sig "
-                                         "KILL. The restart didn't help")
-                _clean_ports(vm, consoles)
-
-
-    def _reset_vm(vm, consoles, no_console=1, no_serialport=1):
-        """
-        Destroy and reload vm.
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be close and than renew.
-        @param no_console: Number of desired virtconsoles.
-        @param no_serialport: Number of desired virtserialports.
-        """
-        vm[0].destroy(gracefully=False)
-        (_vm, _consoles) = _vm_create(no_console, no_serialport)
-        consoles[:] = _consoles[:]
-        vm[:] = _vm[:]
-
-
-    def clean_reload_vm(vm, consoles, expected=False):
-        """
-        Reloads and boots the damaged vm
-
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Consoles which should be clean.
-        """
-        if expected:
-            logging.info("Scheduled vm reboot")
+        vm = env.get_vm(params.get("main_vm"))
+        use_serialport = params.get('virtio_console_params') == "serialport"
+        if use_serialport:
+            vm = get_vm_with_ports(no_serialports=1, strict=True)
         else:
-            logging.info("SCHWARZENEGGER is CLEANING")
-        _reset_vm(vm, consoles, len(consoles[0]), len(consoles[1]))
-        init_guest(vm, consoles)
+            vm = get_vm_with_ports(no_consoles=1, strict=True)
+        if use_serialport:
+            port = get_virtio_ports(vm)[1][0]
+        else:
+            port = get_virtio_ports(vm)[0][1]
+        if not port.is_open():
+            port.open()
+        else:
+            port.close()
+            port.open()
 
+        port.sock.settimeout(20.0)
 
-    def test_smoke(test, vm, consoles, params, global_params):
+        loads = utils.SystemLoad([(os.getpid(), 'autotest'),
+                                  (vm.get_pid(), 'VM'), 0])
+        loads.start()
+
+        try:
+            sent1 = 0
+            for _ in range(1000000):
+                sent1 += port.sock.send("a")
+        except socket.timeout:
+            logging.info("Data sending to closed port timed out.")
+
+        logging.info("Bytes sent to client: %d", sent1)
+        logging.info("\n" + loads.get_cpu_status_string()[:-1])
+
+        logging.info("Open and then close port %s", port.name)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        # Test of live and open and close port again
+        guest_worker.cleanup()
+        port.sock.settimeout(20.0)
+
+        loads.start()
+        try:
+            sent2 = 0
+            for _ in range(40000):
+                sent2 = port.sock.send("a")
+        except socket.timeout:
+            logging.info("Data sending to closed port timed out.")
+
+        logging.info("Bytes sent to client: %d", sent2)
+        logging.info("\n" + loads.get_cpu_status_string()[:-1])
+        loads.stop()
+        if (sent1 != sent2):
+            logging.warning("Inconsistent behavior: First sent %d bytes and "
+                            "second sent %d bytes", sent1, sent2)
+
+        port.sock.settimeout(None)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        cleanup(vm, guest_worker)
+
+    def test_rmmod():
         """
-        Virtio console smoke test.
-
-        Tests the basic functionalities (poll, read/write with and without
-        connected host, etc.
-
-        @param test: Main test object.
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Field of virtio ports with the minimum of 2 items.
-        @param params: Test parameters '$console_type:$data;...'
-        @param global_params: Params defined by tests_base.conf.
+        Remove and load virtio_console kernel module.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
         """
-        # PREPARE
-        if (global_params.get('smoke_test') == "yes"):
-            for param in params.split(';'):
-                if not param:
-                    continue
-                headline = "test_smoke: params: %s" % (param)
-                logging.info(headline)
-                param = param.split(':')
-                if len(param) > 1:
-                    data = param[1]
-                else:
-                    data = "Smoke test data"
-                param = (param[0] == 'serialport')
-                send_pt = consoles[param][0]
-                recv_pt = consoles[param][1]
-                subtest.headline(headline)
-                subtest.do_test(tcheck_zero_sym, [vm], cleanup=False)
-                subtest.do_test(topen, [vm, send_pt], True)
-                subtest.do_test(tclose, [vm, send_pt], True)
-                subtest.do_test(tmulti_open, [vm, send_pt])
-                subtest.do_test(tpolling, [vm, send_pt])
-                subtest.do_test(tsigio, [vm, send_pt])
-                subtest.do_test(tlseek, [vm, send_pt])
-                subtest.do_test(trw_host_offline, [vm, send_pt])
-                subtest.do_test(trw_host_offline_big_data, [vm, send_pt],
-                                cleanup=False)
-                subtest.do_test(trw_notconnect_guest,
-                                [vm, send_pt, consoles])
-                subtest.do_test(trw_nonblocking_mode, [vm, send_pt])
-                subtest.do_test(trw_blocking_mode, [vm, send_pt])
-                subtest.do_test(tbasic_loopback, [vm, send_pt, recv_pt, data],
-                                True)
+        (vm, guest_worker, port) = get_vm_with_single_port(
+                                        params.get('virtio_console_params'))
+        guest_worker.cleanup()
+        session = vm.wait_for_login()
+        if session.cmd_status('lsmod | grep virtio_console'):
+            raise error.TestNAError("virtio_console not loaded, probably "
+                                    " not compiled as module. Can't test it.")
+        session.cmd("rmmod -f virtio_console")
+        session.cmd("modprobe virtio_console")
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        guest_worker.cmd("virt.clean_port('%s'),1024" % port.name, 2)
+        cleanup(vm, guest_worker)
 
-
-    def test_multiport(test, vm, consoles, params, global_params):
+    def test_max_ports():
         """
-        This is group of test which test virtio_console in maximal load and
-        with multiple ports.
-
-        @param test: Main test object.
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Field of virtio ports with the minimum of 2 items.
-        @param params: Test parameters '$console_type:$data;...'
-        @param global_params: Params defined by tests_base.conf.
+        Try to start and initialize machine with maximum supported number of
+        virtio ports. (30)
+        @param cfg: virtio_console_params - which type of virtio port to test
         """
-        subtest.headline("test_multiport:")
-        # Test Loopback
-        if (global_params.get('loopback_test') == "yes"):
-            subtest.do_test(tloopback, [vm, consoles, params[0]])
+        port_count = 30
+        if params.get('virtio_console_params') == "serialport":
+            logging.debug("Count of serialports: %d", port_count)
+            vm = get_vm_with_ports(0, port_count, quiet=True)
+        else:
+            logging.debug("Count of consoles: %d", port_count)
+            vm = get_vm_with_ports(port_count, 0, quiet=True)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        cleanup(vm, guest_worker)
 
-        # Test Performance
-        if (global_params.get('perf_test') == "yes"):
-            subtest.do_test(tperf, [vm, consoles, params[1]])
-
-
-    def test_destructive(test, vm, consoles, global_params, params):
+    def test_max_serials_and_conosles():
         """
-        This is group of tests which might be destructive.
-
-        @param test: Main test object.
-        @param vm: Target virtual machine [vm, session, tmp_dir, ser_session].
-        @param consoles: Field of virtio ports with the minimum of 2 items.
-        @param global_params: Params defined by tests_base.conf.
-        @param params: Dictionary of subtest params from tests_base.conf.
+        Try to start and initialize machine with maximum supported number of
+        virtio ports with 15 virtconsoles and 15 virtserialports.
         """
-        subtest.headline("test_destructive:")
-        # Uses stronger clean up function
-        (_cleanup_func, _cleanup_args) = subtest.get_cleanup_func()
-        subtest.set_cleanup_func(clean_reload_vm, [vm, consoles])
+        port_count = 15
+        logging.debug("Count of virtports: %d %d", port_count, port_count)
+        vm = get_vm_with_ports(port_count, port_count, quiet=True)
+        guest_worker = kvm_virtio_port.GuestWorker(vm)
+        cleanup(vm, guest_worker)
 
-        if (global_params.get('rmmod_test') == "yes"):
-            subtest.do_test(trmmod, [vm, consoles])
-        if (global_params.get('max_ports_test') == "yes"):
-            subtest.do_test(tmax_serial_ports, [vm, consoles])
-            subtest.do_test(tmax_console_ports, [vm, consoles])
-            subtest.do_test(tmax_mix_serial_conosle_port, [vm, consoles])
-        if (global_params.get('shutdown_test') == "yes"):
-            subtest.do_test(tshutdown, [vm, consoles])
-        if (global_params.get('migrate_offline_test') == "yes"):
-            subtest.do_test(tmigrate_offline,
-                            [vm, consoles, params['tmigrate_offline_params']])
-        if (global_params.get('migrate_online_test') == "yes"):
-            subtest.do_test(tmigrate_online,
-                            [vm, consoles, params['tmigrate_online_params']])
-        if (global_params.get('hotplug_serial_test') == "yes"):
-            subtest.do_test(thotplug, [vm, consoles])
-            subtest.do_test(thotplug_no_timeout, [vm, consoles])
-        if (global_params.get('hotplug_console_test') == "yes"):
-            subtest.do_test(thotplug, [vm, consoles, "yes"])
-            subtest.do_test(thotplug_no_timeout, [vm, consoles, "yes"])
-        if (global_params.get('hotplug_pci_test') == "yes"):
-            subtest.do_test(thotplug_virtio_pci, [vm, consoles])
+    def test_shutdown():
+        """
+        Try to gently shutdown the machine while sending data through virtio
+        port.
+        @note: VM should shutdown safely.
+        @param cfg: virtio_console_params - which type of virtio port to test
+        @param cfg: virtio_port_spread - how many devices per virt pci (0=all)
+        """
+        if params.get('virtio_console_params') == 'serialport':
+            vm, guest_worker = get_vm_with_worker(no_serialports=1)
+        else:
+            vm, guest_worker = get_vm_with_worker(no_consoles=1)
+        ports, _ports = get_virtio_ports(vm)
+        ports.extend(_ports)
+        for port in ports:
+            port.open()
+        # If more than one, send data on the other ports
+        for port in ports[1:]:
+            guest_worker.cmd("virt.close('%s')" % (port.name), 2)
+            guest_worker.cmd("virt.open('%s')" % (port.name), 2)
+            try:
+                os.system("dd if=/dev/random of='%s' bs=4096 &>/dev/null &"
+                          % port.path)
+            except Exception:
+                pass
+        # Just start sending, it won't finish anyway...
+        guest_worker._cmd("virt.send('%s', 1024**3, True, is_static=True)"
+                          % ports[0].name, 1)
 
-        subtest.set_cleanup_func(_cleanup_func, _cleanup_args)
+        # Let the computer transfer some bytes :-)
+        time.sleep(2)
 
+        # Power off the computer
+        vm.destroy(gracefully=True)
+        # close the virtio ports on the host side
+        for port in vm.virtio_ports:
+            port.close()
 
-    # INITIALIZE
-    tsmoke_params = params.get('virtio_console_smoke', '')
-    tloopback_params = params.get('virtio_console_loopback', '')
-    tperf_params = params.get('virtio_console_perf', '')
-    tmigrate_offline_params = params.get('virtio_console_migration_offline', '')
-    tmigrate_online_params = params.get('virtio_console_migration_online', '')
-
-    # destructive params
-    tdestructive_params = {}
-    tdestructive_params['tmigrate_offline_params'] = tmigrate_offline_params
-    tdestructive_params['tmigrate_online_params'] = tmigrate_online_params
-
-    no_serialports = int(params.get('virtio_console_no_serialports', 0))
-    no_consoles = int(params.get('virtio_console_no_consoles', 0))
-    # consoles required for Smoke test
-    if tsmoke_params.count('serialport'):
-        no_serialports = max(2, no_serialports)
-    if tsmoke_params.count('console'):
-        no_consoles = max(2, no_consoles)
-    # consoles required for Loopback test
-    for param in tloopback_params.split(';'):
-        no_serialports = max(no_serialports, param.count('serialport'))
-        no_consoles = max(no_consoles, param.count('console'))
-    # consoles required for Performance test
-    if tperf_params.count('serialport'):
-        no_serialports = max(1, no_serialports)
-    if tperf_params.count('console'):
-        no_consoles = max(1, no_consoles)
-    # consoles required for Migration offline test
-    if tmigrate_offline_params.count('serial'):
-        no_serialports = max(2, no_serialports)
-    if tmigrate_offline_params.count('console'):
-        no_consoles = max(2, no_consoles)
-    if tmigrate_online_params.count('serial'):
-        no_serialports = max(2, no_serialports)
-    if tmigrate_online_params.count('console'):
-        no_consoles = max(2, no_consoles)
-
-    if no_serialports + no_consoles == 0:
-        raise error.TestFail("No tests defined, probably incorrect "
-                             "configuration in tests_base.cfg")
-
-    vm, consoles = _vm_create(no_consoles, no_serialports)
-
-    # Copy virtio_console_guest.py into guests
-    virt_dir = os.path.join(os.environ['AUTODIR'], 'virt')
-    vksmd_src = os.path.join(virt_dir, "scripts", "virtio_console_guest.py")
-    dst_dir = "/tmp"
-
-    vm[0].copy_files_to(vksmd_src, dst_dir)
-
-    # ACTUAL TESTING
-    # Defines all available consoles; tests udev and sysfs
-
-    subtest = SubTest()
-    try:
-        init_guest(vm, consoles)
-
-        subtest.set_cleanup_func(clean_ports, [vm, consoles])
-        # Test Smoke
-        test_smoke(subtest, vm, consoles, tsmoke_params, params)
-
-        # Test multiport functionality and performance.
-        test_multiport(subtest, vm, consoles, [tloopback_params, tperf_params],
-                       params)
-
-        #Test destructive test.
-        test_destructive(subtest, vm, consoles, params, tdestructive_params)
-    finally:
-        logging.info(("Summary: %d tests passed  %d test failed :\n" %
-                      (subtest.passed, subtest.failed)) +
-                      subtest.get_text_result())
-
-    if subtest.is_failed():
-        raise error.TestFail("%d out of %d virtio console tests failed" %
-                             (subtest.failed, (subtest.passed + subtest.failed)))
-
-
-    # CLEANUP
-    vm[1].close()   # Close the socket
+    ######################################################################
+    # Main
+    # Executes test specified by virtio_console_test variable in cfg
+    ######################################################################
+    fce = None
+    _fce = "test_" + params.get('virtio_console_test', '').strip()
+    error.context("Executing test: %s" % _fce, logging.info)
+    if _fce not in locals():
+        raise error.TestNAError("Test %s doesn't exist. Check 'virtio_console_"
+                                "test' variable in subtest.cfg" % _fce)
+    else:
+        fce = locals()[_fce]
+        return fce()

--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -949,7 +949,7 @@ class VM(virt_vm.BaseVM):
 
         # Add virtio_serial ports
         virtio_serial_pcis = []
-        virtio_port_spread = int(params.get('virtio_port_spread', 0))
+        virtio_port_spread = int(params.get('virtio_port_spread', 2))
         for port_name in params.objects("virtio_ports"):
             port_params = params.object_params(port_name)
             bus = int(params.get('virtio_port_bus', 0))

--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -1802,77 +1802,120 @@ variants:
 
     - virtio_console: install setup image_copy unattended_install.cdrom
         only Linux
-        vms = ''
         type = virtio_console
+        # Console cleanup is not 100%, consider using kill_vm_on_error
+        kill_vm_on_error = yes
         # Default number of consoles
-        virtio_console_no_serialports = 0
-        virtio_console_no_consoles = 0
-
-        # BASIC INFO ABOUT VIRTIO_CONSOLE PARAMS
-        # smoke params - $console_type:data_string
-        # FIXME: test_smoke doesn't work with console yet (virtio_console bug)
-        # "serialport;console:Custom data"
-        #smoke_test = yes
-        #virtio_console_smoke = "serialport"
-        # loopback params - '$source_console_type@buffer_length:$destination_console_type1@buffer_length:...:$loopback_buffer_length;...'
-        #loopback_test = yes
-        #virtio_console_loopback = "serialport:serialport;serialport@1024:serialport@32:console@1024:console@8:16"
-        # perf params - $console_type@buffer_length:$test_duration
-        # FIXME: test_perf doesn't work with console yet (virtio_console bug)
-        # virtio_console_perf = "serialport;serialport@1000000:120;console@1024:60"
-        #perf_test = yes
-        #virtio_console_perf = "serialport;serialport@1000000:120"
-        # Enable destructive tests: "test_name  = yes"
-        # Disable test: change yes or delete key.
-        #rmmod_test = yes
-        #max_ports_test = yes
-        #shutdown_test = yes
-
-        # Offline migration params - '$console_type:$no_migrations:$send-:$recv-$loopback-buffer_length'
-        #migrate_offline_test = yes
-        #virtio_console_migration_offline = "serialport:1:2048:2048:2048;serialport:5:4096:4096:4096"
-
-        # Online migration params - '$console_type:$no_migrations:$send-:$recv-$loopback-buffer_length'
-        #migrate_online_test = yes
-        #virtio_console_migration_online = "serialport:1:2048:2048:2048;serialport:5:4096:4096:4096"
-
-        #hotplug_test = yes
-        #hotplug_serial_test = yes
-        #hotplug_console_test = no
-
-        # CASES SETUPS:
+        virtio_ports = "vc1 vc2 vc3 vc4 vs1 vs2 vs3 vs4"
+        virtio_port_type = "serialport"
+        virtio_port_type_vc1 = "console"
+        virtio_port_type_vc2 = "console"
+        virtio_port_type_vc3 = "console"
+        virtio_port_type_vc4 = "console"
+        virtio_console_test_time = 60
         variants:
-            - smoke:
-                # Very basic test of presence of virtio_console in system
+            # Tests which can run or serialport or console
+            # NOTE: By default VM have booth serialports and consoles. The difference is that it uses serialport or console as tested object. If you want to test pure VM without the other virtio_port devices change virtio_ports (or virtio_port_type) in 'virtserialport' resp 'virtconsole' variants.
+            - @specifiable:
                 variants:
-                    - serialport:
-                        smoke_test = yes
-                        virtio_console_smoke = "serialport"
-                    - console:
-                        # FIXME: test_smoke doesn't work with console due of virtio_console bug, disable this variant
-                        no virtio_console
-                        smoke_test = yes
-                        virtio_console_smoke = "console"
-            - basic:
-                # Basic virtio_console functionality tests
-                loopback_test = yes
-                virtio_console_loopback = "serialport:serialport;serialport@1024:serialport@32:console@1024:console@8:16"
-            - perf:
-                perf_test = yes
-                virtio_console_perf = "serialport;serialport@1000000:120"
-            - destructive:
-                rmmod_test = yes
-                max_ports_test = yes
-                shutdown_test = yes
-            - migration:
-                migrate_offline_test = yes
-                virtio_console_migration_offline = "serialport:1:2048:2048:2048;serialport:5:4096:4096:4096"
-                migrate_online_test = yes
-                virtio_console_migration_online = "serialport:1:2048:2048:2048;serialport:5:4096:4096:4096"
-            - hotplug:
-                hotplug_test = yes
-                hotplug_serial_test = yes
-                hotplug_console_test = no
+                    # Tests which uses preprocessed VM
+                    - @with_vm:
+                        variants:
+                            # Smoke tests
+                            - open:
+                               virtio_console_test = open
+                            - check_zero_sym:
+                                virtio_console_test = check_zero_sym
+                            - multi_open:
+                                virtio_console_test = multi_open
+                            - close:
+                                virtio_console_test = close
+                            - polling:
+                                virtio_console_test = polling
+                            - sigio:
+                                virtio_console_test = sigio
+                            - lseek:
+                                virtio_console_test = lseek
+                            - rw_host_offline:
+                                virtio_console_test = rw_host_offline
+                            - rw_host_offline_big_data:
+                                virtio_console_test = rw_host_offline_big_data
+                            - rw_blocking_mode:
+                                virtio_console_test = rw_blocking_mode
+                            - rw_nonblocking_mode:
+                                virtio_console_test = rw_nonblocking_mode
+                            - basic_loopback:
+                                virtio_console_test = basic_loopback
+                            # Destructive tests
+                            - rmmod:
+                                virtio_console_test = rmmod
+                            - migration:
+                                virtio_console_no_migrations = 5
+                                virtio_console_no_ports = 2
+                                virtio_console_blocklen = 4096
+                                variants:
+                                    - offline:
+                                        virtio_console_test = migrate_offline
+                                    - online:
+                                        virtio_console_test = migrate_online
+                            - poweroff:
+                                virtio_console_test = shutdown
+                    # Tests which creates own VMs
+                    - @without_vm:
+                        vms = ""
+                        variants:
+                            - hotplug:
+                                only spread_linear
+                                virtio_console_test = hotplug
+                                variants:
+                                    - timeout_0:
+                                        virtio_console_pause = 0
+                                    - timeout_1:
+                                        virtio_console_pause = 1
+                            # Destructive tests
+                            - rw_notconnect_guest:
+                                virtio_console_test = rw_notconnect_guest
+                            - max_ports:
+                                only spread_linear
+                                virtio_port_spread = 0
+                                virtio_console_test = max_ports
+                # Use serialport or console as the main virtioport fpr the tests above
+                variants:
+                    - virtserialport:
+                        # Uncomment this if you want to have VM only with serialports
+                        # virtio_ports = "vs1 vs2 vs3 vs4"
+                        virtio_console_params = serialport
+                    - virtconsole:
+                        # Uncomment this if you want to have VM only with consoles
+                        # virtio_ports = "vc1 vc2 vc3 vc4"
+                        virtio_console_params = console
+            # Tests with different setting of the used medium
+            - @unspecifiable:
+                variants:
+                    - loopback:
+                        virtio_console_test = loopback
+                        virtio_console_params = "serialport@1024:serialport@32:console@1024:console@8:16"
+                    - performance:
+                        virtio_console_test = perf
+                        virtio_console_params = "serialport;serialport@1000000"
+                    - hotplug_virtio_pci:
+                        only spread_linear
+                        virtio_console_test = hotplug_virtio_pci
+                        virtio_console_pause = 10
+                        virtio_console_loops = 2
+                    # Without VMS
+                    - max_serials_and_conosles:
+                        only spread_linear
+                        vms = ""
+                        virtio_port_spread = 0
+                        virtio_console_test = max_serials_and_conosles
+        variants:
+            # Use only single virtio-serial-pci
+            - spread_linear:
+                virtio_port_spread = 0
+            # Spread consoles across multiple virtio-serial-pcis
+            - spread_2:
+                virtio_port_spread = 2
 
     # This unit test module is for older branches of KVM that use the
     # kvmctl test harness (such as the code shipped with RHEL 5.x)


### PR DESCRIPTION
Hi guys,

this patchset adds support for virtio-serialport and virtio-console to framework and changes the virtio_console test to use it.

Please read the actual patch description for details. All commits should be applicable but only the last commit is completely clean and should be without typos and with proper docstrings.
