### PR TITLE
virt: give every virt test a 4 hour timeout

### DIFF
--- a/client/tests/virt/shared/cfg/base.cfg.sample
+++ b/client/tests/virt/shared/cfg/base.cfg.sample
@@ -348,6 +348,7 @@ profilers = kvm_stat
 
 # Timeouts
 login_timeout = 360
+test_timeout = 14400
 
 # libvirt (virt-install optional arguments)
 # TODO: Rename these with 'libvirt_' prefix

--- a/client/tests/virt/virttest/utils_misc.py
+++ b/client/tests/virt/virttest/utils_misc.py
@@ -1650,11 +1650,13 @@ def run_tests(parser, job):
             # We need only one execution, profiled, hence we're passing
             # the profile_only parameter to job.run_test().
             profile_only = bool(profilers) or None
+            test_timeout = int(param_dict.get("test_timeout", 14400))
             current_status = job.run_test_detail("virt",
                                                  params=param_dict,
                                                  tag=test_tag,
                                                  iterations=test_iterations,
-                                                 profile_only=profile_only)
+                                                 profile_only=profile_only,
+                                                 timeout=test_timeout)
             for profiler in profilers:
                 job.profilers.delete(profiler)
         else:


### PR DESCRIPTION
This should protect against situations were test code gets stuck,
using autotest's native timeout mechanism.

Signed-off-by: Cleber Rosa crosa@redhat.com
