### PR TITLE
client.optparse: Add short form for client option "verbose".

### DIFF
--- a/client/optparser.py
+++ b/client/optparser.py
@@ -74,7 +74,7 @@ class AutotestLocalOptionParser(optparse.OptionParser):
         self.add_option_group(job_id)
 
         verbosity = optparse.OptionGroup(self, 'VERBOSITY')
-        verbosity.add_option('--verbose', dest='verbose', action='store_true',
+        verbosity.add_option('-v', '--verbose', dest='verbose', action='store_true',
                              default=False,
                              help='Include DEBUG messages in console output. '
                              'If omitted, only informational messages will be '


### PR DESCRIPTION
Add the short form for verbose to save life.

Signed-off-by: Ouyang Guohua gouyang@redhat.com
