### PR TITLE
Manual: fix typo

### DIFF
--- a/CODING_STYLE
+++ b/CODING_STYLE
@@ -156,7 +156,7 @@ Simple code
 
 Keep it simple; this is not the right place to show how smart you are. We
 have plenty of system failures to deal with without having to spend ages
-figuring out your code, thanks ;-) Readbility, readability, readability.
+figuring out your code, thanks ;-) Readability, readability, readability.
 I really don't care if other things are more compact.
 
 "Debugging is twice as hard as writing the code in the first place. Therefore,

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ tests or setup a fully automated test grid, depending on what you are up to.
 A non extensive list of modules is:
 
 * Autotest client: The engine that executes the tests (dir client). Each
-  autotest test is a a directory inside (client/tests) and it is represented
+  autotest test is a directory inside (client/tests) and it is represented
   by a python class that implements a minimum number of methods. The client
   is what you need if you are a single developer trying out autotest and executing
   some tests. Autotest client executes ''client side control files'', which are


### PR DESCRIPTION
* CODING_STYLE: s/Readbility/Readability/g
* README.rst  : delete the surplus letter 'a'