### PR TITLE
virt: New options for virtio_ports

### DIFF
--- a/client/virt/base.cfg.sample
+++ b/client/virt/base.cfg.sample
@@ -74,6 +74,11 @@ usb_controller_tablet1 = uhci
 # Host socket type
 # virtio_port_chardev = spicevmc
 # virtio_port_chardev_vc1 = socket
+# chardev name prefix (port index will be appended)
+# virtio_port_name_prefix = "com.redhat.spice."
+# By default the port name is used (vc1)
+# virtio_port_name_prefix_vc1 = ""
+
 # Emulated machine type, run following command to see supported machine type.
 # qemu-kvm -M ?
 # machine_type = pc

--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -345,7 +345,8 @@ class VM(virt_vm.BaseVM):
             return cmd
 
 
-        def add_virtio_port(help, name, bus, filename, porttype, chardev):
+        def add_virtio_port(help, name, bus, filename, porttype, chardev,
+                            name_prefix=None, index=None):
             """
             Appends virtio_serialport or virtio_console device to cmdline.
             @param help: qemu -h output
@@ -365,7 +366,11 @@ class VM(virt_vm.BaseVM):
                 cmd += " -device virtconsole"
             else:
                 cmd += " -device virtserialport"
-            cmd += ",chardev=dev%s,name=%s,id=%s" % (name, name, name)
+            if name_prefix:     # used by spiceagent (com.redhat.spice.*)
+                port_name = "%s%d" % (name_prefix, index)
+            else:
+                port_name = name
+            cmd += ",chardev=dev%s,name=%s,id=%s" % (name, port_name, name)
             cmd += _add_option("bus", bus)
             return cmd
 
@@ -976,6 +981,7 @@ class VM(virt_vm.BaseVM):
         qemu_cmd += add_serial(help, vm.get_serial_console_filename())
 
         # Add virtio_serial ports
+        i = 0
         virtio_serial_pcis = []
         virtio_port_spread = int(params.get('virtio_port_spread', 2))
         for port_name in params.objects("virtio_ports"):
@@ -995,7 +1001,10 @@ class VM(virt_vm.BaseVM):
             qemu_cmd += add_virtio_port(help, port_name, bus,
                                     self.get_virtio_port_filename(port_name),
                                     port_params.get('virtio_port_type'),
-                                    port_params.get('virtio_port_chardev'))
+                                    port_params.get('virtio_port_chardev'),
+                                    port_params.get('virtio_port_name_prefix'),
+                                    i)
+            i += 1
 
         # Add logging
         qemu_cmd += add_log_seabios(help)


### PR DESCRIPTION
Hi guys,

This patchset adds `name_prefix` option to virtio_ports. This feature is requested by SPICE team. Spiceagent requires virtio_ports names in following format: "com.redhat.spice.*"

Also it adds commented out examples of using virtio_ports to base.cfg.

Regards,
Lukáš
