### PR TITLE
autotest.client.shared: Update the kernel support check method

### DIFF
--- a/client/shared/iso9660.py
+++ b/client/shared/iso9660.py
@@ -76,7 +76,7 @@ def can_mount():
         logging.debug('Can not use mount: missing "mount" tool')
         return False
 
-    if 'iso9660' not in open('/proc/filesystems').read():
+    if 'iso9660' not in open('/proc/kallsyms').read():
         logging.debug('Can not use mount: lack of iso9660 kernel support')
         return False
 


### PR DESCRIPTION
As /proc/filesystems only show the supported file system by running
kernel. So iso9660 will not show up if no cdrom or iso is already
mounted. So use kallsyms instead of this file to check it.