### PR TITLE
virt: set timeout on http server to prevent it from blocking forever

### DIFF
--- a/client/tests/virt/virttest/http_server.py
+++ b/client/tests/virt/virttest/http_server.py
@@ -118,6 +118,8 @@ class HTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
 
 def http_server(port=8000, cwd=None, terminate_callable=None):
     http = BaseHTTPServer.HTTPServer(('', port), HTTPRequestHandler)
+    http.timeout = 1
+
     if cwd is None:
         cwd = os.getcwd()
     http.cwd = cwd
@@ -128,8 +130,10 @@ def http_server(port=8000, cwd=None, terminate_callable=None):
         else:
             terminate = False
 
-        if not terminate:
-            http.handle_request()
+        if terminate:
+            break
+
+        http.handle_request()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes github issue #502. Thanks to Chris Evich for the brainstorming
that led us to this simple yet effective fix.

Signed-off-by: Cleber Rosa crosa@redhat.com
