### PR TITLE
software_manager: fix inverted logic in AptBackend

### DIFF
--- a/client/shared/software_manager.py
+++ b/client/shared/software_manager.py
@@ -707,7 +707,7 @@ class AptBackend(DpkgBackend):
         except error.CmdError:
             logging.error("Apt package update failed")
 
-        if not name:
+        if name:
             up_command = 'install --only-upgrade'
             up_cmd = self.base_command + ' ' + up_command + ' ' + name
         else:


### PR DESCRIPTION
if name is true then we want to use it.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
