### PR TITLE
client/shared/service_unittest.py: make it runnable standalone

### DIFF
--- a/client/shared/service_unittest.py
+++ b/client/shared/service_unittest.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 #  Copyright(c) 2013 Intel Corporation.
 #
 #  This program is free software; you can redistribute it and/or modify it
@@ -196,3 +198,7 @@ class TestSysVInitServiceManager(unittest.TestCase):
             "graphical.target") == '5'
         assert service.convert_systemd_target_to_runlevel(
             "reboot.target") == '6'
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
By adding the executable bits and the boiler plate code.

Signed-off-by: Cleber Rosa crosa@redhat.com
