### PR TITLE
utils/external_packages.py: Fix Python module versions comparison.

### DIFF
--- a/utils/external_packages.py
+++ b/utils/external_packages.py
@@ -1,5 +1,6 @@
 # Please keep this code python 2.4 compatible and stand alone.
 
+import distutils.version
 import logging, os, shutil, sys, tempfile, time, urllib2
 import subprocess, re
 from autotest.client.shared import utils
@@ -110,9 +111,11 @@ class ExternalPackage(object):
         logging.info('imported %s version %s.', self.module_name,
                      self.installed_version)
         if hasattr(self, 'minimum_version'):
-            return self.minimum_version > self.installed_version
+            return distutils.version.LooseVersion(self.minimum_version) > \
+                distutils.version.LooseVersion(self.installed_version)
         else:
-            return self.version > self.installed_version
+            return distutils.version.LooseVersion(self.version) > \
+                distutils.version.LooseVersion(self.installed_version)
 
 
     def _get_installed_version_from_module(self, module):


### PR DESCRIPTION
The is_needed function was comparing Python module versions with string
comparison.

This resulted in an installation bug on Fedora 18 triggered by the
python-paramiko package. Fedora 18 is currently shipping with paramiko
1.10.1 and it compared incorrectly to the 1.7.5 version required by
Autotest.

The fix uses distutils.version.LooseVersion for Python module versions
comparison. StrictVersion cannot be used because the Autotest required
python-matplotlib version of 0.98.5.3 is an invalid version number with
StrictVersion.

Signed-off-by: Vinson Lee vlee@twitter.com
