### PR TITLE
systemctl autotestd service file dependency

### DIFF
--- a/utils/autotestd.service
+++ b/utils/autotestd.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Autotest scheduler
+Requires=mysqld.service
+After=mysqld.service
 
 [Service]
 ExecStart=/usr/local/autotest/scheduler/autotest-scheduler-watcher


### PR DESCRIPTION
Add dependency on MySQL to the systemctl autotestd service file.
