### PR TITLE
autotest: Modify stdout and stderr check in CmdResult

### DIFF
--- a/client/shared/base_utils.py
+++ b/client/shared/base_utils.py
@@ -1699,6 +1699,12 @@ class CmdResult(object):
                                        initial_indent="\n    ",
                                        subsequent_indent="    ")
 
+        # Some commands' exit_status is 0, stdout has no detail,
+        # but stderr has some infomation.
+        if (not self.exit_status and self.stderr.rstrip()
+           and not self.stdout.rstrip()):
+            (self.stdout, self.stderr) = (self.stderr, self.stdout)
+
         stdout = self.stdout.rstrip()
         if stdout:
             stdout = "\nstdout:\n%s" % stdout


### PR DESCRIPTION
Some commands' exit_status is 0, but stdout has no detail, stderr has some infomation.
At this time, exchange stderr and stdout.For example:
1.Create a cgroup(name is 'test') in a cgroup subsystem, for example memory.
2. Execute 'dd' command in 'test' cgroup with utils.run()
result = utils.run("cgexec -g memory:test dd if=/dev/zero of=/home/tmp bs=1M count=100")
3.Print result(gdb or print it directly).You will find that 
result.exit_status is '0'
result.stdout.strip() is ''
result.stderr.strip() is 
100+0 records in
100+0 records out
104857600 bytes (105 MB) copied, 0.313314 s, 335 MB/s
