### PR TITLE
service: Add a result parser into service to make the result more readable instead of CmdResult object.

### DIFF
--- a/client/shared/service_unittest.py
+++ b/client/shared/service_unittest.py
@@ -89,14 +89,15 @@ class TestSpecificServiceManager(unittest.TestCase):
         @patch.object(service, "get_name_of_init", get_name_of_init_mock)
         def patch_service_command_generator():
             return service._auto_create_specific_service_command_generator()
+
         @patch.object(service, "get_name_of_init", get_name_of_init_mock)
         def patch_service_result_parser():
             return service._auto_create_specific_service_result_parser()
         service_command_generator = patch_service_command_generator()
         service_result_parser = patch_service_result_parser()
         self.service_manager = service._SpecificServiceManager(
-                                "boot.lldpad", service_command_generator,
-                                service_result_parser,  self.run_mock)
+                                       "boot.lldpad", service_command_generator,
+                                       service_result_parser,  self.run_mock)
 
     def test_start(self):
         service = "lldpad"
@@ -118,22 +119,23 @@ class TestSpecificServiceManager(unittest.TestCase):
         assert not hasattr(self.service_manager, "set_target")
 
 
-class TestSystemdServiceManager(unittest.TestCase):
+def get_service_manager_from_init_and_run(init_name, run_mock):
+    command_generator = service._command_generators[init_name]
+    result_parser = service._result_parsers[init_name]
+    service_manager = service._service_managers[init_name]
+    service_command_generator = service._ServiceCommandGenerator(
+                                                 command_generator)
+    service_result_parser = service._ServiceResultParser(result_parser)
+    return service_manager(service_command_generator, service_result_parser, run_mock)
 
-    def _get_service_manager_from_ini_and_run(self, init_name, run_mock):
-        command_generator = service._command_generators[init_name]
-        result_parser = service._result_parsers[init_name]
-        service_manager = service._service_managers[init_name]
-        service_command_generator = service._ServiceCommandGenerator(
-                                                     command_generator)
-        service_result_parser = service._ServiceResultParser(result_parser)
-        return service_manager(service_command_generator, service_result_parser, run_mock)
+
+class TestSystemdServiceManager(unittest.TestCase):
 
     def setUp(self):
         self.run_mock = MagicMock()
         self.init_name = "systemd"
-        self.service_manager = self._get_service_manager_from_ini_and_run(
-                                                self.init_name, self.run_mock)
+        self.service_manager = get_service_manager_from_init_and_run(
+                                  self.init_name, self.run_mock)
 
     def test_start(self):
         service = "lldpad"
@@ -142,13 +144,19 @@ class TestSystemdServiceManager(unittest.TestCase):
             0] == "systemctl start %s.service" % service
 
     def test_list(self):
-        list_result_mock = MagicMock(exit_status=0, stdout="sshd.service enabled")
+        list_result_mock = MagicMock(exit_status=0, stdout="sshd.service enabled\n"
+                                                           "vsftpd.service disabled\n"
+                                                           "systemd-sysctl.service static\n")
         run_mock = MagicMock(return_value=list_result_mock)
-        service_manager = self._get_service_manager_from_ini_and_run(self.init_name,
-                                                                     run_mock)
-        service_manager.list()
+        service_manager = get_service_manager_from_init_and_run(self.init_name,
+                                                                run_mock)
+        list_result = service_manager.list(ignore_status=False)
         assert run_mock.call_args[0][
             0] == "systemctl list-unit-files --type=service --no-pager --full"
+        assert run_mock.call_args[1]["ignore_status"]
+        assert list_result == {'sshd': "enabled",
+                               'vsftpd': "disabled",
+                               'systemd-sysctl': "static"}
 
     def test_set_default_runlevel(self):
         runlevel = service.convert_sysv_runlevel(3)
@@ -185,14 +193,27 @@ class TestSysVInitServiceManager(unittest.TestCase):
     def setUp(self):
         self.run_mock = MagicMock()
         self.init_name = "init"
-        command_generator = service._command_generators[self.init_name]
-        result_parser = service._result_parsers[self.init_name]
-        service_manager = service._service_managers[self.init_name]
-        service_command_generator = service._ServiceCommandGenerator(
-            command_generator)
-        service_result_parser = service._ServiceResultParser(result_parser)
-        self.service_manager = service_manager(
-            service_command_generator, service_result_parser, self.run_mock)
+        self.service_manager = get_service_manager_from_init_and_run(
+                                  self.init_name, self.run_mock)
+
+    def test_list(self):
+        list_result_mock = MagicMock(exit_status=0,
+                                     stdout="sshd             0:off   1:off   2:off   3:off   4:off   5:off   6:off\n"
+                                            "vsftpd           0:off   1:off   2:off   3:off   4:off   5:on   6:off\n"
+                                            "xinetd based services:\n"
+                                            "        amanda:         off\n"
+                                            "        chargen-dgram:  on\n")
+
+        run_mock = MagicMock(return_value=list_result_mock)
+        service_manager = get_service_manager_from_init_and_run(self.init_name,
+                                                                run_mock)
+        list_result = service_manager.list(ignore_status=False)
+        assert run_mock.call_args[0][
+            0] == "chkconfig --list"
+        assert run_mock.call_args[1]["ignore_status"]
+        assert list_result == {'sshd': {0: "off", 1: "off", 2: "off", 3: "off", 4: "off", 5: "off", 6: "off"},
+                               'vsftpd': {0: "off", 1: "off", 2: "off", 3: "off", 4: "off", 5: "on", 6: "off"},
+                               'xinetd': {'amanda': "off", 'chargen-dgram': "on"}}
 
     def test_enable(self):
         service = "lldpad"


### PR DESCRIPTION
Similar struct with command_generator, I add a result_parser into server.py. 

And fix the run method in ServiceManager class to run the command and then parse the result, return the parsing result.
