### PR TITLE
typo in format_str_for_message argument name

### DIFF
--- a/client/shared/utils.py
+++ b/client/shared/utils.py
@@ -2975,15 +2975,15 @@ def generate_tmp_file_name(file_name, ext=None, directory='/tmp/'):
     return file_name
 
 
-def format_str_for_message(str):
+def format_str_for_message(msg_str):
     """
-    Format str so that it can be appended to a message.
-    If str consists of one line, prefix it with a space.
-    If str consists of multiple lines, prefix it with a newline.
+    Format msg_str so that it can be appended to a message.
+    If msg_str consists of one line, prefix it with a space.
+    If msg_str consists of multiple lines, prefix it with a newline.
 
-    :param str: string that will be formatted.
+    :param msg_str: string that will be formatted.
     """
-    lines = str.splitlines()
+    lines = msg_str.splitlines()
     num_lines = len(lines)
     sr = "\n".join(lines)
     if num_lines == 0:


### PR DESCRIPTION
before fix:
TypeError                                 Traceback (most recent call last)
<ipython-input-29-b89509bfa590> in <module>()
----> 1 utils.format_str_for_message(sr = "nnn")

/usr/local/autotest/client/shared/utils.pyc in format_str_for_message(sr)
   2984     :param str: string that will be formatted.
   2985     """
-> 2986     lines = str.splitlines()
   2987     num_lines = len(lines)
   2988     sr = "\n".join(lines)

TypeError: descriptor 'splitlines' of 'str' object needs an argument

after fix:
In [14]: utils.format_str_for_message("nnn")
Out[14]: ' nnn'
