### PR TITLE
Move virsh_*() functions into separate module

### DIFF
--- a/client/tests/libvirt/tests/virsh_capabilities.py
+++ b/client/tests/libvirt/tests/virsh_capabilities.py
@@ -64,7 +64,9 @@ def run_virsh_capabilities(test, params, env):
             raise error.TestFail("The capabilities_xml gives an different "
                                  "hypervisor")
 
-    connect_uri = params.get("connect_uri", virsh.canonical_uri())
+
+    connect_uri = libvirt_vm.normalize_connect_uri( params.get("connect_uri",
+                                                               "default") )
 
     # Prepare libvirtd service
     if params.has_key("libvirtd"):
@@ -75,11 +77,12 @@ def run_virsh_capabilities(test, params, env):
     # Run test case
     option = params.get("virsh_cap_options")
     try:
-        output = virsh.capabilities(option, uri = connect_uri,
-                                    ignore_status = False, debug = True)
+        output = virsh.capabilities(option, uri=connect_uri,
+                                    ignore_status=False, debug=True)
         status = 0 # good
-    except utils.CmdError:
+    except error.CmdError:
         status = 1 # bad
+        output = ''
 
     # Recover libvirtd service start
     if libvirtd == "off":

--- a/client/tests/libvirt/tests/virsh_domname.py
+++ b/client/tests/libvirt/tests/virsh_domname.py
@@ -49,7 +49,7 @@ def run_virsh_domname(test, params, env):
     if options_suffix:
         options = options + " " + options_suffix
     result = virsh.domname(options, ignore_status=True, debug=True,
-                           uri = connect_uri)
+                           uri=connect_uri)
 
     #Recover libvirtd service to start
     if libvirtd == "off":

--- a/client/tests/libvirt/tests/virsh_hostname.py
+++ b/client/tests/libvirt/tests/virsh_hostname.py
@@ -10,13 +10,6 @@ def run_virsh_hostname(test, params, env):
     (2) Call virsh hostname with an unexpected option
     (3) Call virsh hostname with libvirtd service stop
     """
-    def virsh_hostname(option):
-        cmd = "virsh hostname  %s" % option
-        cmd_result = utils.run(cmd, ignore_status=True)
-        logging.debug("Output: %s", cmd_result.stdout.strip())
-        logging.debug("Error: %s", cmd_result.stderr.strip())
-        logging.debug("Status: %d", cmd_result.exit_status)
-        return cmd_result.exit_status, cmd_result.stdout.strip()
 
     hostname_result = utils.run("hostname", ignore_status=True)
     hostname = hostname_result.stdout.strip()
@@ -32,11 +25,12 @@ def run_virsh_hostname(test, params, env):
     option = params.get("virsh_hostname_options")
     try:
         hostname_test = virsh.hostname(option,
-                                       ignore_status = False,
-                                       debug = True)
+                                       ignore_status=False,
+                                       debug=True)
         status = 0 # good
-    except CmdError:
+    except error.CmdError:
         status = 1 # bad
+        hostname_test = None
 
     # Recover libvirtd service start
     if libvirtd == "off":
@@ -50,7 +44,7 @@ def run_virsh_hostname(test, params, env):
                                  "(incorrect command)" % option)
     elif status_error == "no":
         if cmp(hostname, hostname_test) != 0:
-            raise error.TestFail("Virsh cmd gives wrong hostname.")
+            raise error.TestFail("Virsh cmd gives hostname %s != %s." % (hostname_test, hostname))
         if status != 0:
             raise error.TestFail("Command 'virsh hostname %s' failed "
                                  "(correct command)" % option)

--- a/client/tests/libvirt/tests/virsh_migrate.py
+++ b/client/tests/libvirt/tests/virsh_migrate.py
@@ -24,7 +24,7 @@ def run_virsh_migrate(test, params, env):
         """
         logging.info("Cleaning up VMs on %s" % vm.connect_uri)
         try:
-            if virsh.domain_exists(vm.name, uri = vm.connect_uri):
+            if virsh.domain_exists(vm.name, uri=vm.connect_uri):
                 vm_state = vm.state()
                 if vm_state == "paused":
                     vm.resume()
@@ -74,10 +74,6 @@ def run_virsh_migrate(test, params, env):
     if not vm_xmlfile_bak:
         logging.error("Backing up xmlfile failed.")
 
-    vm.connect_uri = params.get("connect_uri", "default")
-    if vm.connect_uri == 'default':
-        vm.connect_uri = virsh.canonical_uri()
-
     src_uri = vm.connect_uri
     dest_uri = params.get("virsh_migrate_desturi")
     # Identify easy config. mistakes early
@@ -110,14 +106,16 @@ def run_virsh_migrate(test, params, env):
         s_ping, o_ping = utils_test.ping(vm_ip, count=2, timeout=delay)
         logging.info(o_ping)
         if s_ping != 0:
