### PR TITLE
client.shared.remote: Fix SSH's options passing syntax.

### DIFF
--- a/client/shared/remote.py
+++ b/client/shared/remote.py
@@ -483,8 +483,8 @@ def scp_between_remotes(src, dst, port, s_passwd, d_passwd, s_name, d_name,
                            "the interface the neighbour attache")
         dst = "%s%%%s" % (dst, dst_inter)
 
-    command = ("scp -v -o UserKnownHostsFile=/dev/null -o "
-               "PreferredAuthentications=password -r %s -P %s"
+    command = ("scp -v -o UserKnownHostsFile=/dev/null "
+               "-o PreferredAuthentications=password -r %s -P %s"
                " %s@\[%s\]:%s %s@\[%s\]:%s" %
                (limit, port, s_name, src, s_path, d_name, dst, d_path))
     password_list = []


### PR DESCRIPTION
See PR #1560.

Signed-off-by: Ruda Moura rmoura@redhat.com
