### PR TITLE
virt: virtio-blk-pci and RHEL 5

### DIFF
--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -479,11 +479,12 @@ class VM(virt_vm.BaseVM):
                 format = "none"
                 index = None
             if format == "virtio":
-                name = "virtio%s" % index
-                dev += " -device virtio-blk-pci"
+                if has_option(help, "device"):
+                    name = "virtio%s" % index
+                    dev += " -device virtio-blk-pci"
+                    dev += _add_option("drive", name)
+                    format = "none"
                 dev += _add_option("bootindex", bootindex)
-                dev += _add_option("drive", name)
-                format = "none"
                 index = None
             if format in ['usb1', 'usb2', 'usb3']:
                 name = "%s.%s" % (format, index)


### PR DESCRIPTION
Checking if qemu-kvm has the '-device' command line option seems to
safe and accurate enough to generate correct syntaxes on both RHEL 5
and latest upstream.

This is better documented on github issue #504.

Signed-off-by: Cleber Rosa crosa@redhat.com
