### PR TITLE
Rhel7

### DIFF
--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -253,7 +253,7 @@ install_packages() {
     print_log "INFO" "Installing packages dependencies"
     print_log "INFO" "Please note that autotest is compatible with Django $DJANGO_SUPPORTED_VERSION"
     print_log "INFO" "If your distro/local install is different, you WILL have problems"
-    print log "INFO" "Please stick with $DJANGO_SUPPORTED_VERSION for the time being"
+    print_log "INFO" "Please stick with $DJANGO_SUPPORTED_VERSION for the time being"
     $ATHOME/installation_support/autotest-install-packages-deps >> $LOG 2>&1
     if [ $? != 0 ]
     then
@@ -566,8 +566,7 @@ fi
 }
 
 setup_firewall_firewalld() {
-    echo "Opening firewall for http traffic" >> $LOG
-    echo "Opening firewall for http traffic"
+    print_log "INFO" "Adding firewalld service"
 
     $ATHOME/installation_support/autotest-firewalld-add-service -s http
     firewall-cmd --reload
@@ -576,8 +575,7 @@ setup_firewall_firewalld() {
 setup_firewall_iptables() {
 if [ "$(grep -- '--dport 80 -j ACCEPT' /etc/sysconfig/iptables)" = "" ]
 then
-    echo "Opening firewall for http traffic" >> $LOG
-    echo "Opening firewall for http traffic"
+    print_log "INFO" "Opening firewall for http traffic"
     awk '/-A INPUT -i lo -j ACCEPT/ { print; print "-A INPUT -m state --state NEW -m tcp -p tcp --dport 80 -j ACCEPT"; next}
 {print}' /etc/sysconfig/iptables > /tmp/tmp$$
     if [ ! -f /etc/sysconfig/iptables.orig ]
@@ -645,7 +643,8 @@ full_install() {
         setup_substitute
         install_basic_pkgs_deb
     else
-        print_log "Sorry, I can't recognize your distro, exiting..."
+        print_log "ERROR" "Sorry, I can't recognize your distro, exiting..."
+        exit 1
     fi
 
     if [ $INSTALL_PACKAGES_ONLY == 0 ]

--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -27,6 +27,7 @@ Currently tested systems - Up to date versions of:
  * Fedora 16
  * Fedora 17
  * Fedora 18
+ * RHEL 7.1
  * RHEL 6.2
  * Ubuntu 12.04
  * Ubuntu 12.10
@@ -223,6 +224,10 @@ then
         then
             print_log "INFO" "Adding EPEL 6 repository"
             rpm -ivh http://download.fedoraproject.org/pub/epel/6/`arch`/epel-release-6-8.noarch.rpm >> $LOG 2>&1
+        elif [ "`grep 'release 7' /etc/redhat-release`" != "" ]
+        then
+            print_log "INFO" "Adding EPEL 7 repository"
+            rpm -ivh http://download.fedoraproject.org/pub/epel/7/`arch`/e/epel-release-7-5.noarch.rpm >> $LOG 2>&1
         fi
     fi
 fi
@@ -249,7 +254,7 @@ install_basic_pkgs_deb() {
     fi
 }
 
-install_packages() {
+_install_packages() {
     print_log "INFO" "Installing packages dependencies"
     print_log "INFO" "Please note that autotest is compatible with Django $DJANGO_SUPPORTED_VERSION"
     print_log "INFO" "If your distro/local install is different, you WILL have problems"
@@ -260,6 +265,28 @@ install_packages() {
         print_log "ERROR" "Failed to install autotest packages dependencies"
         exit 1
     fi
+}
+
+install_packages_deb() {
+_install_packages
+}
+
+install_packages_rh() {
+_install_packages
+if [ ! -z "$(grep "release 7" /etc/redhat-release)" ]
+then
+    # These packages must be obtained from python pip:
+    # python-atfork
+    # python-autopep8
+    # python-django-south
+    #
+    pip install --allow-all-external --allow-unverified atfork atfork autopep8 South
+    if [ $? != 0 ]
+    then
+        print_log "ERROR" "Failed to install autotest package dependencies (install_packages_rh)"
+        exit 1
+    fi
+fi
 }
 
 setup_selinux() {
@@ -674,7 +701,7 @@ full_install() {
             setup_selinux
             create_autotest_user_rh
             install_autotest
-            install_packages
+            install_packages_rh
             setup_db_service_rh
             restart_db_rh
             check_db_password
@@ -698,7 +725,7 @@ full_install() {
         then
             create_autotest_user_deb
             install_autotest
-            install_packages
+            install_packages_deb
             setup_db_service_deb
             restart_db_deb
             check_db_password

--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -36,7 +36,7 @@ Current version of Django supported by autotest: 1.5
 GENERAL OPTIONS:
    -h      Show this message
    -u      Autotest user password
-   -d      MySQL password (both mysql root and autotest_web db)
+   -d      Database password (both mysql root and autotest_web db)
    -a      Autotest base dir (defaults to $ATHOME_DEFAULT)
    -g      Autotest git repo (defaults to $AUTOTEST_DEFAULT_GIT_REPO)
    -b      Autotest git branch (defaults to $AUTOTEST_DEFAULT_GIT_BRANCH)
@@ -280,18 +280,18 @@ then
 fi
 }
 
-setup_mysql_service_deb() {
-print_log "INFO" "Enabling MySQL server on boot"
+setup_db_service_deb() {
+print_log "INFO" "Enabling $DB_NAME server on boot"
 update-rc.d mysql defaults >> $LOG
 }
 
-setup_mysql_service_rh() {
-print_log "INFO" "Enabling MySQL server on boot"
-if [ -x /etc/init.d/mysqld ]
+setup_db_service_rh() {
+print_log "INFO" "Enabling $DB_NAME server on boot"
+if [ -x /etc/init.d/$DB_SERVICE ]
 then
-    chkconfig --level 2345 mysqld on >> $LOG
+    chkconfig --level 2345 $DB_SERVICE on >> $LOG
 else
-    systemctl enable mysqld.service >> $LOG
+    systemctl enable $DB_SERVICE >> $LOG
 fi
 }
 
@@ -370,25 +370,25 @@ $ATHOME/installation_support/autotest-install-packages-deps >> $LOG 2>&1
 }
 
 
-check_mysql_password() {
-print_log "INFO" "Setting MySQL root password"
+check_db_password() {
+print_log "INFO" "Setting $DB_NAME root password"
 mysqladmin -u root password $MYSQLPW > /dev/null 2>&1
 
-print_log "INFO" "Verifying MySQL root password"
+print_log "INFO" "Verifying $DB_NAME root password"
 $ATHOME/installation_support/autotest-database-turnkey --check-credentials --root-password=$MYSQLPW
 if [ $? != 0 ]
 then
-    print_log "ERROR" "MySQL already has a different root password"
+    print_log "ERROR" "$DB_NAME already has a different root password"
     exit 1
 fi
 }
 
 create_autotest_database() {
-print_log "INFO" "Creating MySQL databases for autotest"
+print_log "INFO" "Creating $DB_NAME databases for autotest"
 $ATHOME/installation_support/autotest-database-turnkey -s --root-password=$MYSQLPW -p $MYSQLPW > /dev/null 2>&1
 if [ $? != 0 ]
 then
-    print_log "ERROR" "Error creating MySQL database"
+    print_log "ERROR" "Error creating $DB_NAME database"
     exit 1
 fi
 }
@@ -467,18 +467,18 @@ else
 fi
 }
 
-restart_mysql_deb() {
-print_log "INFO" "Re-starting MySQL server"
+restart_db_deb() {
+print_log "INFO" "Re-starting $DB_NAME server"
 service mysql restart >> $LOG
 }
 
-restart_mysql_rh() {
-print_log "INFO" "Re-starting MySQL server"
-if [ -x /etc/init.d/mysqld ]
+restart_db_rh() {
+print_log "INFO" "Re-starting $DB_NAME server"
+if [ -x /etc/init.d/$DB_SERVICE ]
 then
-    service mysqld restart >> $LOG
+    service $DB_SERVICE restart >> $LOG
 else
-    systemctl restart mysqld.service >> $LOG
+    systemctl restart $DB_SERVICE >> $LOG
 fi
 }
 
@@ -624,6 +624,24 @@ IP="$(ip address show dev $DEFAULT_INTERFACE | grep 'inet ' | awk '{print $2}' |
 print_log "INFO" "You can access your server on http://$IP/afe"
 }
 
+set_database_deb() {
+DB_SERVICE=mysqld
+DB_NAME="MySQL"
+}
+
+set_database_rh() {
+if [ ! -z "$(grep "release 6" /etc/redhat-release)" ]
+then
+    DB_SERVICE=mysqld
+    DB_NAME="MySQL"
+elif [ ! -z "$(grep "release 7" /etc/redhat-release)" ]
+then
+    DB_SERVICE=mariadb.service
+    DB_NAME="mariadb"
+    /usr/local/bin/substitute "mysqld.service" $DB_SERVICE $ATHOME/utils/autotestd.service
+fi
+}
+
 full_install() {
     check_command_line_params
 
@@ -637,11 +655,13 @@ full_install() {
         setup_substitute
         setup_epel_repo
         install_basic_pkgs_rh
+        set_database_rh
     elif [ -f /etc/debian_version ]
     then
         check_disk_space
         setup_substitute
         install_basic_pkgs_deb
+        set_database_deb
     else
         print_log "ERROR" "Sorry, I can't recognize your distro, exiting..."
         exit 1
@@ -655,16 +675,16 @@ full_install() {
             create_autotest_user_rh
             install_autotest
             install_packages
-            setup_mysql_service_rh
-            restart_mysql_rh
-            check_mysql_password
+            setup_db_service_rh
+            restart_db_rh
+            check_db_password
             create_autotest_database
             build_external_packages
             relocate_global_config
             relocate_frontend_wsgi
             relocate_webserver
             configure_webserver_rh
-            restart_mysql_rh
+            restart_db_rh
             patch_python27_bug
             build_web_rpc_client
             import_tests
@@ -679,16 +699,16 @@ full_install() {
             create_autotest_user_deb
             install_autotest
             install_packages
-            setup_mysql_service_deb
-            restart_mysql_deb
-            check_mysql_password
+            setup_db_service_deb
+            restart_db_deb
+            check_db_password
             create_autotest_database
             build_external_packages
             relocate_global_config
             relocate_frontend_wsgi
             relocate_webserver
             configure_webserver_deb
-            restart_mysql_deb
+            restart_db_deb
             build_web_rpc_client
             import_tests
             restart_apache_deb

--- a/frontend/pkgdeps.py
+++ b/frontend/pkgdeps.py
@@ -37,6 +37,33 @@ FEDORA_REDHAT_PKGS = [
     'passwd',
     'pylint']
 
+FEDORA_REDHAT_7_PKGS = [
+    'MySQL-python',
+    'git',
+    'httpd',
+    'java-1.7.0-openjdk-devel',
+    'mod_wsgi',
+    'mariadb-server',
+    'numpy',
+    'passwd',
+    'policycoreutils-python',
+    'protobuf-compiler',
+    'protobuf-python',
+    'pylint',
+    'python-pip',
+    'python-crypto',
+    'python-httplib2',
+    'python-pillow',
+    'python-matplotlib',
+    'python-paramiko',
+    'python-psutil',
+    'selinux-policy',
+    'selinux-policy-targeted',
+    'tar',
+    'unzip',
+    'urw-fonts',
+    'wget',
+]
 
 FEDORA_19_PKGS = [
     'MySQL-python',
@@ -102,4 +129,5 @@ PKG_DEPS = {'fedora': FEDORA_REDHAT_PKGS,
             'centos': FEDORA_REDHAT_PKGS,
             'debian': UBUNTU_PKGS,
             'ubuntu': UBUNTU_PKGS,
-            distro.Spec('fedora', 19): FEDORA_19_PKGS}
+            distro.Spec('fedora', 19): FEDORA_19_PKGS,
+            distro.Spec('redhat', 7): FEDORA_REDHAT_7_PKGS}


### PR DESCRIPTION
Add installation support for Red Hat Enterprise Linux 7.1

This series of patches cleans up the use of the print_log procedure, refactors the human-readable database package name, and finally, refactors the installation procedure into one for debian, one for fedora, and a common utility function for both.

With these changes I am able to run the autotest installation procedure on RHEL-7.1 and get a working configuration.

Signed-off-by: Jeff E. Nelson <jnmnus@yahoo.com>

