### PR TITLE
Remove gnuplot from package dependence and improve the test for Ubuntu by looking for /etc/debian_release.

### DIFF
--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -617,7 +617,7 @@ full_install() {
         setup_substitute
         setup_epel_repo
         install_basic_pkgs_rh
-    elif [ "$(grep 'Ubuntu' /etc/issue)" != "" ]
+    elif [ -f /etc/debian_version ]
     then
         check_disk_space
         setup_substitute
@@ -653,7 +653,7 @@ full_install() {
             setup_firewall
             print_install_status
             print_version_and_url
-        elif [ "$(grep 'Ubuntu' /etc/issue)" != "" ]
+        elif [ -f /etc/debian_version ]
         then
             create_autotest_user_deb
             install_autotest

--- a/frontend/pkgdeps.py
+++ b/frontend/pkgdeps.py
@@ -68,7 +68,6 @@ FEDORA_19_PKGS = [
 UBUNTU_PKGS = [
     'apache2-mpm-prefork',
     'git',
-    'gnuplot',
     'libapache2-mod-wsgi',
     'makepasswd',
     'mysql-server',


### PR DESCRIPTION
pkgdeps.py: Remove gnuplot from package dependence.
install-autotest-server.sh: Improve the test for Ubuntu (and Debian) by looking for /etc/debian_release file.
