### PR TITLE
.travis.yml: Notify done builds and test on py 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,9 @@ script:
     - inspekt lint
     - rm -f tko/tko_pb2.py
     - inspekt style
+
+notifications:
+  irc:
+    channels: "irc.oftc.net#autotest"
+    template:
+      - "%{repository}@%{branch}: %{message} (%{build_url})"


### PR DESCRIPTION
Travis has this interesting feature of notify done
builds. So let's notify the autotest irc channel.
More, let's also test autotest under py 2.6.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
