### PR TITLE
RPC Server: add methods for Autotest and Interface version

### DIFF
--- a/frontend/afe/rpc_interface.py
+++ b/frontend/afe/rpc_interface.py
@@ -41,6 +41,13 @@ from autotest.client.shared import version
 from autotest.client.shared.settings import settings
 
 
+#
+# IMPORTANT: please update INTERFACE_VERSION with the current date whenever
+# the interface changes, so that RPC clients can handle the changes
+#
+INTERFACE_VERSION = (2013, 05, 23)
+
+
 # labels
 
 def add_label(name, kernel_config=None, platform=None, only_if_needed=None):
@@ -989,3 +996,7 @@ def get_server_time():
 
 def get_version():
     return version.get_version()
+
+
+def get_interface_version():
+    return INTERFACE_VERSION

--- a/frontend/tko/rpc_interface.py
+++ b/frontend/tko/rpc_interface.py
@@ -5,6 +5,14 @@ from autotest.frontend.afe import models as afe_models, readonly_connection
 from autotest.frontend.tko import models, tko_rpc_utils, graphing_utils
 from autotest.frontend.tko import preconfigs
 
+
+#
+# IMPORTANT: please update INTERFACE_VERSION with the current date whenever
+# the interface changes, so that RPC clients can handle the changes
+#
+INTERFACE_VERSION = (2013, 05, 23)
+
+
 # table/spreadsheet view support
 
 def get_test_views(**filter_data):
@@ -493,3 +501,7 @@ def get_iteration_attributes(**filter_data):
 def get_iteration_results(**filter_data):
     return rpc_utils.prepare_for_serialization(
         models.IterationResult.list_objects(filter_data))
+
+
+def get_interface_version():
+    return INTERFACE_VERSION


### PR DESCRIPTION
This provides RPC clients with two important pieces of information for keeping compatibility among server versions:
- Autotest version: the version generated by `client/shared/version.py`.
- Interface versions: per-service date based version, that should be updated whenever the interface changes.
