### PR TITLE
version.py: __all__ must be a sequence of strings if defined

### DIFF
--- a/client/shared/version.py
+++ b/client/shared/version.py
@@ -31,7 +31,7 @@ contains the following line:
 
 include RELEASE-VERSION
 """
-__all__ = ("get_version")
+__all__ = ("get_version",)
 
 
 import os, sys


### PR DESCRIPTION
http://docs.python.org/2/reference/simple_stmts.html#the-import-statement

The public names defined by a module are determined by checking the
module’s namespace for a variable named **all**; if defined, it must be
a sequence of strings which are names defined or imported by that
module.

Add a , to force the single-element tuple.

This fixes an issue where epydoc was failing to parse version.py

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
