### PR TITLE
frontend/afe/reservations_unittest.py: requires Django

### DIFF
--- a/utils/unittest_suite.py
+++ b/utils/unittest_suite.py
@@ -151,6 +151,7 @@ REQUIRES_DJANGO = set((
         'site_rpc_utils_unittest.py',
         'execution_engine_unittest.py',
         'service_proxy_lib_unittest.py',
+        'reservations_unittest.py',
         ))
 
 REQUIRES_MYSQLDB = set((


### PR DESCRIPTION
This test was left out of the list of tests that requires Django.
Putting it there now, so that running the unittest suite (without
the --full option) doesn't give false positives.

Signed-off-by: Cleber Rosa crosa@redhat.com
