### PR TITLE
software_manager: add support for single package yum upgrade

### DIFF
--- a/client/shared/software_manager.py
+++ b/client/shared/software_manager.py
@@ -418,11 +418,13 @@ class YumBackend(RpmBackend):
                     self.cfgparser.remove_section(section)
                     self.cfgparser.write(open(self.repo_file_path, "w"))
 
-    def upgrade(self):
+    def upgrade(self, pkg=''):
         """
         Upgrade all available packages.
+        :param pkg: optional parameter wildcard spec to upgrade
+        :type pkg: str
         """
-        r_cmd = self.base_command + ' ' + 'update'
+        r_cmd = ' '.join([self.base_command, 'update', pkg])
         try:
             utils.system(r_cmd)
             return True


### PR DESCRIPTION
Add optional rpm wildcard arg to upgrade so we can upgrade only certain
packages.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
