### PR TITLE
software_manager: fix incorrent call of readlines

### DIFF
--- a/client/shared/software_manager.py
+++ b/client/shared/software_manager.py
@@ -682,7 +682,7 @@ class AptBackend(DpkgBackend):
         """
         repo_file = open(self.repo_file_path, 'r')
         new_file_contents = []
-        for line in repo_file.readlines:
+        for line in repo_file:
             if not line == repo:
                 new_file_contents.append(line)
         repo_file.close()


### PR DESCRIPTION
TypeError with readlines: instead of readlines(): detected by PyCharm
inspections.

Replace readlines() with iterator over file.

Signed-off-by: Ross Brattain ross.b.brattain@intel.com
