### PR TITLE
Remove gnuplot from package dependence (issue #735) and  Improve the test for Ubuntu by looking for /etc/debian_release file

### DIFF
--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -617,7 +617,7 @@ full_install() {
         setup_substitute
         setup_epel_repo
         install_basic_pkgs_rh
-    elif [ "$(grep 'Ubuntu' /etc/issue)" != "" ]
+    elif [ -f /etc/debian_version ]
     then
         check_disk_space
         setup_substitute
@@ -653,7 +653,7 @@ full_install() {
             setup_firewall
             print_install_status
             print_version_and_url
-        elif [ "$(grep 'Ubuntu' /etc/issue)" != "" ]
+        elif [ -f /etc/debian_version ]
         then
             create_autotest_user_deb
             install_autotest

--- a/frontend/pkgdeps.py
+++ b/frontend/pkgdeps.py
@@ -68,7 +68,6 @@ FEDORA_19_PKGS = [
 UBUNTU_PKGS = [
     'apache2-mpm-prefork',
     'git',
-    'gnuplot',
     'libapache2-mod-wsgi',
     'makepasswd',
     'mysql-server',


### PR DESCRIPTION
Two minor fixes, we're dropping gnuplot from the package list dependence in frontend module.
On autotest server install script, I've changed the way we detect Ubuntu by looking for file `/etc/debian_version`.