-            raise error.TestError("%s did not respond after %d sec." % (vm.name, delay))
+            raise error.TestError("%s did not respond after %d sec."
+                                  % (vm.name, delay))
 
         # Prepare for --xml.
         logging.debug("Preparing new xml file for --xml option.")
         if options.count("xml") or extra.count("xml"):
             dest_xmlfile = params.get("virsh_migrate_xml", "")
             if dest_xmlfile:
-                ret_attach = vm.attach_interface("--type bridge --source virbr0 --mac %s" % new_nic_mac, True, True)
+                ret_attach = vm.attach_interface("--type bridge --source "
+                                "virbr0 --mac %s" % new_nic_mac, True, True)
                 if not ret_attach:
                     exception = True
                     raise error.TestError("Attaching nic to %s failed." % vm.name)
@@ -188,15 +186,15 @@ def run_virsh_migrate(test, params, env):
         if options.count("undefinesource") or extra.count("undefinesource"):
             logging.info("Verifying <virsh domstate> DOES return an error."
                          "%s should not exist on %s." % (vm_name, src_uri))
-            if virsh.domain_exists(vm_name, uri = src_uri):
-                check_src_undefine = False
+            if virsh.domain_exists(vm_name, uri=src_uri):
+                check_src_undefine=False
 
         # Checking for --dname.
         logging.debug("Checking for --dname option.")
         check_dest_dname = True
         if options.count("dname") or extra.count("dname"):
             dname = extra.split()[1].strip()
-            if not virsh.domain_exists(dname, uri = dest_uri):
+            if not virsh.domain_exists(dname, uri=dest_uri):
                 check_dest_dname = False
 
         # Checking for --xml.
@@ -240,7 +238,7 @@ def run_virsh_migrate(test, params, env):
 
     # Recover source (just in case).
     # vm.connect_uri has been set back to src_uri in cleanup_dest().
-    if not virsh.domain_exists(vm_name, uri = src_uri):
+    if not virsh.domain_exists(vm_name, uri=src_uri):
         vm.define(vm_xmlfile_bak)
     else:
         #if not vm.shutdown():

--- a/client/tests/libvirt/tests/virsh_nodeinfo.py
+++ b/client/tests/libvirt/tests/virsh_nodeinfo.py
@@ -1,5 +1,6 @@
 import re, logging
-from autotest.client.shared import utils, error
+from autotest.client import utils
+from autotest.client.shared import error
 from autotest.client.virt import libvirt_vm, virsh
 
 def run_virsh_nodeinfo(test, params, env):

--- a/client/tests/libvirt/tests/virsh_pool_create_as.py
+++ b/client/tests/libvirt/tests/virsh_pool_create_as.py
@@ -30,7 +30,7 @@ def run_virsh_pool_create_as(test, params, env):
 
     logging.info('Creating a %s type pool %s' % (pool_type, pool_name))
     status = virsh.pool_create_as(pool_name, pool_type, pool_target,
-                                  extra = pool_options, uri = virsh.canonical_uri())
+                                  extra=pool_options, uri=virsh.canonical_uri())
 
     # Check status_error
     status_error = params.get('status_error')
@@ -40,7 +40,7 @@ def run_virsh_pool_create_as(test, params, env):
         else:
             logging.info("It's an expected error")
     elif status_error == 'no':
-        if not virt.virsh_pool_info(pool_name, uri = virsh.canonical_uri()):
+        if not virsh.pool_info(pool_name, uri=virsh.canonical_uri()):
             raise error.TestFail('Failed to check pool information')
         else:
             logging.info('Pool %s is running' % pool_name)

