### PR TITLE
documentation: set sys.path to use autotest library.

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -3,6 +3,20 @@
 import sys
 import os
 
+try:
+    import autotest.client.setup_modules as setup_modules
+    dirname = os.path.dirname(setup_modules.__file__)
+    autotest_dir = os.path.join(dirname, "..", "..")
+except ImportError:
+    dirname = os.path.dirname(__file__)
+    autotest_dir = os.path.abspath(os.path.join(dirname, "..", ".."))
+    client_dir = os.path.join(autotest_dir, "client")
+    sys.path.insert(0, client_dir)
+    import setup_modules
+    sys.path.pop(0)
+
+setup_modules.setup(base_path=autotest_dir, root_module_name="autotest")
+
 from autotest.client.shared.version import get_version
 from autotest.frontend import setup_django_environment
 


### PR DESCRIPTION
Set sys.path in conf.py to use autotest library without exporting PYTHONPATH.
Required for proper builds of HTML on autotest.readthedocs.org site.

Signed-off-by: Ruda Moura rmoura@redhat.com
