### PR TITLE
Revise netperf's avg_update

### DIFF
--- a/client/tools/perf.conf
+++ b/client/tools/perf.conf
@@ -8,7 +8,7 @@ avg_update =
 [netperf]
 result_file_pattern = .*.RHS
 ignore_col = 2
-avg_update = 4,2,3|14,5,12|15,6,13
+avg_update = 4,2,3|14,6,12|15,5,13
 desc = The tests are *%s* seconds sessions of 'Netperf'. 'throughput' was taken from netperf's report.\nOther measurements were taken on the host.\nHow to read the results:\n - The Throughput is measured in Mbit/sec.\n - io_exit: io exits of KVM.\n - irq_inj: irq injections of KVM.\n
 
 [iozone]


### PR DESCRIPTION
tpkt_per_exit 14=6/12,rpkt_per_irq 15=5/13 according
to following columns.

2               3       4               5       6
throughput  CPU     thr_per_CPU     rx_pkts tx_pkts
7       8       9       10      11      12      13
rx_byts tx_byts     re_pkts rx_intr tx_intr io_exit irq_inj
14             15
tpkt_per_exit rpkt_per_irq

Signed-off-by: wenli wenli@redhat.com
