### PR TITLE
Log installed pkgs

### DIFF
--- a/global_config.ini
+++ b/global_config.ini
@@ -67,7 +67,7 @@ drop_caches_between_iterations: False
 #output_dir: /var/log/autotest/
 output_dir:
 # Log installed packages (recommended setting to True on server setups)
-log_installed_packages = False
+log_installed_packages = True
 # Abort on client state mismatches post reboot (!= list of devices or CPUs)
 abort_on_mismatch = False
 # mirror(s) of kernel.org (space-separated)


### PR DESCRIPTION
global_config.ini: log_installed_packages set to True

set log_installed_packages to True by default
that would helpful for debugging
