### PR TITLE
[V2] RHEL 7 support

### DIFF
--- a/contrib/install-autotest-server.sh
+++ b/contrib/install-autotest-server.sh
@@ -253,7 +253,7 @@ install_packages() {
     print_log "INFO" "Installing packages dependencies"
     print_log "INFO" "Please note that autotest is compatible with Django $DJANGO_SUPPORTED_VERSION"
     print_log "INFO" "If your distro/local install is different, you WILL have problems"
-    print log "INFO" "Please stick with $DJANGO_SUPPORTED_VERSION for the time being"
+    print_log "INFO" "Please stick with $DJANGO_SUPPORTED_VERSION for the time being"
     $ATHOME/installation_support/autotest-install-packages-deps >> $LOG 2>&1
     if [ $? != 0 ]
     then
@@ -566,8 +566,7 @@ fi
 }
 
 setup_firewall_firewalld() {
-    echo "Opening firewall for http traffic" >> $LOG
-    echo "Opening firewall for http traffic"
+    print_log "INFO" "Adding firewalld service"
 
     $ATHOME/installation_support/autotest-firewalld-add-service -s http
     firewall-cmd --reload
@@ -576,8 +575,7 @@ setup_firewall_firewalld() {
 setup_firewall_iptables() {
 if [ "$(grep -- '--dport 80 -j ACCEPT' /etc/sysconfig/iptables)" = "" ]
 then
-    echo "Opening firewall for http traffic" >> $LOG
-    echo "Opening firewall for http traffic"
+    print_log "INFO" "Opening firewall for http traffic"
     awk '/-A INPUT -i lo -j ACCEPT/ { print; print "-A INPUT -m state --state NEW -m tcp -p tcp --dport 80 -j ACCEPT"; next}
 {print}' /etc/sysconfig/iptables > /tmp/tmp$$
     if [ ! -f /etc/sysconfig/iptables.orig ]
@@ -645,7 +643,8 @@ full_install() {
         setup_substitute
         install_basic_pkgs_deb
     else
-        print_log "Sorry, I can't recognize your distro, exiting..."
+        print_log "ERROR" "Sorry, I can't recognize your distro, exiting..."
+        exit 1
     fi
 
     if [ $INSTALL_PACKAGES_ONLY == 0 ]

--- a/frontend/pkgdeps.py
+++ b/frontend/pkgdeps.py
@@ -37,6 +37,33 @@ FEDORA_REDHAT_PKGS = [
     'passwd',
     'pylint']
 
+FEDORA_REDHAT_7_PKGS = [
+    'MySQL-python',
+    'git',
+    'httpd',
+    'java-1.7.0-openjdk-devel',
+    'mod_wsgi',
+    'mariadb-server',
+    'numpy',
+    'passwd',
+    'policycoreutils-python',
+    'protobuf-compiler',
+    'protobuf-python',
+    'pylint',
+    'python-pip',
+    'python-crypto',
+    'python-httplib2',
+    'python-pillow',
+    'python-matplotlib',
+    'python-paramiko',
+    'python-psutil',
+    'selinux-policy',
+    'selinux-policy-targeted',
+    'tar',
+    'unzip',
+    'urw-fonts',
+    'wget',
+]
 
 FEDORA_19_PKGS = [
     'MySQL-python',
@@ -52,7 +79,6 @@ FEDORA_19_PKGS = [
     'protobuf-python',
     'pylint',
     'python-atfork',
-    'python-autopep8',
     'python-crypto',
     'python-django14',
     'python-django-south',
@@ -77,7 +103,6 @@ UBUNTU_PKGS = [
     'makepasswd',
     'mysql-server',
     'openjdk-7-jre-headless',
-    'python-autopep8',
     'python-crypto',
     'python-django',
     'python-django-south',
@@ -102,4 +127,5 @@ PKG_DEPS = {'fedora': FEDORA_REDHAT_PKGS,
             'centos': FEDORA_REDHAT_PKGS,
             'debian': UBUNTU_PKGS,
             'ubuntu': UBUNTU_PKGS,
-            distro.Spec('fedora', 19): FEDORA_19_PKGS}
+            distro.Spec('fedora', 19): FEDORA_19_PKGS,
+            distro.Spec('redhat', 7): FEDORA_REDHAT_7_PKGS}


### PR DESCRIPTION
This is a follow up to #909.

Add installation support for Red Hat Enterprise Linux 7.1

This series of patches cleans up the use of the print_log procedure, refactors the human-readable database package name, and finally, refactors the installation procedure into one for debian, one for fedora, and a common utility function for both.

With these changes I am able to run the autotest installation procedure on RHEL-7.1 and get a working configuration.

Signed-off-by: Jeff E. Nelson <jnmnus@yahoo.com>
