### PR TITLE
install-autotest-server.sh: Install Django South.

### DIFF
--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -216,7 +216,7 @@ fi
 
 install_packages_rh() {
 PACKAGES_UTILITY=(unzip wget)
-PACKAGES_WEBSERVER=(httpd mod_wsgi Django)
+PACKAGES_WEBSERVER=(httpd mod_wsgi Django Django-south)
 PACKAGES_MYSQL=(mysql-server MySQL-python)
 PACKAGES_DEVELOPMENT=(git java-devel)
 PACKAGES_PYTHON_LIBS=(python-imaging python-crypto python-paramiko python-httplib2 numpy python-matplotlib urw-fonts python-atfork)
@@ -253,7 +253,7 @@ fi
 
 install_packages_deb() {
 PACKAGES_UTILITY=(unzip wget gnuplot makepasswd)
-PACKAGES_WEBSERVER=(apache2-mpm-prefork libapache2-mod-wsgi python-django)
+PACKAGES_WEBSERVER=(apache2-mpm-prefork libapache2-mod-wsgi python-django python-django-south)
 PACKAGES_MYSQL=(mysql-server python-mysqldb)
 PACKAGES_DEVELOPMENT=(git openjdk-7-jre-headless)
 PACKAGES_PYTHON_LIBS=(python-imaging python-crypto python-paramiko python-httplib2 python-numpy python-matplotlib python-setuptools python-simplejson)


### PR DESCRIPTION
Django South package is needed by
installation_support/autotest-database-turnkey.

Fixes this error on CentOS 6.

Traceback (most recent call last):
  File "./installation_support/autotest-database-turnkey", line 212, in <module>
    result = app.run()
  File "./installation_support/autotest-database-turnkey", line 182, in run
    django.core.management.execute_from_command_line(argv)
  File "/usr/lib/python2.6/site-packages/django/core/management/**init**.py", line 429, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python2.6/site-packages/django/core/management/**init**.py", line 379, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/lib/python2.6/site-packages/django/core/management/base.py", line 191, in run_from_argv
    self.execute(_args, *_options.**dict**)
  File "/usr/lib/python2.6/site-packages/django/core/management/base.py", line 219, in execute
    self.validate()
  File "/usr/lib/python2.6/site-packages/django/core/management/base.py", line 249, in validate
    num_errors = get_validation_errors(s, app)
  File "/usr/lib/python2.6/site-packages/django/core/management/validation.py", line 35, in get_validation_errors
    for (app_name, error) in get_app_errors().items():
  File "/usr/lib/python2.6/site-packages/django/db/models/loading.py", line 146, in get_app_errors
    self._populate()
  File "/usr/lib/python2.6/site-packages/django/db/models/loading.py", line 61, in _populate
    self.load_app(app_name, True)
  File "/usr/lib/python2.6/site-packages/django/db/models/loading.py", line 76, in load_app
    app_module = import_module(app_name)
  File "/usr/lib/python2.6/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
ImportError: No module named south

Signed-off-by: Vinson Lee vlee@twitter.com
