### PR TITLE
Add support for pbzip2 -d -c instead of bzcat using base_packages.has_pb...

### DIFF
--- a/client/base_utils.py
+++ b/client/base_utils.py
@@ -54,7 +54,10 @@ def cat_file_to_cmd(file, command, ignore_status=0, return_output=False):
         run_cmd = utils.system
 
     if magic.guess_type(file) == 'application/x-bzip2':
-        cat = 'bzcat'
+        if base_packages.has_pbzip2():
+            cat = 'pbzip2 -d -c'
+        else:
+            cat = 'bzcat'
     elif magic.guess_type(file) == 'application/x-gzip':
         cat = 'zcat'
     else:


### PR DESCRIPTION
...zip2()

pbzip2 decompress only speeds up if pbzip2 was used to compress, but
still this saves some time.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
