### PR TITLE
database: Fix connecting to remote database.

### DIFF
--- a/installation_support/database_manager/mysql.py
+++ b/installation_support/database_manager/mysql.py
@@ -22,7 +22,8 @@ class MySQLDatabaseManager(base.BaseDatabaseManager):
                                               user, password, host)
 
         if self.admin_credentials_valid():
-            self.admin_connection = MySQLdb.connect(user=self.admin,
+            self.admin_connection = MySQLdb.connect(host=self.host,
+                                                    user=self.admin,
                                                     passwd=self.admin_password)
         else:
             self.admin_connection = None
@@ -66,7 +67,8 @@ class MySQLDatabaseManager(base.BaseDatabaseManager):
         instance, but to the RDBMS as a whole (where appropriate)
         '''
         try:
-            MySQLdb.connect(user=self.admin,
+            MySQLdb.connect(host=self.host,
+                            user=self.admin,
                             passwd=self.admin_password)
             return True
         except MySQLdb.OperationalError:


### PR DESCRIPTION
autotest-database-turnkey can take the hostname of the database server.
Some MySQLdb.connect calls omitted the host parameter and would default
connect to localhost.

Signed-off-by: Vinson Lee vlee@twitter.com
