### PR TITLE
Ignore exception when unlink /tmp/autotest_results_dir.* failed

### DIFF
--- a/client/test.py
+++ b/client/test.py
@@ -95,8 +95,11 @@ class test(common_test.base_test):
         """
         if self.crash_handling_enabled:
             # Remove the debugdir info file
-            if os.path.isfile(self.debugdir_tmp_file):
-                os.unlink(self.debugdir_tmp_file)
+            try:
+                if os.path.isfile(self.debugdir_tmp_file):
+                    os.unlink(self.debugdir_tmp_file)
+            except OSError:
+                pass
             # Restore the core pattern backup
             try:
                 utils.open_write_close(self.pattern_file,


### PR DESCRIPTION
Sometime when users execute a test, at the end, there's a error happened ,such as :

```
07:46:42 DEBUG|   File "/github-autotest_new/client/test.py", line 95, in crash_handler_report
07:46:42 DEBUG|     os.unlink(self.debugdir_tmp_file)
07:46:42 DEBUG| OSError: [Errno 2] No such file or directory: '/tmp/autotest_results_dir.8971'
```

I don't know what caused this error yet, when execute test second time, maybe this won't happen.
I think this error should be ignored , then test can run successfully
