### PR TITLE
virt: Record qemu_command line as an attribute of kvm vm

### DIFF
--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -85,6 +85,7 @@ class VM(virt_vm.BaseVM):
         # un-overwrite instance attribute, virtnet db lookups depend on this
         if state:
             self.instance = state['instance']
+        self.qemu_command = ''
 
     def verify_alive(self):
         """
@@ -1600,6 +1601,7 @@ class VM(virt_vm.BaseVM):
                                               "[9p proxy helper]")
 
             logging.info("Running qemu command:\n%s", qemu_command)
+            self.qemu_command = qemu_command
             self.process = aexpect.run_bg(qemu_command, None,
                                           logging.info, "[qemu output] ")
 


### PR DESCRIPTION
Make this change to fit some cases need to record or compare the
qemu command.

Signed-off-by: Yiqiao Pu ypu@redhat.com
