### PR TITLE
base_sysinfo: add dmidecode to sysinfo, use lspci -vvnn to get both name...

### DIFF
--- a/client/base_sysinfo.py
+++ b/client/base_sysinfo.py
@@ -9,8 +9,8 @@ _LOG_INSTALLED_PACKAGES = settings.get_value('CLIENT', 'log_installed_packages',
 
 _DEFAULT_COMMANDS_TO_LOG_PER_TEST = []
 _DEFAULT_COMMANDS_TO_LOG_PER_BOOT = [
-    "lspci -vvn", "gcc --version", "ld --version", "mount", "hostname",
-    "uptime",
+    "lspci -vvnn", "gcc --version", "ld --version", "mount", "hostname",
+    "uptime", "dmidecode",
     ]
 _DEFAULT_COMMANDS_TO_LOG_BEFORE_ITERATION = []
 _DEFAULT_COMMANDS_TO_LOG_AFTER_ITERATION = []


### PR DESCRIPTION
... and PCI device ID in output

We use dmidecode to get BIOS and HW platform information.  Use lspci
-vvnn to get both marketing name and PCI device ID, since we detect hardware based
on PCI device ID only.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
