### PR TITLE
client/shared/error: use cgitb to display tracebacks

### DIFF
--- a/client/shared/error.py
+++ b/client/shared/error.py
@@ -6,6 +6,7 @@ import sys
 import traceback
 import threading
 import logging
+import cgitb
 from traceback import format_exception
 
 # Add names you want to be imported by 'from errors import *' to this list.
@@ -201,7 +202,7 @@ class UnhandledJobError(JobError):
                     unhandled_exception)
             if not isinstance(unhandled_exception, AutotestError):
                 msg += _context_message(unhandled_exception)
-            msg += "\n" + traceback.format_exc()
+            msg += "\n" + cgitb.text(sys.exc_info())
             JobError.__init__(self, msg)
 
 


### PR DESCRIPTION
cgitb displays local variables at each stack frame
which provides much more context for debugging failed tests

cgitb is more verbose, but I suggest people give it a try.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
