### PR TITLE
virt: Add option log_func to QemuIO

### DIFF
--- a/client/virt/qemu_io.py
+++ b/client/virt/qemu_io.py
@@ -16,7 +16,8 @@ class QemuIO(object):
     A class for execute qemu-io command
     """
     def __init__(self, test, params, image_name, blkdebug_cfg="",
-                 prompt=r"qemu-io>\s*$", log_filename=None, io_options=""):
+                 prompt=r"qemu-io>\s*$", log_filename=None, io_options="",
+                 log_func=None):
         self.type = ""
         if log_filename:
             log_filename += "-" + virt_utils.generate_random_string(4)
@@ -36,6 +37,7 @@ class QemuIO(object):
         self.run_command = False
         self.image_name = image_name
         self.blkdebug_cfg = blkdebug_cfg
+        self.log_func = log_func
 
 
     def get_cmd_line(self, ignore_option=[], essential_option=[],
@@ -93,9 +95,10 @@ class QemuIOShellSession(QemuIO):
     Use a shell session to execute qemu-io command
     """
     def __init__(self, test, params, image_name, blkdebug_cfg="",
-                 prompt=r"qemu+-io>\s*$", log_filename=None, io_options=""):
+                 prompt=r"qemu+-io>\s*$", log_filename=None, io_options="",
+                 log_func=None):
         QemuIO.__init__(self, test, params, image_name, blkdebug_cfg, prompt,
-                        log_filename, io_options)
+                        log_filename, io_options, log_func)
 
         self.type = "shell"
         forbid_option = ["h", "help", "V", "version", "c", "cmd"]
@@ -120,21 +123,22 @@ class QemuIOShellSession(QemuIO):
         output_params = self.output_params
         output_prefix = self.output_prefix
         if self.create_session:
-            error.context("Running command: %s" % qemu_io_cmd, logging.info)
+            error.context("Running command: %s" % qemu_io_cmd, self.log_func)
             self.session = aexpect.ShellSession(qemu_io_cmd, echo=True,
                                                 prompt=prompt,
                                                 output_func=output_func,
                                                 output_params=output_params,
                                                 output_prefix=output_prefix)
             # Record the command line in log file
-            params = self.output_params + (qemu_io_cmd, )
-            self.output_func(*params)
+            if self.output_func:
+                params = self.output_params + (qemu_io_cmd, )
+                self.output_func(*params)
 
             self.create_session = False
             # Get the reaction from session
             self.session.cmd_output("\n")
 
-        error.context("Executing command: %s" % command, logging.info)
+        error.context("Executing command: %s" % command, self.log_func)
         return self.session.cmd_output(command, timeout=timeout)
 
 
@@ -151,9 +155,10 @@ class QemuIOSystem(QemuIO):
     Run qemu-io with a command line which will return immediately
     """
     def __init__(self, test, params, image_name, blkdebug_cfg="",
-                 prompt=r"qemu-io>\s*$", log_filename=None, io_options=""):
+                 prompt=r"qemu-io>\s*$", log_filename=None, io_options="",
+                 log_func=None):
         QemuIO.__init__(self, test, params, image_name, blkdebug_cfg, prompt,
-                        log_filename, io_options)
+                        log_filename, io_options, log_func)
         ignore_option = ["c", "cmd"]
         essential_option = ["h", "help", "V", "version", "c", "cmd"]
         qemu_io_cmd = self.qemu_io_cmd
@@ -170,19 +175,19 @@ class QemuIOSystem(QemuIO):
         @param timeout: timeout for execute the command
         """
         qemu_io_cmd = self.qemu_io_cmd
-        print qemu_io_cmd
         if command:
             qemu_io_cmd += " -c '%s'" % command
 
-        error.context("Running command: %s" % qemu_io_cmd, logging.info)
+        error.context("Running command: %s" % qemu_io_cmd, self.log_func)
         output = utils.system_output(qemu_io_cmd, timeout=timeout)
 
         # Record command line in log file
-        params = self.output_params + (qemu_io_cmd,)
-        self.output_func(*params)
+        if self.output_func:
+            params = self.output_params + (qemu_io_cmd,)
+            self.output_func(*params)
 
-        params = self.output_params + (output,)
-        self.output_func(*params)
+            params = self.output_params + (output,)
+            self.output_func(*params)
 
         return output
 


### PR DESCRIPTION
Add option log_func to QemuIO to help user to record the
informations in different levels.
Also fix the problem caused by the scripts will try to call
output_func when it is None.

Signed-off-by: Yiqiao Pu ypu@redhat.com
