### PR TITLE
client/shared/utils.py: Add hugetlbfs for is_mounted()

### DIFF
--- a/client/shared/utils.py
+++ b/client/shared/utils.py
@@ -3162,7 +3162,7 @@ def is_mounted(src, mount_point, fstype, perm=None, verbose=True,
         fstype_mtab = fstype
 
     mount_point = os.path.realpath(mount_point)
-    if fstype not in ['nfs', 'smbfs', 'glusterfs']:
+    if fstype not in ['nfs', 'smbfs', 'glusterfs', 'hugetlbfs']:
         if src:
             src = os.path.realpath(src)
         else:


### PR DESCRIPTION
hugetlbfs should be treated as same as 'nfs', 'smbfs'
and 'glusterfs'.