### PR TITLE
utils.external_packages: Lower minimum requirements for psutil

### DIFF
--- a/utils/external_packages.py
+++ b/utils/external_packages.py
@@ -575,7 +575,7 @@ class NumpyPackage(ExternalPackage):
 
 
 class PsUtilPackage(ExternalPackage):
-    minimum_version = '0.6.0'
+    minimum_version = '0.4.0'
     version = '1.0.1'
     local_filename = 'psutil-%s.tar.gz' % version
     urls = ("https://psutil.googlecode.com/files/%s" % local_filename,)


### PR DESCRIPTION
This is a fix for issue #788.

Looking at the psutils documentation:

https://code.google.com/p/psutil/wiki/Documentation#System_related_functions

psutil.process_iter() is available in 0.4, it only had
a behavior change in 0.6 that should be largely irrelevant
to the autotest code. So, in order to help people running
older distros, such as Fedora 17, let's lower the minimum
version requirement for psutil.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
