### PR TITLE
client.shared.autotemp: Fix autotemp.tempdir.clean()

### DIFF
--- a/client/shared/autotemp.py
+++ b/client/shared/autotemp.py
@@ -17,6 +17,8 @@ import os
 import logging
 import tempfile as module_tempfile
 
+from autotest.client import utils
+
 _TEMPLATE = '_autotmp_'
 
 
@@ -97,7 +99,7 @@ class tempdir(object):
         This is also called by the destructor.
         """
         if self.name and os.path.exists(self.name):
-            shutil.rmtree(self.name)
+            utils.safe_rmdir(self.name)
 
         self.name = None
 


### PR DESCRIPTION
On NFS filesystems, when trying to remove the temporary
directory, we might end up with the same problem that
commit 5d1b5ba fixed (directory removal on NFS might
fail due to tmp files created by the NFS implementation).

So let's use utils.safe_rmdir once again to solve the
problem.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
