### PR TITLE
virt: introduce KVM monitor connection timeout

### DIFF
--- a/client/tests/virt/virttest/kvm_monitor.py
+++ b/client/tests/virt/virttest/kvm_monitor.py
@@ -63,6 +63,7 @@ class Monitor:
 
     ACQUIRE_LOCK_TIMEOUT = 20
     DATA_AVAILABLE_TIMEOUT = 0
+    CONNECT_TIMETOUT = 30
 
     def __init__(self, name, filename):
         """
@@ -76,6 +77,7 @@ class Monitor:
         self.filename = filename
         self._lock = threading.RLock()
         self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._socket.settimetout(self.CONNECT_TIMEOUT)
         self._passfd = None
         self._supported_cmds = []
         self.debug_log = False


### PR DESCRIPTION
On some situations a job may get stuck forever trying to establish a
connection to a UNIX domain socket that connects the test code to
the qemu monitor.

This simple connection timeout won't fix all test problems, but will
avoid jobs that never finish properly.

Signed-off-by: Cleber Rosa crosa@redhat.com
