### PR TITLE
service_lib: create utility classes to start/stop service for both

### DIFF
--- a/client/shared/service.py
+++ b/client/shared/service.py
@@ -110,6 +110,11 @@ def sys_v_init_command_generator(command):
         def list_command(service_name):
             return ["chkconfig", "--list"]
         return list_command
+    elif command == "set_target":
+        def set_target_command(target):
+            target = convert_systemd_target_to_runlevel(target)
+            return ["telinit", target]
+        return set_target_command
 
     def method(service_name):
         return [command_name, service_name, command]
@@ -128,11 +133,15 @@ def systemd_command_generator(command):
     command_name = "systemctl"
     if command == "is_enabled":
         command = "is-enabled"
-    if command == "list":
+    elif command == "list":
         # noinspection PyUnusedLocal
         def list_command(service_name):
             return [command_name, "list-unit-files", "--type=service"]
         return list_command
+    elif command == "set_target":
+        def set_target_command(target):
+            return [command_name, "isolate", target]
+        return set_target_command
 
     def method(service_name):
         return [command_name, command, "%s.service" % service_name]
@@ -149,6 +158,7 @@ COMMANDS = (
     "disable",
     "is_enabled",
     "list",
+    "set_target",
 )
 
 
@@ -496,7 +506,7 @@ def _auto_create_specific_service_command_generator():
     """
     command_generator = _command_generators[get_name_of_init()]
     # remove list method
-    command_list = [c for c in COMMANDS if c != "list"]
+    command_list = [c for c in COMMANDS if c not in ["list", "set_target"]]
     return _ServiceCommandGenerator(command_generator, command_list)
 
 


### PR DESCRIPTION
sytemd and sys_v by autodetecting the current init proccess at PID 1

All these examples work on both systemd and sys_v_init.

``` python
service_lib.auto_init_service_manager()
service_lib.get_service_manager().stop("iptables", ignore_status=True)

units = service_lib.get_service_manager().list().stdout
for s in services_to_disable:
    if re.search(r"\s" + s, units):
        logging.info("disabling %s", s)
        service_lib.get_service_manager().disable(s)
        service_lib.get_service_manager().stop(s)

lldpad = SpecificServiceManager("lldpad", service_lib.auto_create_specific_service_command_generator())
lldpad.stop()
lldpad.start()
```

The classes are split into two responsibilities, one classes generates all the
correct command lists by re-arranging the order of arguments to fit systemctl
or service, `service lldpad stop`  versus  `systemctl lldpad.service stop`

The other classes take these command generators and bind them to a
specific service name:
`lldpad.start()` or create a generic systemd or sys_v service object and
take a service name as an argument:
`service_lib.get_service_manager().stop("iptables", ignore_status=True)`

The module uses lazy initialization, in that it will detect systemd or
sys_v_init once when first accessed and will cache that value and not re-detect
`init` again.

This module mainly uses closures which are turned into staticmethods.
Test cases included.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
