### PR TITLE
install-autotest-server.sh: relocate apache-web-conf to new $ATHOME

### DIFF
--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -421,6 +421,7 @@ then
     /usr/local/bin/substitute $ATHOME_DEFAULT $ATHOME $ATHOME/apache/conf/new-tko-directives
     /usr/local/bin/substitute $ATHOME_DEFAULT $ATHOME $ATHOME/apache/conf/tko-directives
     /usr/local/bin/substitute $ATHOME_DEFAULT $ATHOME $ATHOME/apache/apache-conf
+    /usr/local/bin/substitute $ATHOME_DEFAULT $ATHOME $ATHOME/apache/apache-web-conf
     /usr/local/bin/substitute $ATHOME_DEFAULT $ATHOME $ATHOME/apache/drone-conf
 fi
 }


### PR DESCRIPTION
We need to update the DocumentRoot in apache-web-conf to point to the
new $ATHOME.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
