### PR TITLE
virt: Fix the extra blank in readonly_floopy

### DIFF
--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -1134,7 +1134,7 @@ class VM(virt_vm.BaseVM):
                     qemu_cmd += add_drive(help, floppy,
                                           format="floppy",
                                           index=index,
-                                          readonly= floppy_readonly)
+                                          readonly=floppy_readonly)
                 else:
                     qemu_cmd += add_floppy(help, floppy, index)
 


### PR DESCRIPTION
Remove the extra blank

Signed-off-by: Yiqiao Pu ypu@redhat.com