--- a/client/tests/libvirt/tests/virsh_uri.py
+++ b/client/tests/libvirt/tests/virsh_uri.py
@@ -12,6 +12,19 @@ def run_virsh_uri(test, params, env):
     (4) Call virsh uri with libvirtd service stop
     """
 
+    connect_uri = libvirt_vm.normalize_connect_uri( params.get("connect_uri",
+                                                               "default") )
+
+    option = params.get("options")
+    target_uri = params.get("target_uri")
+    if target_uri:
+        if target_uri.count('EXAMPLE.COM'):
+            raise error.TestError('target_uri configuration set to sample value')
+        logging.info("The target_uri: %s", target_uri)
+        cmd = "virsh -c %s uri" % target_uri
+    else:
+        cmd = "virsh uri %s" % option
+
     # Prepare libvirtd service
     check_libvirtd = params.has_key("libvirtd")
     if check_libvirtd:
@@ -20,22 +33,11 @@ def run_virsh_uri(test, params, env):
             libvirt_vm.service_libvirtd_control("stop")
 
     # Run test case
-    connect_uri = params.get('connect_uri')
-    option = params.get("options")
-    target_uri = params.get("target_uri")
-    if target_uri:
-        if target_uri.count('SOURCE_HOSTNAME.EXAMPLE.COM'):
-            raise error.TestError('target_uri configuration set to sample value')
-        logging.info("The target_uri: %s", target_uri)
-        cmd = "virsh -c %s uri" % target_uri
-    else:
-        cmd = "virsh uri %s" % option
-
     logging.info("The command: %s", cmd)
     try:
-        uri_test = virsh.canonical_uri(option, uri = connect_uri,
-                             ignore_status = False,
-                             debug = True)
+        uri_test = virsh.canonical_uri(option, uri=connect_uri,
+                             ignore_status=False,
+                             debug=True)
         status = 0 # good
     except error.CmdError:
         status = 1 # bad
@@ -55,7 +57,7 @@ def run_virsh_uri(test, params, env):
             logging.info("command: %s is a expected error", cmd)
     elif status_error == "no":
         if cmp(target_uri, uri_test) != 0:
-            raise error.TestFail("Virsh cmd gives wrong uri.")
+            raise error.TestFail("Virsh cmd uri %s != %s." % (uri_test,target_uri))
         if status != 0:
             raise error.TestFail("Command: %s  failed "
                                  "(correct command)" % cmd)

--- a/client/tests/libvirt/tests/virsh_vcpupin.py
+++ b/client/tests/libvirt/tests/virsh_vcpupin.py
@@ -1,5 +1,6 @@
 import logging, re, os, commands, string, math
-from autotest.client.shared import utils, error
+from autotest.client import utils
+from autotest.client.shared import error
 from autotest.client.virt import virsh
 
 def run_virsh_vcpupin(test, params, env):

--- a/client/tests/libvirt/tests/virsh_version.py
+++ b/client/tests/libvirt/tests/virsh_version.py
@@ -11,7 +11,8 @@ def run_virsh_version(test, params, env):
     (3) Call virsh version with libvirtd service stop
     """
 
-    connect_uri = params.get("connect_uri")
+    connect_uri = libvirt_vm.normalize_connect_uri( params.get("connect_uri",
+                                                               "default") )
 
     # Prepare libvirtd service
     check_libvirtd = params.has_key("libvirtd")
@@ -23,8 +24,8 @@ def run_virsh_version(test, params, env):
     # Run test case
     option = params.get("virsh_version_options")
     try:
-        output = virsh.version(option, uri = connect_uri,
-                               ignore_status = False, debug = True)
+        output = virsh.version(option, uri=connect_uri,
+                               ignore_status=False, debug=True)
         status = 0 #good
     except error.CmdError:
         status = 1 #bad

--- a/client/virt/subtests.cfg.sample
+++ b/client/virt/subtests.cfg.sample
@@ -200,9 +200,9 @@ variants:
                 #premise: connect with none-password
                 variants:
                     - connect_to_local:
-                        target_uri = "qemu+ssh:///system"
+                        target_uri = "qemu:///system"
                     - connect_to_remote:
-                        target_uri = ${connect_uri}
+                        target_uri = "qemu://TARGET_HOSTNAME.EXAMPLE.COM/system"
             - unexpect_option:
                 options = "xyz"
                 status_error = "yes"

--- a/client/virt/virsh_unittest.py
+++ b/client/virt/virsh_unittest.py
@@ -52,8 +52,8 @@ class class_constructors_test(module_load_test):
         v = self.virsh.Virsh()
 
 
-    def test_VirshPersistant(self):
-        vp = self.virsh.VirshPersistant()
+    def test_VirshPersistent(self):
+        vp = self.virsh.VirshPersistent()
 
 
     def test_DArgMangler(self):
@@ -98,10 +98,10 @@ class virsh_class_has_help_command_test(virsh_has_help_command_test):
     def setUp(self):
         self.virsh = self.virsh.Virsh(debug=True)
 
-class virsh_persistant_class_has_help_command_test(virsh_has_help_command_test):
+class virsh_persistent_class_has_help_command_test(virsh_has_help_command_test):
 
     def setUp(self):
-        self.virsh = self.virsh.VirshPersistant(debug=True)
+        self.virsh = self.virsh.VirshPersistent(debug=True)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<pre><code>
virsh_*()   is now   virsh.whatever()
                     -and/or-
                     v = virsh.Virsh(uri, debug, virsh_exec)
                     v.whatever()
                     v.whatever()
                     v.whatever()

virh_*(..., print_info)   is now  virsh.whatever(..., debug)

virsh_uri() is now virsh.canonical_uri() so it doesn't conflict with class property

virsh_uuid()  is now  virsh.domuuid()

virsh_screenshot()  is now virsh.screenshot and only logs error message once

virsh_cmd() is now virsh.command() or virsh.Virsh.command() 
     with the Virsh class's method holding a persistant connection open to virsh 
     instead of using a new one for every command.

virsh_list() is now virsh.dom_list() 

virsh function (and Virsh method) API is now  name([param, ...], [keyword, ...], **dargs) 
where (currently) dargs contains keys for 'uri', 'debug', 'ignore_status',
and 'virsh_exec' (but it's easily extensible)
</code></pre>
