### PR TITLE
SLES11 : Installation media should be attached on boot test

### DIFF
--- a/client/virt/guest-os.cfg.sample
+++ b/client/virt/guest-os.cfg.sample
@@ -1238,6 +1238,10 @@ variants:
                             cdrom_cd1 = isos/linux/SLES-11-SP1-DVD-i586-GM-DVD1.iso
                             md5sum_cd1 = 0dd6886858d93501c38854552b9b1b0d
                             md5sum_1m_cd1 = a626a3d50813410e3ac42794e05773bb
+                        boot:
+                            cdrom_cd1 = isos/linux/SLES-11-SP1-DVD-i586-GM-DVD1.iso
+                            md5sum_cd1 = 0dd6886858d93501c38854552b9b1b0d
+                            md5sum_1m_cd1 = a626a3d50813410e3ac42794e05773bb
 
                    - 11.1.64:
                         image_name = sles11sp1-64
@@ -1253,6 +1257,10 @@ variants:
                             cdrom_cd1 = isos/linux/SLES-11-SP1-DVD-x86_64-GM-DVD1.iso
                             md5sum_cd1 = d2e10420f3689faa49a004b60fb396b7
                             md5sum_1m_cd1 = f7f67b5da46923a9f01da8a2b6909654
+                        boot:
+                            cdrom_cd1 = isos/linux/SLES-11-SP1-DVD-x86_64-GM-DVD1.iso
+                            md5sum_cd1 = d2e10420f3689faa49a004b60fb396b7
+                            md5sum_1m_cd1 = f7f67b5da46923a9f01da8a2b6909654 
 
             - Ubuntu:
                 shell_prompt = "^root@.*[\#\$]\s*$"


### PR DESCRIPTION
Installation cdrom should be attached on first boot test for SLES11. Otherwise yast2-firstboot will fail to install additional packages and the boot test will always fail:

http://paste.opensuse.org/45523026

I handled that in guest-os.cfg . Is there a better way to do this ?
