### PR TITLE
RPC server: add function get_control_file_from_test()

### DIFF
--- a/frontend/afe/models.py
+++ b/frontend/afe/models.py
@@ -670,6 +670,9 @@ class Test(dbmodels.Model, model_logic.ModelExtensions):
     name_field = 'name'
     objects = model_logic.ExtendedManager()
 
+    def get_control_file(self):
+        return open(os.path.join(common.autotest_dir, self.path)).read()
+
     def admin_description(self):
         escaped_description = saxutils.escape(self.description)
         return '<span style="white-space:pre">%s</span>' % escaped_description

--- a/frontend/afe/rpc_interface.py
+++ b/frontend/afe/rpc_interface.py
@@ -50,7 +50,7 @@ from autotest.client.shared.settings import settings
 # IMPORTANT: please update INTERFACE_VERSION with the current date whenever
 # the interface changes, so that RPC clients can handle the changes
 #
-INTERFACE_VERSION = (2013, 9, 11)
+INTERFACE_VERSION = (2014, 1, 17)
 
 
 # labels
@@ -392,6 +392,11 @@ def delete_test(id):
 def get_tests(**filter_data):
     return rpc_utils.prepare_for_serialization(
         models.Test.list_objects(filter_data))
+
+
+def get_control_file_from_test(id):
+    control_file = models.Test.smart_get(id).get_control_file()
+    return rpc_utils.prepare_for_serialization(control_file)
 
 
 # profilers


### PR DESCRIPTION
Add function get_control_file_from_test() to get the content of a Control File from a specific test id.

In Test class (models.py) create method get_control_file().
Update INTERFACE_VERSION to version 2014.1.17.

Signed-off-by: Ruda Moura rmoura@redhat.com
