### PR TITLE
client.base_utils: Add missing import

### DIFF
--- a/client/base_utils.py
+++ b/client/base_utils.py
@@ -15,7 +15,7 @@ import re
 import fnmatch
 import logging
 import platform
-from autotest.client.shared import error, utils, magic
+from autotest.client.shared import error, utils, magic, base_packages
 
 
 def grep(pattern, file):


### PR DESCRIPTION
Fixing a bug introduced with commit dfb5c95cc16192971daaac22e0e6d02e9c01573e.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
