### PR TITLE
virt: make cpu socket count work on more distros

### DIFF
--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -1781,7 +1781,7 @@ variants:
         vio_driver_chk_cmd = ""
         mem_chk_re_str = ([0-9]+)
         cpu_cores_chk_cmd = "lscpu | grep '^Core'"
-        cpu_sockets_chk_cmd = "lscpu | grep '^Socket'"
+        cpu_sockets_chk_cmd = "lscpu | grep -E '(^Socket|^CPU socket)'"
         cpu_threads_chk_cmd = "lscpu | grep '^Thread'"
         chk_timeout = 240
 


### PR DESCRIPTION
Stock 'lscpu' on distros such as RHEL 6 (and possibly others)
have a different output format on the socket line.

This patch allows both output formats by default, and makes the
physical_resources_check work on such distros out of the box.

Signed-off-by: Cleber Rosa crosa@redhat.com
