### PR TITLE
setup.py: include a setup module for shared module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ except ImportError:
 
 # High level way of installing each autotest component
 import client.setup
+import shared.setup
 import frontend.setup
 import cli.setup
 import server.setup
@@ -65,6 +66,7 @@ def _fix_data_paths(package_data_dict):
 
 def get_package_dir():
     return _combine_dicts([client.setup.get_package_dir(),
+                           shared.setup.get_package_dir(),
                            frontend.setup.get_package_dir(),
                            cli.setup.get_package_dir(),
                            server.setup.get_package_dir(),
@@ -77,6 +79,7 @@ def get_package_dir():
 
 def get_packages():
     return (client.setup.get_packages() +
+            shared.setup.get_packages() +
             frontend.setup.get_packages() +
             cli.setup.get_packages() +
             server.setup.get_packages() +

--- a/shared/common.py
+++ b/shared/common.py
@@ -1,0 +1,15 @@
+import os
+import sys
+try:
+    import autotest.client.setup_modules as setup_modules
+    dirname = os.path.dirname(setup_modules.__file__)
+    autotest_dir = os.path.join(dirname, "..")
+except ImportError:
+    dirname = os.path.dirname(sys.modules[__name__].__file__)
+    autotest_dir = os.path.abspath(os.path.join(dirname, ".."))
+    client_dir = os.path.join(autotest_dir, "client")
+    sys.path.insert(0, client_dir)
+    import setup_modules
+    sys.path.pop(0)
+
+setup_modules.setup(base_path=autotest_dir, root_module_name="autotest")

--- a/shared/setup.py
+++ b/shared/setup.py
@@ -1,0 +1,39 @@
+# pylint: disable=E0611
+from distutils.core import setup
+import os
+
+try:
+    import autotest.common as common
+except ImportError:
+    import common
+
+from autotest.client.shared import version
+
+# Mostly needed when called one level up
+if os.path.isdir('shared'):
+    pkg_dir = 'shared'
+else:
+    pkg_dir = '.'
+
+
+def get_package_dir():
+    return {'autotest.shared': pkg_dir}
+
+
+def get_packages():
+    return ['autotest.shared']
+
+
+def run():
+    setup(name='autotest',
+          description='Autotest test framework - common definitions',
+          maintainer='Lucas Meneghel Rodrigues',
+          author_email='lmr@redhat.com',
+          version=version.get_version(),
+          url='http://autotest.github.com',
+          package_dir=get_package_dir(),
+          packages=get_packages())
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
That module is used for definitions that are common to both autotest
(RPC) server and clients.

Signed-off-by: Cleber Rosa <crosa@redhat.com>