### PR TITLE
autotest: Mention that Django 1.5 is the currently supported version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,19 @@ For the impatient:
 
 http://autotest.readthedocs.org/en/latest/main/local/ClientQuickStart.html
 
+Installing the autotest server
+------------------------------
+
+For the impatient using Red Hat:
+
+http://autotest.readthedocs.org/en/latest/main/sysadmin/AutotestServerInstallRedHat.html
+
+For the impatient using Ubuntu/Debian:
+
+http://autotest.readthedocs.org/en/latest/main/sysadmin/AutotestServerInstall.html
+
+You are advised to read the documentation carefully, specially with details
+regarding appropriate versions of Django autotest is compatible with.
 
 Main project page
 -----------------

--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -9,6 +9,7 @@ LOG="/tmp/$BASENAME-$DATETIMESTAMP.log"
 ATPASSWD=
 MYSQLPW=
 INSTALL_PACKAGES_ONLY=0
+DJANGO_SUPPORTED_VERSION="1.5"
 export LANG=en_US.utf8
 
 print_log() {
@@ -29,6 +30,8 @@ Currently tested systems - Up to date versions of:
  * RHEL 6.2
  * Ubuntu 12.04
  * Ubuntu 12.10
+
+Current version of Django supported by autotest: 1.5
 
 GENERAL OPTIONS:
    -h      Show this message
@@ -248,6 +251,9 @@ install_basic_pkgs_deb() {
 
 install_packages() {
     print_log "INFO" "Installing packages dependencies"
+    print_log "INFO" "Please note that autotest is compatible with Django $DJANGO_SUPPORTED_VERSION"
+    print_log "INFO" "If your distro/local install is different, you WILL have problems"
+    print log "INFO" "Please stick with $DJANGO_SUPPORTED_VERSION for the time being"
     $ATHOME/installation_support/autotest-install-packages-deps >> $LOG 2>&1
     if [ $? != 0 ]
     then

--- a/documentation/source/main/sysadmin/AutotestServerInstall.rst
+++ b/documentation/source/main/sysadmin/AutotestServerInstall.rst
@@ -23,6 +23,15 @@ Server/Scheduler/Web UI Installation Steps
 Install required packages
 -------------------------
 
+Autotest is a complex project and requires a number of dependencies to
+be installed.
+
+.. note::
+
+  Currently autotest is compatible with Django 1.5, so if your
+  distribution has anything lower or higher than this version, you
+  will have problems and are advised to use a compatible version.
+
 We have automated this step on recent Ubuntu (12.04/12.10), although
 it should work on Debian too:
 

--- a/documentation/source/main/sysadmin/AutotestServerInstallRedHat.rst
+++ b/documentation/source/main/sysadmin/AutotestServerInstallRedHat.rst
@@ -33,8 +33,14 @@ it should work on Debian too:
 If you want to install it manually here it goes. Keep in mind this can be
 outdated, if so we kindly ask your help with keeping it up to date.
 
-If the distro you are running has Django >= 1.3 packaged (such as
-Fedora 15 onwards), you can install the django that your distro ships:
+.. note::
+
+  Currently autotest is compatible with Django 1.5, so if your
+  distribution has anything lower or higher than this version, you
+  will have problems and are advised to use a compatible version.
+
+If the distro you are running has Django 1.5 packaged,
+you can install the django that your distro ships:
 
 ::
 


### PR DESCRIPTION
And that installs won't work in other versions. Try to
make that abundantly clear through docs and install script.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
