### PR TITLE
client.shared.test: Add call trace back to log.

### DIFF
--- a/client/shared/test.py
+++ b/client/shared/test.py
@@ -425,6 +425,11 @@ class base_test(object):
 
                 _call_test_function(self.execute, *p_args, **p_dargs)
             except Exception:
+                try:
+                    logging.exception('Exception escaping from test:')
+                except:
+                    pass # don't let logging exceptions here interfere
+
                 # Save the exception while we run our cleanup() before
                 # reraising it.
                 exc_info = sys.exc_info()


### PR DESCRIPTION
When debug qmp_basic_rehl6.py, got following output:
11:54:18 INFO | Running function: qmp_basic_rhel6.run_qmp_basic_rhel6()
11:54:18 ERROR| Test failed: TestFail: 'qemu' key is not of type '<type 'unicode'>', it's '<type 'dict'>'
11:54:18 ERROR| /usr/code/autotest/client/tests/virt/virttest/video_maker.py:195: DeprecationWarning: gst.Bin.add_many() is deprecated, use gst.Bin.add()
11:54:18 ERROR|   pipeline.add_many(source, decoder, encoder, container, output)

11:55:08 ERROR| child process failed
11:55:10 INFO |         FAIL    virt.qemu.Host_RHEL.6.2.repeat1.qcow2.virtio_blk.smp2.virtio_net.RHEL.6.4.x86_64.qmp_basic_rhel6    virt.qemu.Host_RHEL.6.2.repeat1.qcow2.virtio_blk.smp2.virtio_net.RHEL.6.4.x86_64.qmp_basic_rhel6    timestamp=1370663710    localtime=Jun 08 11:55:10   'qemu' key is not of type '<type 'unicode'>', it's '<type 'dict'>'
11:55:10 INFO |     END FAIL    virt.qemu.Host_RHEL.6.2.repeat1.qcow2.virtio_blk.smp2.virtio_net.RHEL.6.4.x86_64.qmp_basic_rhel6    virt.qemu.Host_RHEL.6.2.repeat1.qcow2.virtio_blk.smp2.virtio_net.RHEL.6.4.x86_64.qmp_basic_rhel6    timestamp=1370663710    localtime=Jun 08 11:55:10
11:55:10 INFO | END GOOD    ----    ----    timestamp=1370663710    localtime=Jun 08 11:55:1

It is difficult for us to debug the fail.

Signed-off-by: Feng Yang fyang@redhat.com
