### PR TITLE
virt: set vnet_hdr to True when open the tap device

### DIFF
--- a/client/tests/virt/virttest/kvm_vm.py
+++ b/client/tests/virt/virttest/kvm_vm.py
@@ -1500,7 +1500,7 @@ class VM(virt_vm.BaseVM):
                     try:
                         nic.tapfd = str(utils_misc.open_tap("/dev/net/tun",
                                                             nic.ifname,
-                                                            vnet_hdr=False))
+                                                            vnet_hdr=True))
                         logging.debug("Adding VM %s NIC ifname %s"
                                       " to bridge %s" % (self.name,
                                             nic.ifname, nic.netdst))


### PR DESCRIPTION
Set vnet_hdr to True to let the open_tap to check if IFF_VNET_HDR
is support in tun. Otherwise most of the flags of the device will
be set to off and the performance of the nic device will be poor.

Signed-off-by: Yiqiao Pu ypu@redhat.com
