### PR TITLE
autotest_remote: Fix BUG when control files require PEP 0263 encoding

### DIFF
--- a/server/autotest_remote.py
+++ b/server/autotest_remote.py
@@ -444,6 +444,9 @@ class BaseAutotest(installable_object.InstallableObject):
         # build up the initialization prologue for the control file
         prologue_lines = []
 
+        # to preserve PEP 0263 source encoding it must be in the first two lines
+        prologue_lines.append("# coding=utf-8")
+
         # Add the additional user arguments
         prologue_lines.append("args = %r\n" % self.job.args)
 


### PR DESCRIPTION
I ran across this error sometime back, I don't remember the cause but somehow I had unicode in my control file.  Anyway this is a suggestion, I don't have a better fix.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
