### PR TITLE
[RFC] Rename global_config to settings

### DIFF
--- a/cli/rpc.py
+++ b/cli/rpc.py
@@ -4,10 +4,8 @@
 
 import os
 from autotest.frontend.afe import rpc_client_lib
-from autotest.frontend.afe.json_rpc import proxy
-from autotest.client.shared import global_config, utils
+from autotest.client.shared.settings import settings
 
-GLOBAL_CONFIG = global_config.global_config
 DEFAULT_SERVER = 'autotest'
 AFE_RPC_PATH = '/afe/server/rpc/'
 TKO_RPC_PATH = '/new_tko/server/rpc/'
@@ -22,8 +20,9 @@ def get_autotest_server(web_server=None):
         if 'AUTOTEST_WEB' in os.environ:
             web_server = os.environ['AUTOTEST_WEB']
         else:
-            web_server = 'http://' + GLOBAL_CONFIG.get_config_value(
-                    'SERVER', 'hostname', default=DEFAULT_SERVER)
+            web_server = ('http://' +
+                          settings.get_value('SERVER', 'hostname',
+                                             default=DEFAULT_SERVER))
 
     # if the name doesn't start with http://,
     # nonexistant hosts get an obscure error

--- a/cli/rpc_unittest.py
+++ b/cli/rpc_unittest.py
@@ -10,11 +10,7 @@ try:
 except ImportError:
     import common
 from autotest.cli import rpc
-from autotest.client.shared import global_config
-from autotest.frontend.afe import rpc_client_lib
-from autotest.frontend.afe.json_rpc import proxy
-
-GLOBAL_CONFIG = global_config.global_config
+from autotest.client.shared.settings import settings
 
 
 class rpc_unittest(unittest.TestCase):
@@ -34,7 +30,7 @@ class rpc_unittest(unittest.TestCase):
 
 
     def test_get_autotest_server_none(self):
-        GLOBAL_CONFIG.override_config_value('SERVER', 'hostname', 'Prince')
+        settings.override_value('SERVER', 'hostname', 'Prince')
         self.assertEqual('http://Prince', rpc.get_autotest_server(None))
 
 

--- a/client/autotest_local.py
+++ b/client/autotest_local.py
@@ -18,7 +18,7 @@ os.environ['AUTODIRTEST'] = autodirtest
 os.environ['PYTHONPATH'] = autodirbin
 
 from autotest.client import job
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 from autotest.client import cmdparser, optparser
 
 
@@ -55,10 +55,8 @@ class AutotestLocalApp:
     def main(self):
         self.parse_cmdline()
 
-        drop_caches = global_config.global_config.get_config_value('CLIENT',
-                                                                   'drop_caches',
-                                                                   type=bool,
-                                                                   default=True)
+        drop_caches = settings.get_value('CLIENT', 'drop_caches', type=bool,
+                                         default=True)
 
         if self.options.client_test_setup:
             from autotest.client import setup_job

--- a/client/base_sysinfo.py
+++ b/client/base_sysinfo.py
@@ -1,13 +1,11 @@
 import os, shutil, re, glob, subprocess, logging, gzip
 
-from autotest.client.shared import log, global_config, software_manager
+from autotest.client.shared import log, software_manager
+from autotest.client.shared.settings import settings
 from autotest.client import utils
 
