### PR TITLE
database: add database migration file that replaces Django fixtures

### DIFF
--- a/frontend/afe/fixtures/initial_data.json
+++ b/frontend/afe/fixtures/initial_data.json
@@ -1,1 +1,0 @@
-[{"pk": "1", "model": "afe.aclgroup", "fields": {"name": "Everyone", "description": ""}}]

--- a/frontend/migrations/070_add_acl_group_replace_django_fixture.py
+++ b/frontend/migrations/070_add_acl_group_replace_django_fixture.py
@@ -1,0 +1,8 @@
+UP_SQL = """
+INSERT INTO afe_acl_groups (id, name) VALUES (1, 'Everyone') ON DUPLICATE KEY UPDATE name='Everyone';
+"""
+
+# Since this used to be a value INSERTED by Django fixtures, do not remove it
+# when downgrading versions
+DOWN_SQL = """
+"""


### PR DESCRIPTION
We used to rely on a Django fixtures to add a single record of initial
data to the afe_acl_groups table. We can simply move that data to the
schema, or, as done here, in a database version migration script.

This fixes issue #503.

Signed-off-by: Cleber Rosa crosa@redhat.com
