### PR TITLE
client/shared/distro_def.py: Remove pylint W0142

### DIFF
--- a/client/shared/distro_def.py
+++ b/client/shared/distro_def.py
@@ -47,7 +47,7 @@ def load(path):
     return pickle.loads(bz2.decompress(open(path).read()))
 
 
-# pylint: disable=I0011,R0913,W0142
+# pylint: disable=I0011,R0913
 def load_from_tree(name, version, release, arch,
                    package_type, path):
     '''


### PR DESCRIPTION
Which doesn't seem to exist anymore and is causing CI failures.

Signed-off-by: Cleber Rosa <crosa@redhat.com>