### PR TITLE
Fix git issue with branch different than master.

### DIFF
--- a/client/shared/git.py
+++ b/client/shared/git.py
@@ -18,7 +18,7 @@ class GitRepoHelper(object):
     Helps to deal with git repos, mostly fetching content from a repo
     '''
 
-    def __init__(self, uri, branch='master', lbranch='master', commit=None,
+    def __init__(self, uri, branch='master', lbranch=None, commit=None,
                  destination_dir=None, base_uri=None):
         '''
         Instantiates a new GitRepoHelper
@@ -163,7 +163,7 @@ class GitRepoHelper(object):
         self.checkout()
 
 
-def get_repo(uri, branch='master', lbranch='master', commit=None,
+def get_repo(uri, branch='master', lbranch=None, commit=None,
              destination_dir=None, base_uri=None):
     """
     Utility function that retrieves a given git code repository.
@@ -182,6 +182,8 @@ def get_repo(uri, branch='master', lbranch='master', commit=None,
     :param uri: a closer, usually local, git repository url from where to
                 fetch content first from
     """
+    if lbranch is None:
+        lbranch = branch
     repo = GitRepoHelper(uri, branch, lbranch, commit, destination_dir,
                          base_uri)
     repo.execute()


### PR DESCRIPTION
When setting to fetch from a remote branch different than master, the
local repository is not enable to checkout to the branch due to hardcode
name 'master' used to setup the local branch name.

This patch changes the default name of lbranch variables from 'master'
to be None, and then setup in code the value to be the same of remote
branch name, usually specified by user and as already explained in
documentation.

Signed-off-by: Paulo Vital <paulo.vital@profitbricks.com>