### PR TITLE
result listing: add a header to auto generated results dir page

### DIFF
--- a/apache/conf/tko-directives
+++ b/apache/conf/tko-directives
@@ -13,6 +13,7 @@ RewriteRule /results(.*) /var/lib/autotest/results/$1
     Options Indexes FollowSymLinks MultiViews
     Order allow,deny
     Allow from all
+    IndexHeadInsert "<img src='/afe/header.png'/><hr/>"
 </Location>
 
 <LocationMatch "/results.*\.(log|DEBUG|INFO|WARNING|ERROR)$">


### PR DESCRIPTION
So that it looks a bit better and it's more obvious that it is
an autotest page.

Signed-off-by: Cleber Rosa crosa@redhat.com
