### PR TITLE
client.profilers.kvm_stat: Try to mount debugfs only when it is not moun...

### DIFF
--- a/client/profilers/kvm_stat/kvm_stat.py
+++ b/client/profilers/kvm_stat/kvm_stat.py
@@ -35,13 +35,12 @@ class kvm_stat(profiler.profiler):
                 utils.run("%s --batch" % self.stat_path)
                 self.is_enabled = True
             except error.CmdError, e:
-                if 'debugfs' in str(e):
+                logging.error('Failed to execute kvm_stat:\n%s', str(e))
+                if not os.path.ismount('/sys/kernel/debug'):
                     try:
                         utils.run('mount -t debugfs debugfs /sys/kernel/debug')
                     except error.CmdError, e:
                         logging.error('Failed to mount debugfs:\n%s', str(e))
-                else:
-                    logging.error('Failed to execute kvm_stat:\n%s', str(e))
 
 
     def start(self, test):


### PR DESCRIPTION
...ted

Script will alway try to mount debugfs, if kvm_stat fail.

When "/usr/bin/kvm_stat --batch" fail, we may get following message:

Exit status: 1
Duration: 0.0273129940033

stdout:
Please mount debugfs ('mount -t debugfs debugfs /sys/kernel/debug')
and ensure the kvm modules are loaded

At this time debugfs may already mounted. But script will try to mount it again.

Signed-off-by: Feng Yang fyang@redhat.com
