### PR TITLE
bugfix in delete_job_full

### DIFF
--- a/tko/autotest-db-delete-job
+++ b/tko/autotest-db-delete-job
@@ -136,7 +136,7 @@ def delete_job_full(tag):
 
         logging.info("Deleting job tag %s" % tag)
         if afe_job is not None:
-            deleted = afe_models_utils.job_delete_by_id(afe_job)
+            deleted = afe_models_utils.job_delete_by_id(afe_job.id)
             if not deleted:
                 logging.error("Failed while deleting AFE job")
 


### PR DESCRIPTION
the job object(afe_job) was passed to afe_models_utils.job_delete_by_id(afe_job) method and as a result, the job could not get deleted and threw exception, argument should be an int not job object.
