### PR TITLE
autotest: Suppress bogus errors found by newer version of pylint

### DIFF
--- a/client/shared/backports/simplejson/__init__.py
+++ b/client/shared/backports/simplejson/__init__.py
@@ -124,6 +124,7 @@ OrderedDict = _import_OrderedDict()
 
 def _import_c_make_encoder():
     try:
+        # pylint: disable=E0611
         from simplejson._speedups import make_encoder
         return make_encoder
     except ImportError:

--- a/client/shared/backports/simplejson/decoder.py
+++ b/client/shared/backports/simplejson/decoder.py
@@ -9,6 +9,7 @@ from simplejson.scanner import make_scanner
 
 def _import_c_scanstring():
     try:
+        # pylint: disable=E0611
         from simplejson._speedups import scanstring
         return scanstring
     except ImportError:

--- a/client/shared/backports/simplejson/scanner.py
+++ b/client/shared/backports/simplejson/scanner.py
@@ -5,6 +5,7 @@ import re
 
 def _import_c_make_scanner():
     try:
+        # pylint: disable=E0611
         from simplejson._speedups import make_scanner
         return make_scanner
     except ImportError:

--- a/client/shared/base_job_unittest.py
+++ b/client/shared/base_job_unittest.py
@@ -751,12 +751,14 @@ class test_job_state_backing_file_locking(unittest.TestCase):
             def read_from_file(self, file_path, merge=True):
                 if self._backing_file and file_path == self._backing_file:
                     ut_self.assertNotEqual(None, self._backing_file_lock)
+                # pylint: disable=E1003
                 return super(mocked_job_state, self).read_from_file(
                     file_path, merge=True)
 
             def write_to_file(self, file_path):
                 if self._backing_file and file_path == self._backing_file:
                     ut_self.assertNotEqual(None, self._backing_file_lock)
+                # pylint: disable=E1003
                 return super(mocked_job_state, self).write_to_file(file_path)
         self.state = mocked_job_state()
         self.state.set_backing_file('backing_file')

--- a/client/shared/test_utils/mock.py
+++ b/client/shared/test_utils/mock.py
@@ -311,6 +311,7 @@ class mock_god(object):
 
             @classmethod
             def make_new(typ, *args, **dargs):
+                # pylint: disable=E1003
                 obj = super(cls_sub, typ).__new__(typ, *args,
                                                   **dargs)
 

--- a/server/hosts/abstract_ssh.py
+++ b/server/hosts/abstract_ssh.py
@@ -401,6 +401,8 @@ class AbstractSSHHost(SiteHost):
 
     def ssh_ping(self, timeout=60):
         try:
+            # Complex inheritance confuses pylint here
+            # pylint: disable=E1123
             self.run("true", timeout=timeout, connect_timeout=timeout)
         except error.AutoservSSHTimeout:
             msg = "Host (ssh) verify timed out (timeout = %d)" % timeout


### PR DESCRIPTION
After reviewing the failures, we added a bunch of new
exceptions, so we continue to get clean pylint reports.

Signed-off-by: Lucas Meneghel Rodrigues lmr@redhat.com