-GLOBAL_CONFIG = global_config.global_config
-
-_LOG_INSTALLED_PACKAGES = GLOBAL_CONFIG.get_config_value('CLIENT',
-                                                       'log_installed_packages',
-                                                       type=bool, default=False)
+_LOG_INSTALLED_PACKAGES = settings.get_value('CLIENT', 'log_installed_packages',
+                                             type=bool, default=False)
 
 _DEFAULT_COMMANDS_TO_LOG_PER_TEST = []
 _DEFAULT_COMMANDS_TO_LOG_PER_BOOT = [

--- a/client/client_logging_config.py
+++ b/client/client_logging_config.py
@@ -4,14 +4,14 @@ except ImportError:
     import common
 
 import os
-from autotest.client.shared import logging_config, global_config
+from autotest.client.shared import logging_config
+from autotest.client.shared.settings import settings
 
 class ClientLoggingConfig(logging_config.LoggingConfig):
     def add_debug_file_handlers(self, log_dir, log_name=None):
         if not log_name:
-            log_name = global_config.global_config.get_config_value(
-                    'CLIENT', 'default_logging_name',
-                    type=str, default='client')
+            log_name = settings.get_value('CLIENT', 'default_logging_name',
+                                          type=str, default='client')
         self._add_file_handlers_for_all_levels(log_dir, log_name)
 
 

--- a/client/cmdparser.py
+++ b/client/cmdparser.py
@@ -6,26 +6,21 @@ Autotest command parser
 
 import os, re, sys, logging
 from autotest.client import os_dep, utils
-from autotest.client.shared import global_config, logging_config, logging_manager
+from autotest.client.shared import logging_config, logging_manager
+from autotest.client.shared.settings import settings
 from autotest.client.shared import packages
 
-GLOBAL_CONFIG = global_config.global_config
-
 LOCALDIRTEST = "tests"
-GLOBALDIRTEST = GLOBAL_CONFIG.get_config_value('COMMON',
-                                               'test_dir',
-                                                default="")
+GLOBALDIRTEST = settings.get_value('COMMON', 'test_dir', default="")
 
 try:
     autodir = os.path.abspath(os.environ['AUTODIR'])
 except KeyError:
-    autodir = GLOBAL_CONFIG.get_config_value('COMMON',
-                                             'autotest_top_path')
+    autodir = settings.get_value('COMMON', 'autotest_top_path')
 tmpdir = os.path.join(autodir, 'tmp')
 
-output_dir = GLOBAL_CONFIG.get_config_value('COMMON',
-                                            'test_output_dir',
-                                             default=tmpdir)
+output_dir = settings.get_value('COMMON', 'test_output_dir', default=tmpdir)
+
 FETCHDIRTEST = os.path.join(output_dir, 'site_tests')
 
 if not os.path.isdir(FETCHDIRTEST):

--- a/client/harness_autoserv.py
+++ b/client/harness_autoserv.py
@@ -1,6 +1,6 @@
 import os, logging, ConfigParser
 from autotest.client.shared import autotemp, base_packages, error
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 from autotest.client import harness
 
 
@@ -27,7 +27,7 @@ class harness_autoserv(harness.harness):
         # config items. To avoid that happening silently, the check below
         # was written.
         try:
-            global_config.global_config.get_section_values(["CLIENT", "COMMON"])
+            settings.get_section_values(["CLIENT", "COMMON"])
         except ConfigParser.NoSectionError:
             logging.error("Empty CLIENT or COMMON configuration session. "
                           "global_config.ini missing. This probably means "

--- a/client/harness_standalone.py
+++ b/client/harness_standalone.py
@@ -5,11 +5,11 @@ The default interface as required for the standalone reboot helper.
 
 __author__ = """Copyright Andy Whitcroft 2007"""
 
-from autotest.client.shared import error, global_config
+from autotest.client.shared import error
+from autotest.client.shared.settings import settings
 from autotest.client import utils
 import os, harness, shutil, logging
 
-GLOBAL_CONFIG = global_config.global_config
 
 class harness_standalone(harness.harness):
     """The standalone server harness
@@ -28,8 +28,8 @@ class harness_standalone(harness.harness):
         self.setup(job)
 
         tmpdir = os.path.join(self.autodir, 'tmp')
-        tests_dir = GLOBAL_CONFIG.get_config_value('COMMON', 'test_output_dir',
-                                                   default=tmpdir)
+        tests_dir = settings.get_value('COMMON', 'test_output_dir',
+                                       default=tmpdir)
 
         src = job.control_get()
         dest = os.path.join(tests_dir, 'control')

--- a/client/job_unittest.py
+++ b/client/job_unittest.py
@@ -9,7 +9,7 @@ except ImportError:
 from autotest.client import job, config, sysinfo, harness
 from autotest.client import xen, kernel, utils
 from autotest.client.shared import error, boottool
-from autotest.client.shared.global_config import global_config
+from autotest.client.shared.settings import settings
 from autotest.client.shared import logging_manager, logging_config
 from autotest.client.shared import base_job_unittest
 from autotest.client.shared.test_utils import mock, unittest
@@ -577,14 +577,14 @@ class test_base_job(unittest.TestCase):
         # setup
         self.god.stub_function(job.partition_lib, "get_partition_list")
         self.god.stub_function(utils, "count_cpus")
-        self.god.stub_function(global_config, "get_config_value")
+        self.god.stub_function(settings, "get_value")
 
         part_list = [self.get_partition_mock("/dev/hda1"),
                      self.get_partition_mock("/dev/hdb1")]
         mount_list = ["/mnt/hda1", "/mnt/hdb1"]
 
         # record
-        global_config.get_config_value.expect_call('CLIENT',
+        settings.get_value.expect_call('CLIENT',
                                                    'abort_on_mismatch',
                                                    default=False,
                                               type=bool).and_return(abort_value)

--- a/client/kernelexpand.py
+++ b/client/kernelexpand.py
@@ -17,15 +17,13 @@ try:
 except ImportError:
     import common
 
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 import sys, re, urllib2
 
-GLOBAL_CONFIG = global_config.global_config
-
 def get_mappings_2x():
-    KERNEL_BASE_URL = GLOBAL_CONFIG.get_config_value('CLIENT', 'kernel_mirror', default='')
-    GITWEB_BASE_URL = GLOBAL_CONFIG.get_config_value('CLIENT', 'kernel_gitweb', default='')
-    STABLE_GITWEB_BASE_URL = GLOBAL_CONFIG.get_config_value('CLIENT', 'stable_kernel_gitweb', default='')
+    KERNEL_BASE_URL = settings.get_value('CLIENT', 'kernel_mirror', default='')
+    GITWEB_BASE_URL = settings.get_value('CLIENT', 'kernel_gitweb', default='')
+    STABLE_GITWEB_BASE_URL = settings.get_value('CLIENT', 'stable_kernel_gitweb', default='')
 
     MAPPINGS_2X = [
         [ r'^\d+\.\d+$', '', True,
@@ -65,9 +63,9 @@ def get_mappings_2x():
 
 
 def get_mappings_post_2x():
-    KERNEL_BASE_URL = GLOBAL_CONFIG.get_config_value('CLIENT', 'kernel_mirror', default='')
-    GITWEB_BASE_URL = GLOBAL_CONFIG.get_config_value('CLIENT', 'kernel_gitweb', default='')
-    STABLE_GITWEB_BASE_URL = GLOBAL_CONFIG.get_config_value('CLIENT', 'stable_kernel_gitweb', default='')
+    KERNEL_BASE_URL = settings.get_value('CLIENT', 'kernel_mirror', default='')
+    GITWEB_BASE_URL = settings.get_value('CLIENT', 'kernel_gitweb', default='')
+    STABLE_GITWEB_BASE_URL = settings.get_value('CLIENT', 'stable_kernel_gitweb', default='')
 
     MAPPINGS_POST_2X = [
         [ r'^\d+\.\d+$', '', True,

--- a/client/kernelexpand_unittest.py
+++ b/client/kernelexpand_unittest.py
@@ -7,7 +7,7 @@ except ImportError:
     import common
 from kernelexpand import decompose_kernel
 from kernelexpand import mirror_kernel_components
-from autotest.client.shared.global_config import global_config
+from autotest.client.shared.settings import settings
 from autotest.client.shared.test_utils import mock
 
 km = 'http://www.kernel.org/pub/linux/kernel/'
@@ -97,20 +97,20 @@ class kernelexpandTest(unittest.TestCase):
 
 
     def test_decompose_gitweb(self):
-        self.god.stub_function(global_config, "get_config_value")
-        global_config.get_config_value.expect_call('CLIENT', 'kernel_mirror', default='').and_return(km)
-        global_config.get_config_value.expect_call('CLIENT', 'kernel_gitweb', default='').and_return(gw)
-        global_config.get_config_value.expect_call('CLIENT', 'stable_kernel_gitweb', default='').and_return(sgw)
+        self.god.stub_function(settings, "get_value")
+        settings.get_value.expect_call('CLIENT', 'kernel_mirror', default='').and_return(km)
+        settings.get_value.expect_call('CLIENT', 'kernel_gitweb', default='').and_return(gw)
+        settings.get_value.expect_call('CLIENT', 'stable_kernel_gitweb', default='').and_return(sgw)
         correct = [ [ km + 'v3.x/linux-3.0.tar.bz2', gw + ';a=snapshot;h=refs/tags/v3.0;sf=tgz' ] ]
         sample = decompose_kernel('3.0')
         self.assertEqual(sample, correct)
 
 
     def test_decompose_sha1(self):
-        self.god.stub_function(global_config, "get_config_value")
-        global_config.get_config_value.expect_call('CLIENT', 'kernel_mirror', default='').and_return(km)
-        global_config.get_config_value.expect_call('CLIENT', 'kernel_gitweb', default='').and_return(gw)
-        global_config.get_config_value.expect_call('CLIENT', 'stable_kernel_gitweb', default='').and_return(sgw)
+        self.god.stub_function(settings, "get_value")
+        settings.get_value.expect_call('CLIENT', 'kernel_mirror', default='').and_return(km)
+        settings.get_value.expect_call('CLIENT', 'kernel_gitweb', default='').and_return(gw)
+        settings.get_value.expect_call('CLIENT', 'stable_kernel_gitweb', default='').and_return(sgw)
         correct = [ [ gw + ';a=snapshot;h=02f8c6aee8df3cdc935e9bdd4f2d020306035dbe;sf=tgz', sgw + ';a=snapshot;h=02f8c6aee8df3cdc935e9bdd4f2d020306035dbe;sf=tgz' ] ]
         sample = decompose_kernel('02f8c6aee8df3cdc935e9bdd4f2d020306035dbe')
         self.assertEqual(sample, correct)

--- a/client/profilers/__init__.py
+++ b/client/profilers/__init__.py
@@ -4,8 +4,8 @@ try:
 except ImportError:
     import common
 
-from autotest.client.shared import utils, error, profiler_manager, global_config
-GLOBAL_CONFIG = global_config.global_config
+from autotest.client.shared import utils, error, profiler_manager
+from autotest.client.shared.settings import settings
 
 class profilers(profiler_manager.profiler_manager):
     def load_profiler(self, profiler, args, dargs):
@@ -29,12 +29,10 @@ class profilers(profiler_manager.profiler_manager):
         try:
             autodir = os.path.abspath(os.environ['AUTODIR'])
         except KeyError:
-            autodir = GLOBAL_CONFIG.get_config_value('COMMON',
-                                                 'autotest_top_path')
+            autodir = settings.get_value('COMMON', 'autotest_top_path')
         tmpdir = os.path.join(autodir, 'tmp')
-        output_config = GLOBAL_CONFIG.get_config_value('COMMON',
-                                                       'test_output_dir',
-                                                       default=tmpdir)
+        output_config = settings.get_value('COMMON', 'test_output_dir',
+                                           default=tmpdir)
         newprofiler.srcdir = os.path.join(output_config,
                                           os.path.basename(newprofiler.bindir),
                                          'src')

--- a/client/shared/base_job.py
+++ b/client/shared/base_job.py
@@ -1,9 +1,8 @@
 import os, copy, logging, errno, fcntl, time, re, weakref, traceback
 import tarfile
 import cPickle as pickle
-from autotest.client.shared import autotemp, error, log, global_config
-
-GLOBAL_CONFIG = global_config.global_config
+from autotest.client.shared import autotemp, error, log
+from autotest.client.shared.settings import settings
 
 
 class job_directory(object):
@@ -841,7 +840,7 @@ class TAPReport(object):
         """
         os.chdir(self.resultdir)
         tap_files = []
-        for rel_path, d, files in os.walk('.'):
+        for rel_path, _, files in os.walk('.'):
             tap_files.extend(["/".join(
                 [rel_path, f]) for f in files if f.endswith('.tap')])
         meta_yaml = open('meta.yml', 'w')
@@ -935,7 +934,7 @@ class base_job(object):
             Returns a status_logger instance for recording job status logs.
     """
 
-   # capture the dependency on several helper classes with factories
+    # capture the dependency on several helper classes with factories
     _job_directory = job_directory
     _job_state = job_state
 
@@ -1031,12 +1030,12 @@ class base_job(object):
         try:
             autodir = os.path.abspath(os.environ['AUTODIR'])
         except KeyError:
-            autodir = GLOBAL_CONFIG.get_config_value('COMMON',
+            autodir = settings.get_value('COMMON',
                                                      'autotest_top_path')
 
         tmpdir = os.path.join(autodir, 'tmp')
 
-        tests_out_dir = GLOBAL_CONFIG.get_config_value('COMMON',
+        tests_out_dir = settings.get_value('COMMON',
                                                        'test_output_dir',
                                                        default=tmpdir)
 

--- a/client/shared/base_utils.py
+++ b/client/shared/base_utils.py
@@ -9,10 +9,10 @@ try:
     import hashlib
 except ImportError:
     import md5, sha
-from autotest.client.shared import error, logging_manager, global_config
+from autotest.client.shared import error, logging_manager
 from autotest.client.shared import progressbar
+from autotest.client.shared.settings import settings
 
-GLOBAL_CONFIG = global_config.global_config
 
 def deprecated(func):
     """This is a decorator which can be used to mark functions as deprecated.
@@ -773,8 +773,7 @@ def update_version(srcdir, preserve_srcdir, new_version, install,
         tests_dir = os.path.join(base_autotest, 'tests')
         site_tests_dir = os.path.join(base_autotest, 'site-tests')
         profilers_dir = os.path.join(base_autotest, 'profilers')
-        other_tests_dir = GLOBAL_CONFIG.get_config_value("COMMON", "test_dir",
-                                                         default="")
+        other_tests_dir = settings.get_value("COMMON", "test_dir", default="")
         source_code_dir = ""
         for d in [other_tests_dir, site_tests_dir, tests_dir, profilers_dir]:
             source_code_dir = os.path.join(d, module_name, "src")
@@ -1785,9 +1784,8 @@ def import_site_function(path, module, funcname, dummy, modulefile=None):
 
 def get_pid_path(program_name, pid_files_dir=None):
     if pid_files_dir is None:
-        pid_files_dir = GLOBAL_CONFIG.get_config_value("SERVER",
-                                                       'pid_files_dir',
-                                                       default="")
+        pid_files_dir = settings.get_value("SERVER", 'pid_files_dir',
+                                           default="")
 
     if not pid_files_dir:
         base_dir = os.path.dirname(__file__)

--- a/client/shared/host_protections.py
+++ b/client/shared/host_protections.py
@@ -1,4 +1,5 @@
-from autotest.client.shared import enum, global_config
+from autotest.client.shared import enum
+from autotest.client.shared.settings import settings, SettingsError
 
 # Changing this file has consequences that need to be understood.
 # Adding a protection level to the enum requires you to append your change to
@@ -21,22 +22,23 @@ Protection = enum.Enum('No protection',          # Repair can do anything to
                                                  # this host
                        )
 
-running_client = global_config.global_config.check_stand_alone_client_run()
+running_client = settings.check_stand_alone_client_run()
 
 try:
     _bad_value = object()
-    default_protection = global_config.global_config.get_config_value(
-                            'HOSTS', 'default_protection', default=_bad_value)
+    default_protection = settings.get_value('HOSTS',
+                                            'default_protection',
+                                            default=_bad_value)
     if default_protection == _bad_value:
         if not running_client:
-            raise global_config.ConfigError(
-                'No HOSTS.default_protection defined in global_config.ini')
+            raise SettingsError('No HOSTS.default_protection defined in '
+                              'global_config.ini')
     else:
         default = Protection.get_value(default_protection)
 
 # It is OK to have an empty global configuration object (stand alone client)
 # so we trap this exception.
-except global_config.ConfigError:
+except SettingsError:
     pass
 
 choices = Protection.choices()

--- a/client/shared/hosts/base_classes.py
+++ b/client/shared/hosts/base_classes.py
@@ -17,9 +17,10 @@ stutsman@google.com (Ryan Stutsman)
 
 import cPickle, cStringIO, logging, os, re
 
-from autotest.client.shared import global_config, error, utils
+from autotest.client.shared import error, utils
 from autotest.client.shared import host_protections
 from autotest.client import partition
+from autotest.client.shared.settings import settings
 
 
 class Host(object):
@@ -50,14 +51,18 @@ class Host(object):
     """
 
     job = None
-    DEFAULT_REBOOT_TIMEOUT = global_config.global_config.get_config_value(
-        "HOSTS", "default_reboot_timeout", type=int, default=1800)
-    WAIT_DOWN_REBOOT_TIMEOUT = global_config.global_config.get_config_value(
-        "HOSTS", "wait_down_reboot_timeout", type=int, default=840)
-    WAIT_DOWN_REBOOT_WARNING = global_config.global_config.get_config_value(
-        "HOSTS", "wait_down_reboot_warning", type=int, default=540)
-    HOURS_TO_WAIT_FOR_RECOVERY = global_config.global_config.get_config_value(
-        "HOSTS", "hours_to_wait_for_recovery", type=float, default=2.5)
+    DEFAULT_REBOOT_TIMEOUT = settings.get_value("HOSTS",
+                                                "default_reboot_timeout",
+                                                type=int, default=1800)
+    WAIT_DOWN_REBOOT_TIMEOUT = settings.get_value("HOSTS",
+                                                  "wait_down_reboot_timeout",
+                                                  type=int, default=840)
+    WAIT_DOWN_REBOOT_WARNING = settings.get_value("HOSTS",
+                                                  "wait_down_reboot_warning",
+                                                  type=int, default=540)
+    HOURS_TO_WAIT_FOR_RECOVERY = settings.get_value("HOSTS",
+                                                    "hours_to_wait_for_recovery",
+                                                    type=float, default=2.5)
     # the number of hardware repair requests that need to happen before we
     # actually send machines to hardware repair
     HARDWARE_REPAIR_REQUEST_THRESHOLD = 4
@@ -154,9 +159,8 @@ class Host(object):
 
     def get_wait_up_processes(self):
         """ Gets the list of local processes to wait for in wait_up. """
-        get_config = global_config.global_config.get_config_value
-        proc_list = get_config("HOSTS", "wait_up_processes",
-                               default="").strip()
+        proc_list = settings.get_value("HOSTS", "wait_up_processes",
+                                       default="").strip()
         processes = set(p.strip() for p in proc_list.split(","))
         processes.discard("")
         return processes
@@ -682,8 +686,8 @@ class Host(object):
 
         # find all the module directories associated with unused kernels
         modules_prefix = '/lib/modules/'
-        all_moddirs = [dir for dir in self.list_files_glob(modules_prefix + '*')
-                       if re.match(modules_prefix + r'\d+\.\d+\.\d+.*', dir)]
+        all_moddirs = [mod_dir for mod_dir in self.list_files_glob(modules_prefix + '*')
+                       if re.match(modules_prefix + r'\d+\.\d+\.\d+.*', mod_dir)]
         used_moddirs = self.symlink_closure(modules_prefix + kernver
                                             for kernver in used_kernver)
         unused_moddirs = set(all_moddirs) - set(used_moddirs)

--- a/client/shared/logging_config.py
+++ b/client/shared/logging_config.py
@@ -1,7 +1,5 @@
 import logging, os, sys, time
-from autotest.client.shared import global_config
-
-GLOBAL_CONFIG = global_config.global_config
+from autotest.client.shared.settings import settings
 
 # set up a simple catchall configuration for use during import time.  some code
 # may log messages at import time and we don't want those to get completely
@@ -54,8 +52,7 @@ class LoggingConfig(object):
 
     @classmethod
     def get_server_log_dir(cls):
-        server_log_dir = GLOBAL_CONFIG.get_config_value('SERVER',
-                                                        'logs_dir', default='')
+        server_log_dir = settings.get_value('SERVER', 'logs_dir', default='')
         if not server_log_dir:
             server_log_dir = os.path.join(cls.get_autotest_root(), 'logs')
         return server_log_dir

--- a/client/shared/settings.py
+++ b/client/shared/settings.py
@@ -1,6 +1,7 @@
-"""A singleton class for accessing global config values
+"""
+A singleton class for accessing global config values.
 
-provides access to global configuration file
+provides access to global configuration file.
 """
 
 __author__ = 'raphtee@google.com (Travis Miller)'
@@ -9,14 +10,14 @@ import os, sys, ConfigParser
 from autotest.client.shared import error
 
 
-class ConfigError(error.AutotestError):
+class SettingsError(error.AutotestError):
     pass
 
 
-class ConfigValueError(ConfigError):
+class SettingsValueError(SettingsError):
     pass
 
-global_config_filename = 'global_config.ini'
+settings_filename = 'global_config.ini'
 shadow_config_filename = 'shadow_config.ini'
 
 shared_dir = os.path.dirname(sys.modules[__name__].__file__)
@@ -25,35 +26,35 @@ root_dir = os.path.dirname(client_dir)
 system_wide_dir = '/etc/autotest'
 
 # Check if the config files are in the system wide directory
-global_config_path_system_wide = os.path.join(system_wide_dir,
-                                              global_config_filename)
+settings_path_system_wide = os.path.join(system_wide_dir,
+                                         settings_filename)
 shadow_config_path_system_wide = os.path.join(system_wide_dir,
                                               shadow_config_filename)
-config_in_system_wide = os.path.exists(global_config_path_system_wide)
+config_in_system_wide = os.path.exists(settings_path_system_wide)
 
 # Check if the config files are at autotest's root dir
 # This will happen if client is executing inside a full autotest tree, or if
 # other entry points are being executed
-global_config_path_root = os.path.join(root_dir, global_config_filename)
+settings_path_root = os.path.join(root_dir, settings_filename)
 shadow_config_path_root = os.path.join(root_dir, shadow_config_filename)
-config_in_root = (os.path.exists(global_config_path_root) and
+config_in_root = (os.path.exists(settings_path_root) and
                   os.path.exists(shadow_config_path_root))
 
 # Check if the config files are at autotest's client dir
 # This will happen if a client stand alone execution is happening
-global_config_path_client = os.path.join(client_dir, 'global_config.ini')
-config_in_client = os.path.exists(global_config_path_client)
+settings_path_client = os.path.join(client_dir, 'global_config.ini')
+config_in_client = os.path.exists(settings_path_client)
 
 if config_in_system_wide:
-    DEFAULT_CONFIG_FILE = global_config_path_system_wide
+    DEFAULT_CONFIG_FILE = settings_path_system_wide
     DEFAULT_SHADOW_FILE = shadow_config_path_system_wide
     RUNNING_STAND_ALONE_CLIENT = False
 elif config_in_root:
-    DEFAULT_CONFIG_FILE = global_config_path_root
+    DEFAULT_CONFIG_FILE = settings_path_root
     DEFAULT_SHADOW_FILE = shadow_config_path_root
     RUNNING_STAND_ALONE_CLIENT = False
 elif config_in_client:
-    DEFAULT_CONFIG_FILE = global_config_path_client
+    DEFAULT_CONFIG_FILE = settings_path_client
     DEFAULT_SHADOW_FILE = None
     RUNNING_STAND_ALONE_CLIENT = True
 else:
@@ -61,7 +62,7 @@ else:
     DEFAULT_SHADOW_FILE = None
     RUNNING_STAND_ALONE_CLIENT = True
 
-class global_config(object):
+class Settings(object):
     _NO_DEFAULT_SPECIFIED = object()
 
     config = None
@@ -85,7 +86,7 @@ class global_config(object):
         if default is self._NO_DEFAULT_SPECIFIED:
             msg = ("Value '%s' not found in section '%s'" %
                    (key, section))
-            raise ConfigError(msg)
+            raise SettingsError(msg)
         else:
             return default
 
@@ -111,8 +112,8 @@ class global_config(object):
         return cfgparser
 
 
-    def get_config_value(self, section, key, type=str,
-                         default=_NO_DEFAULT_SPECIFIED, allow_blank=False):
+    def get_value(self, section, key, type=str, default=_NO_DEFAULT_SPECIFIED,
+                  allow_blank=False):
         self._ensure_config_parsed()
 
         try:
@@ -126,7 +127,7 @@ class global_config(object):
         return self._convert_value(key, section, val, type)
 
 
-    def override_config_value(self, section, key, new_value):
+    def override_value(self, section, key, new_value):
         """
         Override a value from the config file with a new value.
         """
@@ -134,7 +135,7 @@ class global_config(object):
         self.config.set(section, key, new_value)
 
 
-    def reset_config_values(self):
+    def reset_values(self):
         """
         Reset all values to those found in the config files (undoes all
         overrides).
@@ -166,7 +167,7 @@ class global_config(object):
         if self.config_file and os.path.exists(self.config_file):
             self.config.read(self.config_file)
         else:
-            raise ConfigError('%s not found' % (self.config_file))
+            raise SettingsError('%s not found' % (self.config_file))
 
         # now also read the shadow file if there is one
         # this will overwrite anything that is found in the
@@ -216,9 +217,9 @@ class global_config(object):
         except Exception:
             msg = ("Could not convert %s value %r in section %s to type %s" %
                     (key, sval, section, value_type))
-            raise ConfigValueError(msg)
+            raise SettingsValueError(msg)
 
 
-# insure the class is a singleton.  Now the symbol global_config
+# insure the class is a singleton.  Now the symbol settings
 # will point to the one and only one instace of the class
-global_config = global_config()
+settings = Settings()

--- a/client/shared/settings_unittest.py
+++ b/client/shared/settings_unittest.py
@@ -5,11 +5,11 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared import settings
 from autotest.client.shared import autotemp
 
 
-global_config_ini_contents = """
+settings_ini_contents = """
 [SECTION_A]
 value_1: 6.0
 value_2: hello
@@ -37,7 +37,7 @@ value_1: somebody@remotehost
 def create_config_files():
     global_temp = autotemp.tempfile("global", ".ini",
                                             text=True)
-    os.write(global_temp.fd, global_config_ini_contents)
+    os.write(global_temp.fd, settings_ini_contents)
 
     shadow_temp = autotemp.tempfile("shadow", ".ini",
                                            text=True)
@@ -47,9 +47,9 @@ def create_config_files():
     return (global_temp, shadow_temp)
 
 
-class global_config_test(unittest.TestCase):
+class settings_test(unittest.TestCase):
     # grab the singelton
-    conf = global_config.global_config
+    conf = settings.settings
 
     def setUp(self):
         # set the config files to our test files
@@ -61,41 +61,41 @@ class global_config_test(unittest.TestCase):
     def tearDown(self):
         self.shadow_temp.clean()
         self.global_temp.clean()
-        self.conf.set_config_files(global_config.DEFAULT_CONFIG_FILE,
-                                global_config.DEFAULT_SHADOW_FILE)
+        self.conf.set_config_files(settings.DEFAULT_CONFIG_FILE,
+                                settings.DEFAULT_SHADOW_FILE)
 
 
     def test_float(self):
-        val = self.conf.get_config_value("SECTION_A", "value_1", float)
+        val = self.conf.get_value("SECTION_A", "value_1", float)
         self.assertEquals(type(val), types.FloatType)
         self.assertEquals(val, 6.0)
 
 
     def test_int(self):
-        val = self.conf.get_config_value("SECTION_B", "value_1", int)
+        val = self.conf.get_value("SECTION_B", "value_1", int)
         self.assertEquals(type(val), types.IntType)
         self.assertTrue(val < 0)
-        val = self.conf.get_config_value("SECTION_B", "value_3", int)
+        val = self.conf.get_value("SECTION_B", "value_3", int)
         self.assertEquals(val, 0)
-        val = self.conf.get_config_value("SECTION_B", "value_4", int)
+        val = self.conf.get_value("SECTION_B", "value_4", int)
         self.assertTrue(val > 0)
 
 
     def test_string(self):
-        val = self.conf.get_config_value("SECTION_A", "value_2")
+        val = self.conf.get_value("SECTION_A", "value_2")
         self.assertEquals(type(val),types.StringType)
         self.assertEquals(val, "hello")
 
 
     def test_override(self):
-        val = self.conf.get_config_value("SECTION_C", "value_1")
+        val = self.conf.get_value("SECTION_C", "value_1")
         self.assertEquals(val, "somebody@remotehost")
 
 
     def test_exception(self):
         error = 0
         try:
-            val = self.conf.get_config_value("SECTION_B",
+            val = self.conf.get_value("SECTION_B",
                                             "value_2", int)
         except Exception:
             error = 1
@@ -103,20 +103,20 @@ class global_config_test(unittest.TestCase):
 
 
     def test_boolean(self):
-        val = self.conf.get_config_value("SECTION_A", "value_3", bool)
+        val = self.conf.get_value("SECTION_A", "value_3", bool)
         self.assertEquals(val, True)
-        val = self.conf.get_config_value("SECTION_A", "value_4", bool)
+        val = self.conf.get_value("SECTION_A", "value_4", bool)
         self.assertEquals(val, False)
-        val = self.conf.get_config_value("SECTION_A", "value_5", bool)
+        val = self.conf.get_value("SECTION_A", "value_5", bool)
         self.assertEquals(val, True)
-        val = self.conf.get_config_value("SECTION_A", "value_6", bool)
+        val = self.conf.get_value("SECTION_A", "value_6", bool)
         self.assertEquals(val, False)
 
 
     def test_defaults(self):
-        val = self.conf.get_config_value("MISSING", "foo", float, 3.6)
+        val = self.conf.get_value("MISSING", "foo", float, 3.6)
         self.assertEquals(val, 3.6)
-        val = self.conf.get_config_value("SECTION_A", "novalue", str,
+        val = self.conf.get_value("SECTION_A", "novalue", str,
                                                 "default")
         self.assertEquals(val, "default")
 

--- a/client/shared/test.py
+++ b/client/shared/test.py
@@ -17,13 +17,10 @@
 #       tmpdir          eg. tmp/<tempname>_<testname.tag>
 
 import fcntl, getpass, os, re, sys, shutil, tempfile, time, traceback, logging
-import glob
 
-from autotest.client.shared import error, global_config
+from autotest.client.shared import error
+from autotest.client.shared.settings import settings
 from autotest.client import utils
-
-
-GLOBAL_CONFIG = global_config.global_config
 
 
 class base_test(object):
@@ -50,12 +47,10 @@ class base_test(object):
         try:
             autodir = os.path.abspath(os.environ['AUTODIR'])
         except KeyError:
-            autodir = GLOBAL_CONFIG.get_config_value('COMMON',
-                                                     'autotest_top_path')
+            autodir = settings.get_value('COMMON', 'autotest_top_path')
         tmpdir = os.path.join(autodir, 'tmp')
-        output_config = GLOBAL_CONFIG.get_config_value('COMMON',
-                                                       'test_output_dir',
-                                                       default=tmpdir)
+        output_config = settings.get_value('COMMON', 'test_output_dir',
+                                           default=tmpdir)
         self.srcdir = os.path.join(output_config, os.path.basename(self.bindir),
                                    'src')
         self.tmpdir = tempfile.mkdtemp("_" + self.tagged_testname,
@@ -891,9 +886,7 @@ def runtest(job, url, tag, args, dargs,
                 pass
 
         testdir_list = [job.testdir, getattr(job, 'site_testdir', None)]
-        bindir_config = GLOBAL_CONFIG.get_config_value('COMMON',
-                                                        'test_dir',
-                                                        default="")
+        bindir_config = settings.get_value('COMMON', 'test_dir', default="")
         if bindir_config:
             testdir_list.extend(bindir_config.strip().split(','))
 

--- a/client/tools/boottool.py
+++ b/client/tools/boottool.py
@@ -1420,11 +1420,9 @@ class Grubby(object):
         except:
             try:
                 # then the autotest source directory
-                from autotest.client.shared import global_config
-                GLOBAL_CONFIG = global_config.global_config
-                tarball = os.path.join(
-                   GLOBAL_CONFIG.get_config_value('COMMON', 'autotest_top_path'),
-                   tarball_name)
+                from autotest.client.shared.settings import settings
+                top_path = settings.get_value('COMMON', 'autotest_top_path')
+                tarball = os.path.join(top_path, tarball_name)
                 f = open(tarball)
             except:
                 # then try to grab it from github

--- a/database/database_connection.py
+++ b/database/database_connection.py
@@ -3,7 +3,7 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 
 RECONNECT_FOREVER = object()
 
@@ -116,7 +116,7 @@ class _SqliteBackend(_GenericBackend):
 
 class _DjangoBackend(_GenericBackend):
     def __init__(self):
-        from django.db import backend, connection, transaction
+        from django.db import connection, transaction
         import django.db as django_db
         super(_DjangoBackend, self).__init__(django_db)
         self._django_connection = connection
@@ -155,7 +155,7 @@ class DatabaseConnection(object):
     * max_reconnect_attempts: maximum number of time to try reconnecting before
       giving up.  Setting to RECONNECT_FOREVER removes the limit.
     * rowcount - will hold cursor.rowcount after each call to execute().
-    * global_config_section - the section in which to find DB information. this
+    * settings_section - the section in which to find DB information. this
       should be passed to the constructor, not set later, and may be None, in
       which case information must be passed to connect().
     * debug - if set True, all queries will be printed before being executed
@@ -163,8 +163,8 @@ class DatabaseConnection(object):
     _DATABASE_ATTRIBUTES = ('db_type', 'host', 'username', 'password',
                             'db_name')
 
-    def __init__(self, global_config_section=None, debug=False):
-        self.global_config_section = global_config_section
+    def __init__(self, settings_section=None, debug=False):
+        self.settings_section = settings_section
         self._backend = None
         self.rowcount = None
         self.debug = debug
@@ -180,10 +180,9 @@ class DatabaseConnection(object):
     def _get_option(self, name, provided_value):
         if provided_value is not None:
             return provided_value
-        if self.global_config_section:
-            global_config_name = _GLOBAL_CONFIG_NAMES.get(name, name)
-            return global_config.global_config.get_config_value(
-                self.global_config_section, global_config_name)
+        if self.settings_section:
+            settings_name = _GLOBAL_CONFIG_NAMES.get(name, name)
+            return settings.get_value(self.settings_section, settings_name)
         return getattr(self, name, None)
 
 

--- a/database/database_connection_unittest.py
+++ b/database/database_connection_unittest.py
@@ -5,7 +5,7 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared import settings
 from autotest.client.shared.test_utils import mock
 from autotest.database import database_connection
 
@@ -31,7 +31,7 @@ class DatabaseConnectionTest(unittest.TestCase):
 
 
     def tearDown(self):
-        global_config.global_config.reset_config_values()
+        settings.settings.reset_values()
         self.god.unstub_all()
 
 
@@ -56,12 +56,12 @@ class DatabaseConnectionTest(unittest.TestCase):
 
 
     def _override_config(self):
-        c = global_config.global_config
-        c.override_config_value(_CONFIG_SECTION, 'host', _HOST)
-        c.override_config_value(_CONFIG_SECTION, 'user', _USER)
-        c.override_config_value(_CONFIG_SECTION, 'password', _PASS)
-        c.override_config_value(_CONFIG_SECTION, 'database', _DB_NAME)
-        c.override_config_value(_CONFIG_SECTION, 'db_type', _DB_TYPE)
+        c = settings.settings
+        c.override_value(_CONFIG_SECTION, 'host', _HOST)
+        c.override_value(_CONFIG_SECTION, 'user', _USER)
+        c.override_value(_CONFIG_SECTION, 'password', _PASS)
+        c.override_value(_CONFIG_SECTION, 'database', _DB_NAME)
+        c.override_value(_CONFIG_SECTION, 'db_type', _DB_TYPE)
 
 
     def test_connect(self):
@@ -75,7 +75,7 @@ class DatabaseConnectionTest(unittest.TestCase):
         self.god.check_playback()
 
 
-    def test_global_config(self):
+    def test_settings(self):
         db = self._get_database_connection()
         self._fake_backend.connect.expect_call(**_CONNECT_KWARGS)
 

--- a/database/migrate.py
+++ b/database/migrate.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     import common
 
-from autotest.client.shared import global_config, utils
+from autotest.client.shared import utils
 from autotest.database import database_connection
 
 MIGRATE_TABLE = 'migrate_info'
@@ -95,7 +95,7 @@ class MigrationManager(object):
 
 
     def _config_section(self):
-        return self._database.global_config_section
+        return self._database.settings_section
 
 
     def get_db_name(self):
@@ -118,7 +118,7 @@ class MigrationManager(object):
         try:
             self.execute("SELECT * FROM %s" % MIGRATE_TABLE)
             return True
-        except self._database.DatabaseError, exc:
+        except self._database.DatabaseError:
             # we can't check for more specifics due to differences between DB
             # backends (we can't even check for a subclass of DatabaseError)
             return False

--- a/database/migrate_unittest.py
+++ b/database/migrate_unittest.py
@@ -1,12 +1,10 @@
 #!/usr/bin/python
 
-import unittest, tempfile, os
+import unittest
 try:
     import autotest.common as common
 except ImportError:
     import common
-import MySQLdb
-from autotest.client.shared import global_config
 from autotest.database import database_connection, migrate
 
 # Which section of the global config to pull info from.  We won't actually use

--- a/frontend/afe/control_file.py
+++ b/frontend/afe/control_file.py
@@ -11,11 +11,11 @@ try:
 except ImportError:
     import common
 from autotest.frontend.afe import model_logic
-from autotest.client.shared import global_config
-import frontend.settings
+from autotest.client.shared.settings import settings
+import autotest.frontend.settings as frontend_settings
 
-AUTOTEST_DIR = os.path.abspath(os.path.join(
-    os.path.dirname(frontend.settings.__file__), '..'))
+frontend_settings_dir = os.path.dirname(frontend_settings.__file__)
+AUTOTEST_DIR = os.path.abspath(os.path.join(frontend_settings_dir, '..'))
 
 EMPTY_TEMPLATE = 'def step_init():\n'
 
@@ -161,12 +161,9 @@ def read_control_file(test):
     test_dirs = [AUTOTEST_DIR]
     # if test_dir is defined in global config file
     # try to fetch control file from there
-    global_config_test_dirs = (
-        global_config.global_config.get_config_value('COMMON',
-                                                     'test_dir',
-                                                     default=""))
-    if global_config_test_dirs:
-        test_dirs = global_config_test_dirs.strip().split(',') + test_dirs
+    settings_test_dirs = settings.get_value('COMMON', 'test_dir', default="")
+    if settings_test_dirs:
+        test_dirs = settings_test_dirs.strip().split(',') + test_dirs
     control_file = None
     for test_dir in test_dirs:
         if os.path.isfile(os.path.join(test_dir, test.path)):

--- a/frontend/afe/frontend_test_utils.py
+++ b/frontend/afe/frontend_test_utils.py
@@ -1,4 +1,4 @@
-import atexit, datetime, os, tempfile, unittest
+import datetime
 try:
     import autotest.common as common
 except ImportError:
@@ -6,7 +6,7 @@ except ImportError:
 from autotest.frontend import setup_test_environment
 from autotest.frontend import thread_local
 from autotest.frontend.afe import models, model_attributes
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 from autotest.client.shared.test_utils import mock
 
 class FrontendTestMixin(object):
@@ -69,10 +69,8 @@ class FrontendTestMixin(object):
     def _frontend_common_setup(self, fill_data=True):
         self.god = mock.mock_god(ut=self)
         setup_test_environment.set_up()
-        global_config.global_config.override_config_value(
-                'AUTOTEST_WEB', 'parameterized_jobs', 'False')
-        global_config.global_config.override_config_value(
-                'SERVER', 'rpc_logging', 'False')
+        settings.override_value('AUTOTEST_WEB', 'parameterized_jobs', 'False')
+        settings.override_value('SERVER', 'rpc_logging', 'False')
 
         if fill_data:
             self._fill_in_test_data()

--- a/frontend/afe/models_unittest.py
+++ b/frontend/afe/models_unittest.py
@@ -7,8 +7,8 @@ except ImportError:
     import common
 from autotest.frontend import setup_django_environment
 from autotest.frontend.afe import frontend_test_utils
-from autotest.frontend.afe import models, model_attributes, model_logic
-from autotest.client.shared import global_config
+from autotest.frontend.afe import models, model_attributes
+from autotest.client.shared.settings import settings
 
 
 class AclGroupTest(unittest.TestCase,
@@ -261,8 +261,7 @@ class ParameterizedJobTest(unittest.TestCase,
 
 
     def test_job(self):
-        global_config.global_config.override_config_value(
-                'AUTOTEST_WEB', 'parameterized_jobs', 'True')
+        settings.override_value('AUTOTEST_WEB', 'parameterized_jobs', 'True')
 
         test = models.Test.objects.create(
                 name='name', author='author', test_class='class',
@@ -300,8 +299,7 @@ class JobTest(unittest.TestCase, frontend_test_utils.FrontendTestMixin):
 
 
     def test_check_parameterized_jobs_enabled(self):
-        global_config.global_config.override_config_value(
-                'AUTOTEST_WEB', 'parameterized_jobs', 'True')
+        settings.override_value('AUTOTEST_WEB', 'parameterized_jobs', 'True')
         self.assertRaises(Exception, models.Job.check_parameterized_job,
                           control_file=object(), parameterized_job=None)
 

--- a/frontend/afe/resources_unittest.py
+++ b/frontend/afe/resources_unittest.py
@@ -7,15 +7,11 @@ except ImportError:
 import unittest
 
 # This has to be done very early.
-from autotest.client.shared import global_config
-global_config.global_config.override_config_value(
-    'HOSTS', 'default_protection',
-    'NO_PROTECTION')
-from autotest.client.shared import host_protections
+from autotest.client.shared.settings import settings
+settings.override_value('HOSTS', 'default_protection', 'NO_PROTECTION')
 
 from autotest.frontend import setup_django_environment
 from autotest.frontend import setup_test_environment
-from django.test import client
 from autotest.frontend.shared import resource_test_utils
 from autotest.frontend.afe import control_file, models, model_attributes
 

--- a/frontend/afe/rpc_handler.py
+++ b/frontend/afe/rpc_handler.py
@@ -5,10 +5,9 @@ defined in rpc_interface.py.
 
 __author__ = 'showard@google.com (Steve Howard)'
 
-import traceback, pydoc, re, urllib, logging, logging.handlers, inspect
+import pydoc, re, urllib, inspect
 from autotest.frontend.afe.json_rpc import serviceHandler
 from autotest.frontend.afe import models, rpc_utils
-from autotest.client.shared import global_config
 from autotest.frontend.afe import rpcserver_logging
 
 LOGGING_REGEXPS = [r'.*add_.*',

--- a/frontend/afe/rpc_interface.py
+++ b/frontend/afe/rpc_interface.py
@@ -35,8 +35,7 @@ try:
 except ImportError:
     import common
 from autotest.frontend.afe import models, model_logic, model_attributes
-from autotest.frontend.afe import control_file, rpc_utils, rpcserver_logging
-from autotest.client.shared import global_config
+from autotest.frontend.afe import control_file, rpc_utils
 from autotest.server.hosts.remote import get_install_server_info
 
 

--- a/frontend/afe/rpc_interface_unittest.py
+++ b/frontend/afe/rpc_interface_unittest.py
@@ -10,7 +10,7 @@ from autotest.frontend.afe import frontend_test_utils
 from django.db import connection
 from autotest.frontend.afe import models, rpc_interface, frontend_test_utils
 from autotest.frontend.afe import model_logic, model_attributes
-from autotest.client.shared import global_config
+from autotest.client.shared import settings
 
 
 _hqe_status = models.HostQueueEntry.Status
@@ -320,7 +320,7 @@ class RpcInterfaceTest(unittest.TestCase,
 
 
     def test_parameterized_job(self):
-        global_config.global_config.override_config_value(
+        settings.settings.override_value(
                 'AUTOTEST_WEB', 'parameterized_jobs', 'True')
 
         string_type = model_attributes.ParameterTypes.STRING

--- a/frontend/afe/rpcserver_logging.py
+++ b/frontend/afe/rpcserver_logging.py
@@ -1,24 +1,22 @@
-import logging, logging.handlers, time, os
+import logging
 try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 
 
-config = global_config.global_config
-LOGGING_ENABLED = config.get_config_value('SERVER', 'rpc_logging', type=bool)
+LOGGING_ENABLED = settings.get_value('SERVER', 'rpc_logging', type=bool)
 
 MEGABYTE = 1024 * 1024
 
 rpc_logger = None
 
 def configure_logging():
-    MAX_LOG_SIZE = config.get_config_value('SERVER', 'rpc_max_log_size_mb',
-                                           type=int)
-    NUMBER_OF_OLD_LOGS = config.get_config_value('SERVER', 'rpc_num_old_logs',
-                                                 type=int)
-    log_path = config.get_config_value('SERVER', 'rpc_log_path')
+    MAX_LOG_SIZE = settings.get_value('SERVER', 'rpc_max_log_size_mb', type=int)
+    NUMBER_OF_OLD_LOGS = settings.get_value('SERVER', 'rpc_num_old_logs',
+                                            type=int)
+    log_path = settings.get_value('SERVER', 'rpc_log_path')
 
     formatter = logging.Formatter(
         fmt='[%(asctime)s %(levelname)-5.5s] %(message)s',

--- a/frontend/frontend_unittest.py
+++ b/frontend/frontend_unittest.py
@@ -7,18 +7,17 @@ except ImportError:
     import common
 from autotest.frontend import setup_django_environment
 from autotest.frontend import setup_test_environment
-from autotest.frontend.afe import test, readonly_connection
-from autotest.client.shared import global_config
+from autotest.frontend.afe import test
+from autotest.client.shared import settings
 
 _APP_DIR = os.path.join(os.path.dirname(__file__), 'afe')
 
 class FrontendTest(unittest.TestCase):
     def setUp(self):
         setup_test_environment.set_up()
-        global_config.global_config.override_config_value(
-                'AUTOTEST_WEB', 'parameterized_jobs', 'False')
-        global_config.global_config.override_config_value(
-                'SERVER', 'rpc_logging', 'False')
+        settings.settings.override_value('AUTOTEST_WEB', 'parameterized_jobs',
+                                         'False')
+        settings.settings.override_value('SERVER', 'rpc_logging', 'False')
 
 
     def tearDown(self):

--- a/frontend/make_superuser.py
+++ b/frontend/make_superuser.py
@@ -6,19 +6,18 @@ except ImportError:
     import common
 import MySQLdb
 import sys
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 
 if (len(sys.argv) < 2 or
     [arg for arg in sys.argv[1:] if arg.startswith('-')]):
     print "Usage: %s username [username ...]" %sys.argv[0]
     sys.exit(1)
 
-config = global_config.global_config
 section = 'AUTOTEST_WEB'
-host = config.get_config_value(section, "host")
-db_name = config.get_config_value(section, "database")
-user = config.get_config_value(section, "user")
-password = config.get_config_value(section, "password")
+host = settings.get_value(section, "host")
+db_name = settings.get_value(section, "database")
+user = settings.get_value(section, "user")
+password = settings.get_value(section, "password")
 
 con = MySQLdb.connect(host=host, user=user,
                       passwd=password, db=db_name)

--- a/frontend/migrations/009_add_timeout_to_jobs.py
+++ b/frontend/migrations/009_add_timeout_to_jobs.py
@@ -1,4 +1,4 @@
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 
 def migrate_up(manager):
     # Add the column with a default first, and then drop the default.
@@ -11,9 +11,9 @@ def migrate_up(manager):
 def migrate_down(manager):
     manager.execute(DROP_COLUMN)
 
-job_timeout_default = global_config.global_config.get_config_value(
-    'AUTOTEST_WEB', 'job_timeout_default')
-ADD_COLUMN = ('ALTER TABLE jobs ADD COLUMN timeout INT NOT NULL DEFAULT %s'
-              % job_timeout_default)
+job_timeout_default = settings.get_value('AUTOTEST_WEB',
+                                         'job_timeout_default')
+ADD_COLUMN = ('ALTER TABLE jobs ADD COLUMN timeout INT NOT NULL DEFAULT %s' %
+              job_timeout_default)
 DROP_DEFAULT = 'ALTER TABLE jobs ALTER COLUMN timeout DROP DEFAULT'
 DROP_COLUMN = 'ALTER TABLE jobs DROP COLUMN timeout'

--- a/frontend/migrations/010_add_protection_to_hosts.py
+++ b/frontend/migrations/010_add_protection_to_hosts.py
@@ -1,4 +1,6 @@
-from autotest.client.shared import global_config, host_protections
+from autotest.client.shared import host_protections
+from autotest.client.shared.settings import settings
+
 
 def migrate_up(manager):
     manager.execute_script(ADD_PROTECTION_COLUMN)
@@ -6,10 +8,10 @@ def migrate_up(manager):
 def migrate_down(manager):
     manager.execute(DROP_COLUMN)
 
-default_protection = global_config.global_config.get_config_value(
-    'HOSTS', 'default_protection')
+
+default_protection = settings.get_value('HOSTS', 'default_protection')
 default_protection_value = host_protections.Protection.get_value(
-    default_protection)
+                                                             default_protection)
 
 ADD_PROTECTION_COLUMN = """ALTER TABLE hosts
                            ADD COLUMN protection INT NOT NULL

--- a/frontend/settings.py
+++ b/frontend/settings.py
@@ -5,13 +5,12 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 
-c = global_config.global_config
 _section = 'AUTOTEST_WEB'
 
-DEBUG = c.get_config_value(_section, "sql_debug_mode", type=bool, default=False)
-TEMPLATE_DEBUG = c.get_config_value(_section, "template_debug_mode", type=bool,
+DEBUG = settings.get_value(_section, "sql_debug_mode", type=bool, default=False)
+TEMPLATE_DEBUG = settings.get_value(_section, "template_debug_mode", type=bool,
                                     default=False)
 
 FULL_ADMIN = False
@@ -23,7 +22,7 @@ ADMINS = (
 MANAGERS = ADMINS
 
 def _get_config(config_key, default=None):
-    return c.get_config_value(_section, config_key, default=default)
+    return settings.get_value(_section, config_key, default=default)
 
 AUTOTEST_DEFAULT = {
     'ENGINE': 'autotest.frontend.db.backends.afe',

--- a/frontend/setup_test_environment.py
+++ b/frontend/setup_test_environment.py
@@ -1,4 +1,3 @@
-import tempfile, shutil, os
 from django.core import management
 from django.conf import settings
 try:

--- a/frontend/tko/graphing_utils.py
+++ b/frontend/tko/graphing_utils.py
@@ -1,4 +1,4 @@
-import base64, os, tempfile, operator, pickle, datetime, django.db
+import base64, tempfile, pickle, datetime, django
 import os.path, getpass
 from math import sqrt
 
@@ -23,7 +23,7 @@ import StringIO, colorsys, PIL.Image, PIL.ImageChops
 from autotest.frontend.afe import readonly_connection
 from autotest.frontend.afe.model_logic import ValidationError
 from simplejson import encoder
-from autotest.client.shared import global_config
+from autotest.client.shared import settings
 from autotest.frontend.tko import models, tko_rpc_utils
 
 _FIGURE_DPI = 100
@@ -809,8 +809,8 @@ def create_embedded_plot(model, update_time):
     return image
 
 
-_cache_timeout = global_config.global_config.get_config_value(
-    'AUTOTEST_WEB', 'graph_cache_creation_timeout_minutes')
+_cache_timeout = settings.settings.get_value('AUTOTEST_WEB',
+                                         'graph_cache_creation_timeout_minutes')
 
 
 def handle_plot_request(id, max_age):

--- a/scheduler/archive_results.py
+++ b/scheduler/archive_results.py
@@ -5,13 +5,14 @@ try:
 except ImportError:
     import common
 import logging
-from autotest.client.shared import global_config, utils
+from autotest.client.shared import utils
+from autotest.client.shared.settings import settings
 from autotest.scheduler import drone_utility
 
 class BaseResultsArchiver(object):
     def archive_results(self, path):
-        results_host = global_config.global_config.get_config_value(
-                'SCHEDULER', 'results_host', default=None)
+        results_host = settings.get_value('SCHEDULER', 'results_host',
+                                          default=None)
         if not results_host or results_host == 'localhost':
             return
 

--- a/scheduler/drone_manager.py
+++ b/scheduler/drone_manager.py
@@ -4,7 +4,8 @@ try:
 except ImportError:
     import common
 import logging
-from autotest.client.shared import error, global_config
+from autotest.client.shared import error
+from autotest.client.shared.settings import settings
 from autotest.scheduler import email_manager, drone_utility, drones
 from autotest.scheduler import scheduler_config
 
@@ -174,7 +175,7 @@ class DroneManager(object):
         logging.info('Using results repository on %s',
                      results_repository_hostname)
         self._results_drone = drones.get_drone(results_repository_hostname)
-        results_installation_dir = global_config.global_config.get_config_value(
+        results_installation_dir = settings.get_value(
                 scheduler_config.CONFIG_SECTION,
                 'results_host_installation_directory', default=None)
         if results_installation_dir:
@@ -199,9 +200,9 @@ class DroneManager(object):
 
         @returns: The number of refresh() calls before we forget a pidfile.
         """
-        pidfile_timeout = global_config.global_config.get_config_value(
-                scheduler_config.CONFIG_SECTION, 'max_pidfile_refreshes',
-                type=int, default=2000)
+        pidfile_timeout = settings.get_value(
+                       scheduler_config.CONFIG_SECTION, 'max_pidfile_refreshes',
+                       type=int, default=2000)
         return pidfile_timeout
 
 
@@ -221,20 +222,19 @@ class DroneManager(object):
         """
         Reread global config options for all drones.
         """
-        config = global_config.global_config
         section = scheduler_config.CONFIG_SECTION
-        config.parse_config_file()
+        settings.parse_config_file()
         for hostname, drone in self._drones.iteritems():
-            disabled = config.get_config_value(
-                    section, '%s_disabled' % hostname, default='')
+            disabled = settings.get_value(section, '%s_disabled' % hostname,
+                                          default='')
             drone.enabled = not bool(disabled)
 
-            drone.max_processes = config.get_config_value(
+            drone.max_processes = settings.get_value(
                     section, '%s_max_processes' % hostname, type=int,
                     default=scheduler_config.config.max_processes_per_drone)
 
-            allowed_users = config.get_config_value(
-                    section, '%s_users' % hostname, default=None)
+            allowed_users = settings.get_value(section, '%s_users' % hostname,
+                                               default=None)
             if allowed_users is not None:
                 allowed_users = set(allowed_users.split())
             drone.allowed_users = allowed_users
@@ -621,9 +621,8 @@ class DroneManager(object):
         if on_results_repository:
             base_dir = self._results_dir
         else:
-            output_dir = global_config.global_config.get_config_value('COMMON',
-                                                              'test_output_dir',
-                                                               default="")
+            output_dir = settings.get_value('COMMON', 'test_output_dir',
+                                            default="")
             if output_dir:
                 base_dir = output_dir
             else:

--- a/scheduler/drone_manager_unittest.py
+++ b/scheduler/drone_manager_unittest.py
@@ -5,7 +5,7 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 from autotest.client.shared.test_utils import mock
 from autotest.scheduler import drone_manager, drones
 from autotest.scheduler import scheduler_config
@@ -223,9 +223,9 @@ class DroneManager(unittest.TestCase):
     def test_initialize(self):
         results_hostname = 'results_repo'
         results_install_dir = '/results/install'
-        global_config.global_config.override_config_value(
-                scheduler_config.CONFIG_SECTION,
-                'results_host_installation_directory', results_install_dir)
+        settings.override_value(scheduler_config.CONFIG_SECTION,
+                                'results_host_installation_directory',
+                                results_install_dir)
 
         (drones.get_drone.expect_call(self.mock_drone.name)
          .and_return(self.mock_drone))

--- a/scheduler/drone_utility.py
+++ b/scheduler/drone_utility.py
@@ -6,7 +6,8 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import utils, global_config, error
+from autotest.client.shared import utils, error
+from autotest.client.shared.settings import settings
 from autotest.server import hosts, subcommand
 from autotest.scheduler import email_manager, scheduler_config
 
@@ -15,9 +16,7 @@ from autotest.scheduler import email_manager, scheduler_config
 # something else during recovery.  Name credit goes to showard. ;)
 DARK_MARK_ENVIRONMENT_VAR = 'AUTOTEST_SCHEDULER_DARK_MARK'
 
-_OUTPUT_DIR = global_config.global_config.get_config_value('COMMON',
-                                                           'test_output_dir',
-                                                            default="")
+_OUTPUT_DIR = settings.get_value('COMMON','test_output_dir', default="")
 
 if _OUTPUT_DIR:
     _TEMPORARY_DIRECTORY = os.path.join(_OUTPUT_DIR, 'drone_tmp')
@@ -123,8 +122,9 @@ class DroneUtility(object):
     def _refresh_processes(self, command_name, open=open,
                            site_check_parse=None):
         # The open argument is used for test injection.
-        check_mark = global_config.global_config.get_config_value(
-            'SCHEDULER', 'check_processes_for_dark_mark', bool, False)
+        check_mark = settings.get_value('SCHEDULER',
+                                        'check_processes_for_dark_mark',
+                                        bool, False)
         processes = []
         for info in self._get_process_info():
             is_parse = (site_check_parse and site_check_parse(info))
@@ -411,8 +411,8 @@ class DroneUtility(object):
 
 
 def create_host(hostname):
-    username = global_config.global_config.get_config_value(
-        'SCHEDULER', hostname + '_username', default=getpass.getuser())
+    username = settings.get_value('SCHEDULER', hostname + '_username',
+                                  default=getpass.getuser())
     return hosts.SSHHost(hostname, user=username)
 
 
@@ -426,7 +426,7 @@ def parse_input():
 
     try:
         return pickle.loads(pickled_input)
-    except Exception, exc:
+    except Exception:
         separator = '*' * 50
         raise ValueError('Unpickling input failed\n'
                          'Input: %r\n'

--- a/scheduler/drone_utility_unittest.py
+++ b/scheduler/drone_utility_unittest.py
@@ -9,7 +9,7 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 from autotest.client.shared.test_utils import mock
 from autotest.scheduler import drone_utility
 
@@ -26,13 +26,13 @@ class TestDroneUtility(unittest.TestCase):
 
     def tearDown(self):
         self.god.unstub_all()
-        global_config.global_config.reset_config_values()
+        settings.reset_values()
 
 
     @staticmethod
     def _set_check_dark_mark(value):
-        global_config.global_config.override_config_value(
-                'SCHEDULER', 'check_processes_for_dark_mark', repr(value))
+        settings.override_value('SCHEDULER', 'check_processes_for_dark_mark',
+                                repr(value))
 
 
     def test_refresh_processes_ignore_dark_mark(self):

--- a/scheduler/drones.py
+++ b/scheduler/drones.py
@@ -4,11 +4,11 @@ try:
 except ImportError:
     import common
 from autotest.scheduler import drone_utility, email_manager
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 
 
-AUTOTEST_INSTALL_DIR = global_config.global_config.get_config_value('SCHEDULER',
-                                                 'drone_installation_directory')
+AUTOTEST_INSTALL_DIR = settings.get_value('SCHEDULER',
+                                          'drone_installation_directory')
 
 class DroneUnreachable(Exception):
     """The drone is non-sshable."""

--- a/scheduler/email_manager.py
+++ b/scheduler/email_manager.py
@@ -3,7 +3,7 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 
 CONFIG_SECTION = 'SCHEDULER'
 
@@ -13,23 +13,27 @@ class EmailNotificationManager(object):
     def __init__(self):
         self._emails = []
 
-        self._from_address = global_config.global_config.get_config_value(
-            CONFIG_SECTION, "notify_email_from", default=getpass.getuser())
+        self._from_address = settings.get_value(CONFIG_SECTION,
+                                                "notify_email_from",
+                                                default=getpass.getuser())
 
-        self._notify_address = global_config.global_config.get_config_value(
-            CONFIG_SECTION, "notify_email", default='')
+        self._notify_address = settings.get_value(CONFIG_SECTION,
+                                                  "notify_email", default='')
 
-        self._smtp_server = global_config.global_config.get_config_value(
-            CONFIG_SECTION_SMTP, "smtp_server", default='localhost')
+        self._smtp_server = settings.get_value(CONFIG_SECTION_SMTP,
+                                               "smtp_server",
+                                               default='localhost')
 
-        self._smtp_port = global_config.global_config.get_config_value(
-            CONFIG_SECTION_SMTP, "smtp_port", default=None)
+        self._smtp_port = settings.get_value(CONFIG_SECTION_SMTP,
+                                             "smtp_port",
+                                             default=None)
 
-        self._smtp_user = global_config.global_config.get_config_value(
-            CONFIG_SECTION_SMTP, "smtp_user", default='')
+        self._smtp_user = settings.get_value(CONFIG_SECTION_SMTP,
+                                             "smtp_user", default='')
 
-        self._smtp_password = global_config.global_config.get_config_value(
-            CONFIG_SECTION_SMTP, "smtp_password", default='')
+        self._smtp_password = settings.get_value(CONFIG_SECTION_SMTP,
+                                                 "smtp_password", default='')
+
 
     def send_email(self, to_string, subject, body):
         """Mails out emails to the addresses listed in to_string.

--- a/scheduler/host_scheduler.py
+++ b/scheduler/host_scheduler.py
@@ -1,11 +1,10 @@
 """
 Autotest scheduling utility.
 """
-
-
 import logging
 
-from autotest.client.shared import global_config, utils
+from autotest.client.shared import utils
+from autotest.client.shared.settings import settings
 from autotest.frontend.afe import models
 from autotest.scheduler import metahost_scheduler, scheduler_config
 from autotest.scheduler import scheduler_models
@@ -36,8 +35,8 @@ class BaseHostScheduler(metahost_scheduler.HostSchedulingUtility):
         self._db = db
         self._metahost_schedulers = metahost_scheduler.get_metahost_schedulers()
 
-        # load site-specific scheduler selected in global_config
-        site_schedulers_str = global_config.global_config.get_config_value(
+        # load site-specific scheduler selected in settings
+        site_schedulers_str = settings.get_value(
                 scheduler_config.CONFIG_SECTION, 'site_metahost_schedulers',
                 default='')
         site_schedulers = set(site_schedulers_str.split(','))

--- a/scheduler/monitor_db_functional_unittest.py
+++ b/scheduler/monitor_db_functional_unittest.py
@@ -5,7 +5,7 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import enum, global_config, host_protections
+from autotest.client.shared import enum, settings, host_protections
 from autotest.database import database_connection
 from autotest.frontend import setup_django_environment
 from autotest.frontend.afe import frontend_test_utils, models
@@ -45,7 +45,7 @@ class MockGlobalConfig(object):
         self._config_info[(section, key)] = value
 
 
-    def get_config_value(self, section, key, type=str,
+    def get_value(self, section, key, type=str,
                          default=None, allow_blank=False):
         identifier = (section, key)
         if identifier not in self._config_info:
@@ -311,7 +311,7 @@ class SchedulerFunctionalTest(unittest.TestCase,
     def setUp(self):
         self._frontend_common_setup()
         self._set_stubs()
-        self._set_global_config_values()
+        self._set_settings_values()
         self._create_dispatcher()
 
         logging.basicConfig(level=logging.DEBUG)
@@ -328,7 +328,7 @@ class SchedulerFunctionalTest(unittest.TestCase,
 
     def _set_stubs(self):
         self.mock_config = MockGlobalConfig()
-        self.god.stub_with(global_config, 'global_config', self.mock_config)
+        self.god.stub_with(settings, 'settings', self.mock_config)
 
         self.mock_drone_manager = MockDroneManager()
         drone_manager._set_instance(self.mock_drone_manager)
@@ -347,7 +347,7 @@ class SchedulerFunctionalTest(unittest.TestCase,
         scheduler_models.initialize_globals()
 
 
-    def _set_global_config_values(self):
+    def _set_settings_values(self):
         self.mock_config.set_config_value('SCHEDULER', 'pidfile_timeout_mins',
                                           1)
         self.mock_config.set_config_value('SCHEDULER', 'gc_stats_interval_mins',

--- a/scheduler/monitor_db_watcher.py
+++ b/scheduler/monitor_db_watcher.py
@@ -10,8 +10,9 @@ except ImportError:
     import common
 from autotest.scheduler import watcher_logging_config
 from autotest.client import os_dep
-from autotest.client.shared import error, global_config, utils
+from autotest.client.shared import error, utils
 from autotest.client.shared import logging_manager
+from autotest.client.shared.settings import settings, SettingsError
 from autotest.scheduler import scheduler_logging_config
 from autotest.scheduler import monitor_db
 
@@ -19,9 +20,7 @@ from autotest.scheduler import monitor_db
 PAUSE_LENGTH = 60
 STALL_TIMEOUT = 2*60*60
 
-output_dir = global_config.global_config.get_config_value('COMMON',
-                                                          'test_output_dir',
-                                                          default="")
+output_dir = settings.get_value('COMMON', 'test_output_dir', default="")
 
 autodir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -126,13 +125,12 @@ class MonitorProc(SiteMonitorProc):
                            'iostat -k -x 2 4',
                           ]
         db_cmd = '/usr/bin/mysqladmin --verbose processlist -u%s -p%s'
-        config = global_config.global_config
         try:
-            user = config.get_config_value("BACKUP", "user")
-            password = config.get_config_value("BACKUP", "password")
+            user = settings.get_value("BACKUP", "user")
+            password = settings.get_value("BACKUP", "password")
             db_cmd %= (user, password)
             INFO_TO_COLLECT.append(db_cmd)
-        except global_config.ConfigError:
+        except SettingsError:
             pass
         stall_log_path = self.log_path + '.stall_info'
         log = open(stall_log_path, "w")

--- a/scheduler/scheduler_config.py
+++ b/scheduler/scheduler_config.py
@@ -2,7 +2,7 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 
 CONFIG_SECTION = 'SCHEDULER'
 
@@ -28,12 +28,11 @@ class SchedulerConfig(object):
 
 
     def read_config(self):
-        config = global_config.global_config
-        config.parse_config_file()
+        settings.parse_config_file()
         for field, config_option in self.FIELDS.iteritems():
-            setattr(self, field, config.get_config_value(CONFIG_SECTION,
-                                                         config_option,
-                                                         type=int))
+            setattr(self, field, settings.get_value(CONFIG_SECTION,
+                                                    config_option,
+                                                    type=int))
 
 
 config = SchedulerConfig()

--- a/server/autoserv.py
+++ b/server/autoserv.py
@@ -9,9 +9,9 @@ try:
 except ImportError:
     import common
 
-from autotest.client.shared.global_config import global_config
-require_atfork = global_config.get_config_value(
-        'AUTOSERV', 'require_atfork_module', type=bool, default=True)
+from autotest.client.shared.settings import settings
+require_atfork = settings.get_value('AUTOSERV', 'require_atfork_module',
+                                    type=bool, default=True)
 
 try:
     import atfork
@@ -23,9 +23,9 @@ try:
     warnings.filterwarnings('ignore', 'logging module already imported')
     atfork.stdlib_fixer.fix_logging_module()
 except ImportError, e:
-    from autotest.client.shared.global_config import global_config
-    if global_config.get_config_value(
-            'AUTOSERV', 'require_atfork_module', type=bool, default=False):
+    from autotest.client.shared.settings import settings
+    if settings.get_value('AUTOSERV', 'require_atfork_module', type=bool,
+                          default=False):
         print >>sys.stderr, 'Please run utils/build_externals.py'
         print e
         sys.exit(1)
@@ -75,7 +75,6 @@ def run_autoserv(pid_file_manager, results, parser):
     verify = parser.options.verify
     repair = parser.options.repair
     cleanup = parser.options.cleanup
-    no_tee = parser.options.no_tee
     parse_job = parser.options.parse_job
     execution_tag = parser.options.execution_tag
     if not execution_tag:
@@ -173,9 +172,7 @@ def main():
     if parser.options.no_logging:
         results = None
     else:
-        output_dir = global_config.get_config_value('COMMON',
-                                                    'test_output_dir',
-                                                    default="")
+        output_dir = settings.get_value('COMMON', 'test_output_dir', default="")
         results = parser.options.results
         if not results:
             results = 'results.' + time.strftime('%Y-%m-%d-%H.%M.%S')

--- a/server/autoserv_parser.py
+++ b/server/autoserv_parser.py
@@ -74,9 +74,6 @@ class base_autoserv_parser(object):
         self.parser.add_option("-C", "--cleanup", action="store_true",
                                default=False,
                                help="cleanup all machines after the job")
-        self.parser.add_option("-n", action="store_true",
-                               dest="no_tee", default=False,
-                               help="no teeing the status to stdout/err")
         self.parser.add_option("-N", action="store_true",
                                dest="no_logging", default=False,
                                help="no logging")

--- a/server/autotest_remote_unittest.py
+++ b/server/autotest_remote_unittest.py
@@ -51,8 +51,7 @@ class TestBaseAutotest(unittest.TestCase):
         self.god.stub_function(os, "fdopen")
         self.god.stub_function(os.path, "exists")
         self.god.stub_function(autotest_remote, "open")
-        self.god.stub_function(autotest_remote.global_config.global_config,
-                               "get_config_value")
+        self.god.stub_function(autotest_remote.settings, "get_value")
         self.god.stub_function(logging, "exception")
         self.god.stub_class(autotest_remote, "_Run")
         self.god.stub_class(autotest_remote, "log_collector")
@@ -117,15 +116,15 @@ class TestBaseAutotest(unittest.TestCase):
     def test_full_client_install(self):
         self.record_install_prologue()
 
-        c = autotest_remote.global_config.global_config
-        c.get_config_value.expect_call('PACKAGES',
+
+        autotest_remote.settings.get_value.expect_call('PACKAGES',
                                        'serve_packages_from_autoserv',
                                        type=bool).and_return(False)
         self.host.send_file.expect_call('source_material', 'autodir',
                                         delete_dest=True)
 
         tmpdir = 'autodir/tmp'
-        c.get_config_value.expect_call('COMMON',
+        autotest_remote.settings.get_value.expect_call('COMMON',
                                        'test_output_dir',
                                        default=tmpdir).and_return(tmpdir)
         self.host.run.expect_call('mkdir -p %s' % tmpdir)
@@ -138,17 +137,17 @@ class TestBaseAutotest(unittest.TestCase):
     def test_autoserv_install(self):
         self.record_install_prologue()
 
-        c = autotest_remote.global_config.global_config
-        c.get_config_value.expect_call('PACKAGES',
+
+        autotest_remote.settings.get_value.expect_call('PACKAGES',
             'fetch_location', type=list, default=[]).and_return([])
 
-        c.get_config_value.expect_call('PACKAGES',
+        autotest_remote.settings.get_value.expect_call('PACKAGES',
                                        'serve_packages_from_autoserv',
                                        type=bool).and_return(True)
         self.base_autotest._install_using_send_file.expect_call(self.host,
                                                                 'autodir')
         tmpdir = 'autodir/tmp'
-        c.get_config_value.expect_call('COMMON',
+        autotest_remote.settings.get_value.expect_call('COMMON',
                                        'test_output_dir',
                                        default=tmpdir).and_return(tmpdir)
         self.host.run.expect_call('mkdir -p %s' % tmpdir)
@@ -160,8 +159,8 @@ class TestBaseAutotest(unittest.TestCase):
     def test_packaging_install(self):
         self.record_install_prologue()
 
-        c = autotest_remote.global_config.global_config
-        c.get_config_value.expect_call('PACKAGES',
+
+        autotest_remote.settings.get_value.expect_call('PACKAGES',
             'fetch_location', type=list, default=[]).and_return(['repo'])
         pkgmgr = packages.PackageManager.expect_new('autodir',
             repo_urls=['repo'], hostname='hostname', do_locking=False,
@@ -173,11 +172,11 @@ class TestBaseAutotest(unittest.TestCase):
         pkgmgr.install_pkg.expect_call('autotest', 'client', pkg_dir,
                                        'autodir', preserve_install_dir=True)
         tmpdir = 'autodir/tmp'
-        c.get_config_value.expect_call('COMMON',
+        autotest_remote.settings.get_value.expect_call('COMMON',
                                        'test_output_dir',
                                        default=tmpdir).and_return(tmpdir)
         self.host.run.expect_call('mkdir -p %s' % tmpdir)
-        c.get_config_value.expect_call('COMMON',
+        autotest_remote.settings.get_value.expect_call('COMMON',
                                        'test_output_dir',
                                        default=tmpdir).and_return(tmpdir)
         self.host.run.expect_call('mkdir -p %s' % tmpdir)
@@ -232,8 +231,8 @@ class TestBaseAutotest(unittest.TestCase):
 
         utils.get.expect_call(control).and_return("temp")
 
-        c = autotest_remote.global_config.global_config
-        c.get_config_value.expect_call("PACKAGES",
+
+        autotest_remote.settings.get_value.expect_call("PACKAGES",
             'fetch_location', type=list, default=[]).and_return(['repo'])
         pkgmgr = packages.PackageManager.expect_new('autotest',
                                                      repo_urls=['repo'],
@@ -328,8 +327,8 @@ class TestBaseAutotest(unittest.TestCase):
         logger = autotest_remote.client_logger(self.host, '', '')
         self.god.stub_function(logger, '_send_tarball')
 
-        c = autotest_remote.global_config.global_config
-        c.get_config_value.expect_call('PACKAGES',
+
+        autotest_remote.settings.get_value.expect_call('PACKAGES',
                                        'serve_packages_from_autoserv',
                                        type=bool).and_return(True)
         logger._send_tarball.expect_call('pkgname.tar.bz2', '/autotest/dest/')

--- a/server/crashcollect.py
+++ b/server/crashcollect.py
@@ -1,6 +1,6 @@
 import os, time, logging, shutil, gzip
 
-from autotest.client.shared import global_config
+from autotest.client.shared import settings
 from autotest.server import utils
 
 
@@ -35,7 +35,7 @@ def get_crashinfo(host, test_start_time):
 
 
 # Load default for number of hours to wait before giving up on crash collection.
-HOURS_TO_WAIT = global_config.global_config.get_config_value(
+HOURS_TO_WAIT = settings.settings.get_value(
     'SERVER', 'crash_collection_hours_to_wait', type=float, default=4.0)
 
 

--- a/server/frontend.py
+++ b/server/frontend.py
@@ -14,21 +14,20 @@ For docs, see:
     http://docs.djangoproject.com/en/dev/ref/models/querysets/#queryset-api
 """
 
-import getpass, os, time, traceback, re, xmlrpclib
+import getpass, os, time, traceback, re
 try:
     import autotest.common as common
 except ImportError:
     import common
 from autotest.frontend.afe import rpc_client_lib
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 from autotest.client.shared import utils
 try:
     from autotest.server.site_common import site_utils as server_utils
-except:
+except ImportError:
     from autotest.server import utils as server_utils
 form_ntuples_from_machines = server_utils.form_ntuples_from_machines
 
-GLOBAL_CONFIG = global_config.global_config
 DEFAULT_SERVER = 'autotest'
 
 def dump_object(header, obj):
@@ -67,8 +66,8 @@ class RpcClient(object):
             if 'AUTOTEST_WEB' in os.environ:
                 server = os.environ['AUTOTEST_WEB']
             else:
-                server = GLOBAL_CONFIG.get_config_value('SERVER', 'hostname',
-                                                        default=DEFAULT_SERVER)
+                server = settings.get_value('SERVER', 'hostname',
+                                            default=DEFAULT_SERVER)
         self.server = server
         self.user = user
         self.print_log = print_log
@@ -397,18 +396,14 @@ class AFE(RpcClient):
         text.append(url + '\n')
 
         smtp_info = {}
-        smtp_info['server'] = GLOBAL_CONFIG.get_config_value('SERVER',
-                                                             'smtp_server',
-                                                             default='localhost')
-        smtp_info['port'] = GLOBAL_CONFIG.get_config_value('SERVER',
-                                                           'smtp_port',
-                                                           default='')
-        smtp_info['user'] = GLOBAL_CONFIG.get_config_value('SERVER',
-                                                           'smtp_user',
-                                                           default='')
-        smtp_info['password'] = GLOBAL_CONFIG.get_config_value('SERVER',
-                                                               'smtp_password',
-                                                               default='')
+        smtp_info['server'] = settings.get_value('SERVER', 'smtp_server',
+                                                default='localhost')
+        smtp_info['port'] = settings.get_value('SERVER', 'smtp_port',
+                                               default='')
+        smtp_info['user'] = settings.get_value('SERVER', 'smtp_user',
+                                               default='')
+        smtp_info['password'] = settings.get_value('SERVER', 'smtp_password',
+                                                   default='')
 
         body = '\n'.join(text)
         print '---------------------------------------------------'

--- a/server/frontend_unittest.py
+++ b/server/frontend_unittest.py
@@ -11,13 +11,11 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 from autotest.client.shared import utils
 from autotest.client.shared.test_utils import mock
 from autotest.frontend.afe import rpc_client_lib
 from autotest.server import frontend
-
-GLOBAL_CONFIG = global_config.global_config
 
 
 class BaseRpcClientTest(unittest.TestCase):
@@ -39,7 +37,7 @@ class BaseRpcClientTest(unittest.TestCase):
 class RpcClientTest(BaseRpcClientTest):
     def test_init(self):
         os.environ['LOGNAME'] = 'unittest-user'
-        GLOBAL_CONFIG.override_config_value('SERVER', 'hostname', 'test-host')
+        settings.override_value('SERVER', 'hostname', 'test-host')
         rpc_client_lib.authorization_headers.expect_call(
                 'unittest-user', 'http://test-host').and_return(
                         {'AUTHORIZATION': 'unittest-user'})
@@ -57,7 +55,7 @@ class AFETest(BaseRpcClientTest):
             name = 'nameFoo'
             id = 'idFoo'
             results_platform_map = {'NORAD' : {'Seeking_Joshua': ['WOPR']}}
-        GLOBAL_CONFIG.override_config_value('SERVER', 'hostname', 'chess')
+        settings.override_value('SERVER', 'hostname', 'chess')
         rpc_client_lib.authorization_headers.expect_call(
                 'david', 'http://chess').and_return(
                         {'AUTHORIZATION': 'david'})

--- a/server/hosts/abstract_ssh.py
+++ b/server/hosts/abstract_ssh.py
@@ -1,13 +1,12 @@
-import os, time, types, socket, shutil, glob, logging, traceback, tempfile
-from autotest.client.shared import autotemp, error, logging_manager
+import os, time, socket, shutil, glob, logging, traceback, tempfile
+from autotest.client.shared import autotemp, error
 from autotest.server import utils, autotest_remote
 from autotest.server.hosts import remote
-from autotest.client.shared.global_config import global_config
+from autotest.client.shared.settings import settings
 
 
-get_value = global_config.get_config_value
-enable_master_ssh = get_value('AUTOSERV', 'enable_master_ssh', type=bool,
-                              default=False)
+enable_master_ssh = settings.get_value('AUTOSERV', 'enable_master_ssh',
+                                       type=bool, default=False)
 
 
 def _make_ssh_cmd_default(user="root", port=22, opts='', hosts_file='/dev/null',
@@ -532,10 +531,10 @@ class AbstractSSHHost(SiteHost):
 
 
     # tunable constants for the verify & repair code
-    AUTOTEST_GB_DISKSPACE_REQUIRED = get_value("SERVER",
-                                               "gb_diskspace_required",
-                                               type=int,
-                                               default=20)
+    AUTOTEST_GB_DISKSPACE_REQUIRED = settings.get_value("SERVER",
+                                                        "gb_diskspace_required",
+                                                        type=int,
+                                                        default=20)
 
 
     def verify_connectivity(self):

--- a/server/hosts/base_classes_unittest.py
+++ b/server/hosts/base_classes_unittest.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     import common
 
-from autotest.client.shared import global_config
+from autotest.client.shared import settings
 from autotest.client.shared.test_utils import mock
 from autotest.server import utils
 from autotest.server.hosts import base_classes, bootloader
@@ -15,11 +15,11 @@ from autotest.server.hosts import base_classes, bootloader
 class test_host_class(unittest.TestCase):
     def setUp(self):
         self.god = mock.mock_god()
-        # stub out get_server_dir, global_config.get_config_value
+        # stub out get_server_dir, settings.get_value
         self.god.stub_with(utils, "get_server_dir",
                            lambda: "/unittest/server")
-        self.god.stub_function(global_config.global_config,
-                               "get_config_value")
+        self.god.stub_function(settings.settings,
+                               "get_value")
         # stub out the bootloader
         self.real_bootloader = bootloader.Bootloader
         bootloader.Bootloader = lambda arg: object()
@@ -62,7 +62,7 @@ class test_host_class(unittest.TestCase):
 
 
     def test_get_wait_up_empty(self):
-        global_config.global_config.get_config_value.expect_call(
+        settings.settings.get_value.expect_call(
             "HOSTS", "wait_up_processes", default="").and_return("")
 
         host = base_classes.Host()
@@ -71,7 +71,7 @@ class test_host_class(unittest.TestCase):
 
 
     def test_get_wait_up_ignores_whitespace(self):
-        global_config.global_config.get_config_value.expect_call(
+        settings.settings.get_value.expect_call(
             "HOSTS", "wait_up_processes", default="").and_return("  ")
 
         host = base_classes.Host()
@@ -80,7 +80,7 @@ class test_host_class(unittest.TestCase):
 
 
     def test_get_wait_up_single_process(self):
-        global_config.global_config.get_config_value.expect_call(
+        settings.settings.get_value.expect_call(
             "HOSTS", "wait_up_processes", default="").and_return("proc1")
 
         host = base_classes.Host()
@@ -90,7 +90,7 @@ class test_host_class(unittest.TestCase):
 
 
     def test_get_wait_up_multiple_process(self):
-        global_config.global_config.get_config_value.expect_call(
+        settings.settings.get_value.expect_call(
             "HOSTS", "wait_up_processes", default="").and_return(
             "proc1,proc2,proc3")
 
@@ -101,7 +101,7 @@ class test_host_class(unittest.TestCase):
 
 
     def test_get_wait_up_drops_duplicates(self):
-        global_config.global_config.get_config_value.expect_call(
+        settings.settings.get_value.expect_call(
             "HOSTS", "wait_up_processes", default="").and_return(
             "proc1,proc2,proc1")
 

--- a/server/hosts/factory.py
+++ b/server/hosts/factory.py
@@ -1,13 +1,11 @@
-from autotest.client.shared import utils, error, global_config
+from autotest.client.shared import error, settings
 from autotest.server import autotest_remote, utils as server_utils
-from autotest.server.hosts import site_factory, ssh_host, serial, remote
+from autotest.server.hosts import site_factory, ssh_host, serial
 from autotest.server.hosts import logfile_monitor
 
 DEFAULT_FOLLOW_PATH = '/var/log/kern.log'
 DEFAULT_PATTERNS_PATH = 'console_patterns'
-SSH_ENGINE = global_config.global_config.get_config_value('AUTOSERV',
-                                                          'ssh_engine',
-                                                          type=str)
+SSH_ENGINE = settings.settings.get_value('AUTOSERV', 'ssh_engine')
 
 # for tracking which hostnames have already had job_start called
 _started_hostnames = set()

--- a/server/hosts/paramiko_host.py
+++ b/server/hosts/paramiko_host.py
@@ -1,7 +1,8 @@
-import os, sys, time, signal, socket, re, fnmatch, logging, threading
+import os, time, signal, socket, re, fnmatch, logging, threading
 import paramiko
 
-from autotest.client.shared import utils, error, global_config
+from autotest.client.shared import utils, error
+from autotest.client.shared.settings import settings
 from autotest.server import subcommand
 from autotest.server.hosts import abstract_ssh
 
@@ -88,8 +89,9 @@ class ParamikoHost(abstract_ssh.AbstractSSHHost):
                 user_keys[path] = key
 
         # load up all the ssh agent keys
-        use_sshagent = global_config.global_config.get_config_value(
-            'AUTOSERV', 'use_sshagent_with_paramiko', type=bool)
+        use_sshagent = settings.get_value('AUTOSERV',
+                                          'use_sshagent_with_paramiko',
+                                          type=bool)
         if use_sshagent:
             ssh_agent = paramiko.Agent()
             for i, key in enumerate(ssh_agent.get_keys()):

--- a/server/hosts/remote.py
+++ b/server/hosts/remote.py
@@ -2,16 +2,16 @@
 if it is available."""
 
 import os, logging, urllib
-from autotest.client.shared import error, global_config
+from autotest.client.shared import error
+from autotest.client.shared.settings import settings
 from autotest.server import utils
 from autotest.server.hosts import base_classes, install_server
 
 
 def get_install_server_info():
     server_info = {}
-    cfg = global_config.global_config
-    cfg.parse_config_file()
-    for option, value in cfg.config.items('INSTALL_SERVER'):
+    settings.parse_config_file()
+    for option, value in settings.config.items('INSTALL_SERVER'):
         server_info[option] = value
 
     return server_info

--- a/tko/db.py
+++ b/tko/db.py
@@ -1,10 +1,10 @@
-import re, os, sys, types, time, random
+import re, os, sys, time, random
 
 try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings
 from autotest.tko import utils
 
 
@@ -40,35 +40,32 @@ class db_sql(object):
 
 
     def _load_config(self, host, database, user, password):
-        # grab the global config
-        get_value = global_config.global_config.get_config_value
-
         # grab the host, database
         if host:
             self.host = host
         else:
-            self.host = get_value("AUTOTEST_WEB", "host")
+            self.host = settings.get_value("AUTOTEST_WEB", "host")
         if database:
             self.database = database
         else:
-            self.database = get_value("AUTOTEST_WEB", "database")
+            self.database = settings.get_value("AUTOTEST_WEB", "database")
 
         # grab the user and password
         if user:
             self.user = user
         else:
-            self.user = get_value("AUTOTEST_WEB", "user")
+            self.user = settings.get_value("AUTOTEST_WEB", "user")
         if password is not None:
             self.password = password
         else:
-            self.password = get_value("AUTOTEST_WEB", "password")
+            self.password = settings.get_value("AUTOTEST_WEB", "password")
 
         # grab the timeout configuration
-        self.query_timeout = get_value("AUTOTEST_WEB", "query_timeout",
+        self.query_timeout = settings.get_value("AUTOTEST_WEB", "query_timeout",
                                        type=int, default=3600)
-        self.min_delay = get_value("AUTOTEST_WEB", "min_retry_delay", type=int,
+        self.min_delay = settings.get_value("AUTOTEST_WEB", "min_retry_delay", type=int,
                                    default=20)
-        self.max_delay = get_value("AUTOTEST_WEB", "max_retry_delay", type=int,
+        self.max_delay = settings.get_value("AUTOTEST_WEB", "max_retry_delay", type=int,
                                    default=60)
 
 
@@ -575,8 +572,7 @@ class db_sql(object):
 
 def _get_db_type():
     """Get the database type name to use from the global config."""
-    get_value = global_config.global_config.get_config_value
-    return "db_" + get_value("AUTOTEST_WEB", "db_type", default="mysql")
+    return "db_" + settings.get_value("AUTOTEST_WEB", "db_type", default="mysql")
 
 
 def _get_error_class(class_name):

--- a/utils/packager.py
+++ b/utils/packager.py
@@ -4,17 +4,17 @@
 Utility to upload or remove the packages from the packages repository.
 """
 
-import logging, os, sys, optparse, socket, tempfile, shutil
+import logging, os, sys, optparse, tempfile, shutil
 try:
     import autotest.common as common
 except ImportError:
     import common
 from autotest.client.shared import utils as client_utils
-from autotest.client.shared import global_config, error
+from autotest.client.shared import error
+from autotest.client.shared.settings import settings
 from autotest.client.shared import base_packages, packages
 from autotest.server import utils as server_utils
 
-c = global_config.global_config
 logging.basicConfig(level=logging.DEBUG)
 
 def get_exclude_string(client_dir):
@@ -225,9 +225,9 @@ def main():
     autotest_dir = os.path.abspath(os.path.join(server_dir, '..'))
 
     # extract the pkg locations from global config
-    repo_urls = c.get_config_value('PACKAGES', 'fetch_location',
+    repo_urls = settings.get_value('PACKAGES', 'fetch_location',
                                    type=list, default=[])
-    upload_paths = c.get_config_value('PACKAGES', 'upload_location',
+    upload_paths = settings.get_value('PACKAGES', 'upload_location',
                                       type=list, default=[])
 
     if options.repo:

--- a/utils/read_config_var.py
+++ b/utils/read_config_var.py
@@ -9,7 +9,7 @@ try:
     import autotest.common as common
 except ImportError:
     import common
-from autotest.client.shared import global_config
+from autotest.client.shared.settings import settings, SettingsError
 
 
 def usage():
@@ -32,8 +32,8 @@ def main(args):
             usage()
 
         try:
-            print global_config.global_config.get_config_value(section, var)
-        except global_config.ConfigError:
+            print settings.get_value(section, var)
+        except SettingsError:
             print "Error reading %s.%s" % (section, var)
 
 


### PR DESCRIPTION
For a long time, we have been using a quite cumbersome
way of accessing settings in the autotest global config
file. In nearly all source code files that do this
access, people created shortcuts to avoid accessing the
full API namespace, such as:

from autotest.client.shared import global_config

c = global_config.global_config.get_config_value
c.get_value("mysection", "mykey")

This is an eyesore. Let's change this to something
more sane:

from autotest.client.shared.settings import settings

settings.get_value("mysection", "mykey")

In order to keep the config file name in sync with
the library name, and also, have a nicer name, we
renamed:

global_config.ini -> settings.ini
shadow_config.ini -> shadow.ini

This last change might bring some headache for
current users that are using older versions of
autotest and want to upgrade, but this file
should be easily rebaseable.

CC: Cleber Rosa crosa@redhat.com
Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
