### PR TITLE
client.shared.report: Set encoding to utf8 and allow customization.

### DIFF
--- a/client/shared/report.py
+++ b/client/shared/report.py
@@ -256,7 +256,7 @@ def generate_html_report(results_dir, relative_links=True):
     return jsontemplate.expand(base_template, context)
 
 
-def write_html_report(results_dir, report_path=None):
+def write_html_report(results_dir, report_path=None, encoding="utf8"):
     """
     Write an HTML file at report_path, with job data summary.
 
@@ -264,6 +264,7 @@ def write_html_report(results_dir, report_path=None):
 
     :param results_dir: Directory with test results.
     :param report_path: Path to a report file (optional).
+    :param encoding: Encoding for output (optional).
     """
     default_report_path = os.path.join(results_dir, "job_report.html")
     if report_path is None:
@@ -280,7 +281,7 @@ def write_html_report(results_dir, report_path=None):
         raise InvalidOutputDirError(report_dir)
 
     html_result = open(report_path, "w")
-    html_result.write(rendered_html)
+    html_result.write(rendered_html.encode(encoding))
     html_result.close()
     logging.info("Report successfully generated at %s", report_path)
 
@@ -308,6 +309,11 @@ class ReportOptionParser(optparse.OptionParser):
                              "value different than the default, the HTML will "
                              "link to the absolute paths of the results dir. "
                              "Default: %default")
+        self.add_option("-e", action="store", type="string",
+                        dest="encoding",
+                        default="utf8",
+                        help="Encoding for output. Example of codecs are "
+                              "ascii, latin1 and utf8. Default: %default")
 
 
 class ReportLoggingConfig(logging_config.LoggingConfig):
@@ -338,7 +344,8 @@ if __name__ == "__main__":
 
     try:
         write_html_report(results_dir=options.results_dir,
-                          report_path=options.report_path)
+                          report_path=options.report_path,
+                          encoding=options.encoding)
     except InvalidAutotestResultDirError, e:
         logging.error(e)
         sys.exit(ERROR_INVALID_RESULT_DIR)


### PR DESCRIPTION
When writing the HTML report, set the current encoding output to utf8.
Allow the customization of the encoding output too (with option -e)

It is know to work with LANG set en_US.utf8, pt_BR.utf8, fr_FR.utf8.

Fix issue #803.

Signed-off-by: Ruda Moura rmoura@redhat.com
