### PR TITLE
virt.unattended: Add dmidecode to kickstart

### DIFF
--- a/client/virt/unattended/Fedora-16.ks
+++ b/client/virt/unattended/Fedora-16.ks
@@ -21,6 +21,7 @@ autopart
 @base
 @development-libs
 @development-tools
+dmidecode
 %end
 
 %post --interpreter /usr/bin/python

--- a/client/virt/unattended/Fedora-17.ks
+++ b/client/virt/unattended/Fedora-17.ks
@@ -21,6 +21,7 @@ autopart
 @base
 @development-libs
 @development-tools
+dmidecode
 %end
 
 %post --interpreter /usr/bin/python


### PR DESCRIPTION
Hi,

F16 and F17 is missing `dmidecode` program in kickstart thus `vm.get_memory_size` with default guest returns 0. This patch adds it to required packages in kickstart.

Regards,
Lukáš
