### PR TITLE
client.shared.logging_manager_unittest: s/assertIn/assertTrue/.

### DIFF
--- a/client/shared/logging_manager_unittest.py
+++ b/client/shared/logging_manager_unittest.py
@@ -262,7 +262,7 @@ class MonkeyPatchTestCase(unittest.TestCase):
     def check_filename(self, filename, expected=None):
         if expected is None:
             expected = [self.expected_filename]
-        self.assertIn(os.path.split(filename)[1], expected)
+        self.assertTrue(os.path.split(filename)[1] in expected)
 
 
     def _0_test_find_caller(self):


### PR DESCRIPTION
This patch fixes autotest.client.shared.logging_manager_unittest on
CentOS 6 (Python 2.6.6).

Signed-off-by: Vinson Lee vlee@twitter.com
