### PR TITLE
get_autotest_from_git doesn't work for non-master branches.

### DIFF
--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -288,12 +288,7 @@ fi
 
 get_autotest_from_git() {
 print_log "INFO" "Cloning autotest repo $AUTOTEST_GIT_REPO, branch $AUTOTEST_GIT_BRANCH in $ATHOME"
-cd $ATHOME
-git init
-git remote add origin $AUTOTEST_GIT_REPO
-git config branch.$AUTOTEST_GIT_BRANCH.remote origin
-git config branch.$AUTOTEST_GIT_BRANCH.merge refs/heads/$AUTOTEST_GIT_BRANCH
-git pull
+git clone $AUTOTEST_GIT_REPO $ATHOME
 git checkout $AUTOTEST_GIT_BRANCH
 if [ -n $AUTOTEST_GIT_COMMIT ]; then
     git checkout $AUTOTEST_GIT_COMMIT


### PR DESCRIPTION
The get_autotest_from_git function fails when trying to checkout a branch that is not the master branch.

This reproduction case demonstrates the failure.

$ git init
$ git remote add origin git://github.com/autotest/autotest.git
$ git config branch.next.remote origin
$ git config branch.next.merge refs/heads/next
$ git pull
[...]
You asked me to pull without telling me which branch you
want to merge with, and 'branch.master.merge' in
your configuration file does not tell me, either. Please
specify which branch you want to use on the command line and
try again (e.g. 'git pull <repository> <refspec>').
See git-pull(1) for details.

If you often merge with the same branch, you may want to
use something like the following in your configuration file:
    [branch "master"]
    remote = <nickname>
    merge = <remote-ref>

```
[remote "<nickname>"]
url = <url>
fetch = <refspec>
```

See git-config(1) for details.

$ cat .git/config 
[...]
[remote "origin"]
    url = git://github.com/autotest/autotest.git
    fetch = +refs/heads/_:refs/remotes/origin/_
[branch "next"]
    remote = origin
    merge = refs/heads/next
