### PR TITLE
tko.db: Fix job status when deleting jobs

### DIFF
--- a/tko/db.py
+++ b/tko/db.py
@@ -327,7 +327,7 @@ class db_sql(object):
         self.delete('tko_jobs', where)
         self.delete('afe_aborted_host_queue_entries', {'queue_entry_id' : afe_job_idx})
         self.delete('afe_special_tasks', {'queue_entry_id' : afe_job_idx})
-        self.delete('afe_host_queue_entries', {'id' : afe_job_idx})
+        self.delete('afe_host_queue_entries', {'job_id' : afe_job_idx})
         self.delete('afe_jobs', {'id' : afe_job_idx})
 
 


### PR DESCRIPTION
When deleting jobs, we should delete job_id instead of id in table
afe_host_queue_entries. Otherwise after deleting a job, all other
job's status were also deleted.

Signed-off-by: Wenli Quan wquan@redhat.com
