### PR TITLE
autotest_firewalld_add_service_unittest: add proper wrapper to preserve sys.dont_write_bytecode value

### DIFF
--- a/installation_support/autotest-firewalld-add-service
+++ b/installation_support/autotest-firewalld-add-service
@@ -16,8 +16,8 @@ from subprocess import Popen, PIPE
 import xml.etree.ElementTree
 
 
-DEFAULT_ZONE_DEFAULT_BASE_PATH = '/usr/lib/firewalld/zones'
-DEFAULT_ZONE_SYSTEM_BASE_PATH = '/etc/firewalld/zones'
+DEFAULT_ZONE_DEFAULT_BASE_PATH = os.path.join(os.sep, "usr", "lib", "firewalld", "zones")
+DEFAULT_ZONE_SYSTEM_BASE_PATH =  os.path.join(os.sep, "etc", "firewalld", "zones")
 
 
 class ArgumentParser(argparse.ArgumentParser):

--- a/installation_support/autotest_firewalld_add_service_unittest.py
+++ b/installation_support/autotest_firewalld_add_service_unittest.py
@@ -112,8 +112,9 @@ def load_module_from_file(module_file_path):
 
 MODULE_FILE = "autotest-firewalld-add-service"
 
-ETC_PATH = "/etc/firewalld/zones/public.xml"
-USR_LIB_PATH = "/usr/lib/firewalld/zones/public.xml"
+ETC_PATH = os.path.join(os.sep, "etc", "firewalld", "zones", "public.xml")
+USR_LIB_PATH = os.path.join(
+    os.sep, "usr", "lib", "firewalld", "zones", "public.xml")
 
 test_path = os.path.dirname(os.path.realpath(__file__))
 


### PR DESCRIPTION
autopep8 fixes, and os.path.join for path constants.

**autotest_firewalld_add_service_unittest: add proper wrapper to preserve sys.dont_write_bytecode value**

To be more proper we should save and reset the value of
`sys.dont_write_bytecode` since it is a global system value.

We need to set dont_write_bytecode because if we don't when we
load a module from a file 'foo', python will write the bytecode to 'fooc',
or in this test case 'autotest-firewalld-add-servicec'

This function decorator is adapted from the original context manger from
http://stackoverflow.com/a/6811921
We have to use a function decorator since Python 2.4 doesn't have
context managers.

Eventually preserve_value should probably extracted and placed in
client/shared for use with importing and unittest 'control' files.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
