### PR TITLE
Make kvm_vm create nic device following the params

### DIFF
--- a/client/virt/kvm_vm.py
+++ b/client/virt/kvm_vm.py
@@ -2624,11 +2624,22 @@ class VM(virt_vm.BaseVM):
         """
         if (self.__make_qemu_command() !=
                 self.__make_qemu_command(name, params, basedir)):
-            logging.debug("VM params in env don't match requested, restarting.")
-            return True
+            restart = True
+        else:
+            for i, nic in enumerate(params.objects('nics')):
+                if (self.virtnet[i]['netdst'] !=
+                    params.object_params('nic').get('netdst')):
+                    restart = True
+            else:
+                restart = False
+
+        if restart:
+            logging.debug("VM params in env don't match requested, "
+                          "restarting.")
         else:
             logging.debug("VM params in env do match requested, continuing.")
-            return False
+
+        return restart
 
     def pause(self):
         """


### PR DESCRIPTION
Now when running a set up cases with different nic configure, some case will failed with the nic config problem, this is caused by the nic devices is create and the qmeu command line is make up following the old virtnet read from env but not the params. This patch will fix it.

And also fix the netdst change will not shows up in the qmeu command line which may cause the miss judge in the needs_restart function.
