### PR TITLE
os_dep: refactor into common functions

### DIFF
--- a/client/os_dep.py
+++ b/client/os_dep.py
@@ -1,71 +1,523 @@
+#!/usr/bin/env python
+
+#  Copyright(c) 2013-2015 Intel Corporation.
+#
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms and conditions of the GNU General Public License,
+#  version 2, as published by the Free Software Foundation.
+#
+#  This program is distributed in the hope it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU General Public License along with
+#  this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#  The full GNU General Public License is included in this distribution in
+#  the file called "COPYING".
+
+
 import os
-import glob
+import itertools
+import logging
+from glob import glob
 
+try:
+    import autotest.common as common
+except ImportError:
+    import common
+
+try:
+    next(iter(''), '')
+except NameError:
+    from autotest.client.shared.backports import next
+
+# One day, when this module grows up, it might actually try to fix things.
+# 'apt-cache search | apt-get install' ... or a less terrifying version of
+# the same. With added distro-independant pixie dust.
+
+COMMON_BIN_PATHS = ("/usr/libexec", "/usr/local/sbin", "/usr/local/bin",
+                    "/usr/sbin", "/usr/bin", "/sbin", "/bin")
+
+
+def exception_when_false_wrapper(func, exception_class, value_error_message_template):
+    """
+    Wrap a function to raise an exception when the return value is not True.
+
+    :param func: function to wrap
+    :type func: function
+    :param exception_class: exception class to raise
+    :type exception_class: Exception
+    :param value_error_message_template: string to pass to exception
+    :type value_error_message_template: str
+    :return: wrapped function
+    :rtype: function
+    :raise exception_class: when func returns not true
+    """
+
+    def g(target, *args, **kwargs):
+        val = func(target, *args, **kwargs)
+        if val:
+            return val
+        else:
+            raise exception_class(value_error_message_template % target)
+    g.__name__ = func.__name__
+    g.__doc__ = func.__doc__
+    return g
+
+
+def path_joiner(target, search_paths):
+    """
+    Create a generator that joins target to each search path
+
+    :param target: filename to join to each search path
+    :type target: str
+    :param search_paths: iterator over all the search paths
+    :type search_paths: iterator
+    :return: iterator over all the joined paths
+    :rtype: iterator
+    """
+    return (os.path.join(path, target) for path in search_paths)
+
+
+def is_file_and_rx(pth):
+    """
+    :param pth: path to check
+    :return: true if the path is a file and R_OK & X_OK
+    :rtype: bool
+    """
+    return os.path.isfile(pth) and os.access(pth, os.R_OK & os.X_OK)
+
+
+def is_file_and_readable(pth):
+    """
+    :param pth: path to check
+    :return: true if the path is a file and R_OK
+    :rtype: bool
+    """
+    return os.path.isfile(pth) and os.access(pth, os.R_OK)
+
+
+def make_path_searcher(path_generator, target_predicate, target_normalizer, extra_paths, **kwargs):
+    """
+    Universal search function generator using lazy evaluation.
+
+    Generate a function that will iterate over all the paths from path_generator using
+    target_predicate to filter matching paths.  Each matching path is then noramlized by target_predicate.
+    Only the first match is returned.
+
+    :param path_generator: all paths to test with target_predicate
+    :type path_generator: iterator
+    :param target_predicate: boolean function that tests a given path
+    :type target_predicate: function
+    :param target_normalizer: function that transforms a matching path to some noramlized form
+    :type target_normalizer: function
+    :param extra_paths: extra paths to pass to the path_generator
+    :type extra_paths: iterator
+    :return: the path searching function
+    :rtype:  function
+    """
+
+    def path_searcher(target, extra_dirs=extra_paths):
+        matches = itertools.ifilter(
+            target_predicate, path_generator(target, extra_dirs, **kwargs))
+        paths = itertools.imap(target_normalizer, matches)
+        return next(paths, '')
+    return path_searcher
+
+
+def unique_not_false_list(arg_paths):
+    # probably better than an ordered dict or ordered set
+    included = set()
+    # preserve ordering while filtering out duplicates
+    search_paths = []
+    for p in arg_paths:
+        # remove any empty paths
+        if p and p not in included:
+            included.add(p)
+            search_paths.append(p)
+    return search_paths
+
+
+def generate_bin_search_paths(program, extra_dirs):
+    """
+    Generate full paths of potential locations of a given binary file based on
+    COMMON_BIN_PATHS.
+
+    Use the enviroment variable $PATH seed the list of search directories.
+
+    :param program: library filename to join with all search directories
+    :type program: str
+    :param extra_dirs: extra directories to append to the directory search list
+    :type extra_dirs: str
+    :return: iterator over all generated paths
+    :rtype: iter
+    """
+    # relative paths are accepted so don't use os.path.isabs()
+    if os.sep in program:
+        # if program already contains path then only check that path
+        # e.g. `which bin/more` will succeed from /
+        paths = [program]
+    else:
+        # `which` fails if PATH is empty, replicate this by returning '' when PATH is empty
+        # such that ''.split(os.pathsep) == [''] which is filtered out
+        arg_paths = itertools.chain(
+            os.environ.get('PATH', '').split(os.pathsep), extra_dirs)
+        # remove any empty paths and duplicates
+        search_paths = unique_not_false_list(arg_paths)
+        paths = path_joiner(program, search_paths)
+    return paths
+
+
+which = make_path_searcher(
+    generate_bin_search_paths, is_file_and_rx, os.path.abspath, COMMON_BIN_PATHS)
+which.__name__ = "which"
+which.__doc__ = """
+Find a program by searching in the environment path and in common binary paths.
+
+check both if it is a file and executable
+`which` always returns the abspath
+return '' if failure because '' is well-defined NULL path, so it is
+better than None or ValueError
+
+:param program: command name or path to command
+:type program: str
+:param extra_dirs: iterable of extra paths to search
+:type extra_dirs: iterble
+:return: abspath of command if found, else ''
+:rtype: str
 """
-One day, when this module grows up, it might actually try to fix things.
-'apt-cache search | apt-get install' ... or a less terrifying version of
-the same. With added distro-independant pixie dust.
+
+command = exception_when_false_wrapper(
+    which, ValueError, 'Missing command: %s')
+command.__name__ = "command"
+command.__doc__ = """
+Find a program by searching in the environment path and in common binary paths.
+
+check both if it is a file and executable
+`which` always returns the abspath
+return '' if failure because '' is well-defined NULL path, so it is
+better than None or ValueError
+
+:param program: command name or path to command
+:type program: str
+:param extra_dirs: iterable of extra paths to search
+:type extra_dirs: iterable
+:return: abspath of command if found
+:rtype: str
+:exception ValueError: when program not found
 """
-
-
-def command(cmd):
-    for directory in os.environ.get('PATH', '').split(':'):
-        filepath = os.path.join(directory, cmd)
-        if os.path.exists(filepath):
-            return filepath
-    raise ValueError('Missing command: %s' % cmd)
 
 
 def commands(*cmds):
-    results = []
-    for cmd in cmds:
-        results.append(command(cmd))
+    return [command(c) for c in cmds]
+
+# Don't be smart and try to guess the architecture because we could be
+# on a multi-arch system
+COMMON_LIB_BASE_PATHS = ['/lib', '/usr/lib', '/lib64', '/usr/lib64']
+# the TLS hwcap is always added by ldconfig, so pre-generate the tls paths
+# ldconfig.c:1276:   hwcap_extra[63 - _DL_FIRST_EXTRA] = "tls";
+COMMON_LIB_TLS_PATHS = [os.path.join(p, 'tls') for p in COMMON_LIB_BASE_PATHS]
+# convert to tuple so when used as default argument it is not mutable
+COMMON_LIB_PATHS = tuple(COMMON_LIB_BASE_PATHS + COMMON_LIB_TLS_PATHS)
 
 
-def library(lib):
-    lddirs = []
-    # read lddirs from  main ld.so.conf file
-    for line in open('/etc/ld.so.conf', 'r').readlines():
-        line = line.strip()
-        if line.startswith('include '):
-            glob_pattern = line.split('include ')[1]
-            if not os.path.isabs(glob_pattern):
-                # prepend with a base path of '/etc'
-                glob_pattern = os.path.join('/etc', glob_pattern)
-            glob_result = glob.glob(glob_pattern)
-            for conf_file in glob_result:
-                for conf_file_line in open(conf_file, 'r').readlines():
-                    if os.path.isdir(conf_file_line.strip()):
-                        lddirs.append(conf_file_line.strip())
+class Ldconfig(object):
+
+    LD_SO_CONF = "/etc/ld.so.conf"
+    MAX_RECURSION_DEPTH = 20
+
+    class DirEntry(object):
+
+        def __init__(self, path, flag, ino, dev):
+            """
+            Replica of ldconfig.c struct dir_entry.  Meant to hold ldconfig directories.
+            In order to detect duplicates the inode and device number are compared on insert.
+            /* List of directories to handle.  */
+            struct dir_entry
+            {
+              char *path;
+              int flag;
+              ino64_t ino;
+              dev_t dev;
+              struct dir_entry *next;
+            };
+            :param path: library path
+            :type path: str
+            :param flag: string like 'libc4','libc5', 'libc6', 'glibc2'
+            :type flag: str
+            :param ino: inode number
+            :type ino: int
+            :param dev: id of device containing file
+            :type dev: long
+            """
+            self.path = path
+            self.flag = flag
+            self.ino = ino
+            self.dev = dev
+
+        def __eq__(self, other):
+            """
+            Compare DirEntry based only on inode and device number
+
+            :param other: other DirEntry
+            :type other: DirEntry
+            :return: True iff ino and dev are equal
+            :rtype: bool
+            """
+            return self.ino == other.ino and self.dev == other.dev
+
+        def __ne__(self, other):
+            return not self == other
+
+        def __repr__(self):
+            return self.__class__.__name__ + "(%(path)r, %(flag)r, %(ino)r, %(dev)r)" % vars(self)
+
+    def __init__(self):
+        """
+        This class is meant duplicate the behaviour of ldconfig and parse
+        /etc/ld.so.conf and all the related config files Since the only specification
+        for ldconfig is in the source code, this class is as much as possible a
+        line-by-line direct translation from the C to Python.
+
+        Currently we attempt to preserve the following behaviours, with caveats
+
+        * include parsing is recursive, included files can include /etc/ld.so.conf,
+          ldconfig.c has it's recursion depth limited by the process max file open
+          limit.  We artifically limit the recursion depth to MAX_RECURSION_DEPTH
+
+        * The library type suffix, .e.g. '/usr/lib/foo=glibc2' is correctly parsed and
+          stored.  There can be any amount of whitespace between the end of the path
+          and the type suffix.  We do not overwrite duplicate paths with new flag
+          information.
+
+        * hwcap is currently ignored.  Ideally we would parse the hwcap and add those
+          directories to the search path based on runtime parsing of the HW
+          capabilities set in /proc/cpuinfo, but that is not implemented.
+
+        * The hardcoded hwcap of 'tls' is added to COMMON_LIB_PATHS during runtime
+          constant definition.  This means we search /usr/lib64/tls by default.
+
+        This current translation is based on elf/ldconfig.c from glibc-2.16-34.fc18.src.rpm
+
+        """
+        self.lddirs = []
+
+    def _parse_config_line(self, config_file, filename, recursion):
+        for line in config_file:
+            line = line.strip()
+            line = line.split('#')[0]
+            if not line:
+                continue
+            # hardcoded to 'include' + space
+            if line.startswith('include '):
+                glob_patterns = line.split('include ')[1]
+                # include supports multiple files split by whitespace
+                for glob_pattern in glob_patterns.split():
+                    self._parse_conf_include(
+                        filename, glob_pattern, recursion)
+            # hardcoded to 'hwcap' + space
+            elif line.startswith("hwcap "):
+                # ignore hwcap lines, but they do point to alternate directories
+                # based on runtime processor capabilities in /proc/cpuinfo
+                # .e.g. hwcap 0 nosegneg would add /lib/i686/nosegneg/libc.so.6
+                continue
+            else:
+                self._add_dir(line)
+
+    def parse_conf(self, filename=LD_SO_CONF, recursion=0):
+        # print filename
+        if recursion < self.MAX_RECURSION_DEPTH:
+            # read lddirs from  main ld.so.conf file
+            try:
+                config_file = open(filename, 'r')
+            except IOError:
+                return
+            try:
+                self._parse_config_line(config_file, filename, recursion)
+            finally:
+                config_file.close()
+
+    def _parse_conf_include(self, filename, glob_pattern, recursion):
+        # os.path.dirname will succeed if os.sep is in filename
+        if not os.path.isabs(glob_pattern) and os.sep in filename:
+            # prepend with dirname of filename, e.g. /etc if /etc/ld.so.conf
+            glob_pattern = os.path.join(
+                os.path.dirname(filename), glob_pattern)
+        glob_result = glob(glob_pattern)
+        for conf_file in glob_result:
+            # increment recusion so can limit depth
+            self.parse_conf(conf_file, recursion + 1)
+
+    def _add_single_dir(self, new_dir_entry):
+        if new_dir_entry in self.lddirs:
+            logging.debug("Path %s given more than once", new_dir_entry.path)
         else:
-            if os.path.isdir(line):
-                lddirs.append(line)
+            self.lddirs.append(new_dir_entry)
 
-    lddirs = set(lddirs)
-    lddirs = list(lddirs)
+    def _add_dir(self, line):
+        # extract lib_type suffix, e.g. 'dirname=TYPE' where TYPE is in 'libc4',
+        # 'libc5', 'libc6', 'glibc2'
+        if '=' in line:
+            path, flag = line.split('=', 1)
+        else:
+            path = line
+            flag = ''
+        path = path.rstrip()
+        path = path.rstrip(os.sep)
+        try:
+            stat = os.stat(path)
+            de = Ldconfig.DirEntry(path, flag, stat.st_ino, stat.st_dev)
+            self._add_single_dir(de)
+        except (IOError, OSError):
+            logging.debug("Can't stat %s", path)
 
-    for dir in ['/lib', '/usr/lib', '/lib64', '/usr/lib64'] + lddirs:
-        file = os.path.join(dir, lib)
-        if os.path.exists(file):
-            return file
-    raise ValueError('Missing library: %s' % lib)
+    def ldconfig(self, ld_so_conf_filename=LD_SO_CONF, extra_dirs=COMMON_LIB_PATHS):
+        """
+        Read and parse /etc/ld.so.conf to generate a list of directories that ldconfig would search.
+        Pre-seed the search directory list with ('/lib', '/usr/lib', '/lib64', '/usr/lib64')
+
+        :param ld_so_conf_filename: path to /etc/ld.so.conf
+        :type ld_so_conf_filename: str
+        :param extra_dirs:
+        :type extra_dirs: iterable
+        :return: iterator over the directories found
+        :rtype: iterable
+        """
+        self.lddirs = []
+        for d in extra_dirs:
+            self._add_dir(d)
+        self.parse_conf(ld_so_conf_filename)
+        # only return the paths
+        return (ld.path for ld in self.lddirs)
+
+
+def generate_library_search_paths(lib, extra_dirs=COMMON_LIB_PATHS, ld_so_conf_filename=Ldconfig.LD_SO_CONF):
+    """
+    Generate full paths of potential locations of a given library file based on
+    COMMON_LIB_PATHS.
+
+    :param lib: library filename to join with all search directories
+    :type lib: str
+    :param extra_dirs: extra directories to append to the directory search list
+    :type extra_dirs: iterable
+    :param ld_so_conf_filename: location of /etc/ld.so.conf to parse to find all system library locations
+    :type ld_so_conf_filename: str
+    :return: iterator over all generated paths
+    :rtype: iterable
+    """
+    if os.sep in lib:
+        # is program already contains path then only check that path
+        paths = [lib]
+    else:
+        l = Ldconfig()
+        search_paths = l.ldconfig(ld_so_conf_filename, extra_dirs)
+        paths = path_joiner(lib, search_paths)
+
+    return paths
+
+
+which_library = make_path_searcher(
+    generate_library_search_paths, is_file_and_readable, os.path.abspath, COMMON_LIB_PATHS)
+which_library.__name__ = "which_library"
+which_library.__doc__ = """
+Find a library file by parsing /etc/ld.so.conf and also searcing in the common library search paths, %s
+
+Check both if the library is a file and readable.
+
+:param lib: library file or path to library file, e.g. libc.so.6
+:type lib: str
+:param extra_dirs: iterable of extra paths to search
+:type extra_dirs: iterable
+:return: abspath of library if found, else ''
+:rtype: str
+""" % str(COMMON_LIB_PATHS)
+
+library = exception_when_false_wrapper(
+    which_library, ValueError, 'Missing library: %s')
+library.__name__ = "library"
+library.__doc__ = """
+Find a library file by parsing /etc/ld.so.conf and also searcing in the common library search paths, %s
+
+Check both if the library is a file and readable.
+
+:param lib: library file or path to library file, e.g. libc.so.6
+:type lib: str
+:param extra_dirs: iterable of extra paths to search
+:type extra_dirs: iterable
+:return: abspath of library if found
+:rtype: str
+:exception ValueError: when library is not found
+""" % str(COMMON_LIB_PATHS)
 
 
 def libraries(*libs):
-    results = []
-    for lib in libs:
-        results.append(library(lib))
+    return [library(l) for l in libs]
 
 
-def header(hdr):
-    for dir in ['/usr/include', '/usr/local/include']:
-        file = os.path.join(dir, hdr)
-        if os.path.exists(file):
-            return file
-    raise ValueError('Missing header: %s' % hdr)
+COMMON_HEADER_PATHS = ('/usr/include', '/usr/local/include')
+
+
+def generate_include_search_paths(hdr, extra_dirs):
+    """
+    Generate full paths of potential locations of a given header file based on
+    COMMON_HEADER_PATHS.
+
+    :param hdr: header filename to join with all search directories
+    :type hdr: str
+    :param extra_dirs: extra directories to append to the directory search list
+    :type extra_dirs: iterable
+    :return: iterator over all generated paths
+    :rtype: iterable
+    """
+    if os.sep in hdr:
+        # is program already contains path then only check that path
+        paths = [hdr]
+    else:
+        # `which` fails if PATH is empty, replicate this by returning '' when PATH is empty
+        # such that ''.split(os.pathsep) == [''] which is filtered out
+        arg_paths = itertools.chain(COMMON_HEADER_PATHS, extra_dirs)
+        # remove any empty paths and duplicates
+        search_paths = unique_not_false_list(arg_paths)
+        paths = path_joiner(hdr, search_paths)
+        # `which` always returns the abspath
+    return paths
+
+which_header = make_path_searcher(
+    generate_include_search_paths, is_file_and_readable, os.path.abspath, frozenset([]))
+which_header.__name__ = "which_header"
+which_header.__doc__ = """
+Find a header file by searching in the common include search paths, %s
+
+Check both if the header is a file and readable.
+
+:param hdr: header file or path to header file, e.g. stdio.h
+:type hdr: str
+:param extra_dirs: iterable of extra paths to search
+:type extra_dirs: iterable
+:return: abspath of header if found, else ''
+:rtype: str
+""" % str(COMMON_HEADER_PATHS)
+
+header = exception_when_false_wrapper(
+    which_header, ValueError, 'Missing header: %s')
+header.__name__ = "header"
+header.__doc__ = """
+Find a header file by searching in the common include search paths, %s
+
+Check both if the header is a file and readable.
+
+:param hdr: header file or path to header file, e.g. stdio.h
+:type hdr: str
+:param extra_dirs: iterable of extra paths to search
+:type extra_dirs: iterable
+:return: abspath of header if found
+:rtype: str
+:exception ValueError: when header is not found
+""" % str(COMMON_HEADER_PATHS)
 
 
 def headers(*hdrs):
-    results = []
-    for hdr in hdrs:
-        results.append(header(hdr))
+    return [header(h) for h in hdrs]

--- a/client/os_dep_unittest.py
+++ b/client/os_dep_unittest.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python
+
+#  Copyright(c) 2013-2015 Intel Corporation.
+#
+#  This program is free software; you can redistribute it and/or modify it
+#  under the terms and conditions of the GNU General Public License,
+#  version 2, as published by the Free Software Foundation.
+#
+#  This program is distributed in the hope it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU General Public License along with
+#  this program; if not, write to the Free Software Foundation, Inc.,
+#  51 Franklin St - Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#  The full GNU General Public License is included in this distribution in
+#  the file called "COPYING".
+
+import os
+import unittest
+import sys
+import itertools
+
+from autotest.client.shared.mock import patch, MagicMock, call
+from autotest.client import os_dep
+
+
+def both_true(fun):
+    return patch.object(sys.modules['os'].path, "isfile", return_value=True)(
+        patch.object(sys.modules['os'], "access", return_value=True)(fun))
+
+
+def is_not_file(fun):
+    return patch.object(sys.modules['os'].path, "isfile", return_value=False)(
+        patch.object(sys.modules['os'], "access", return_value=False)(fun))
+
+
+def not_executable(fun):
+    return patch.object(sys.modules['os'].path, "isfile", return_value=True)(
+        patch.object(sys.modules['os'], "access", return_value=False)(fun))
+
+
+def empty_path(fun):
+    # delete path
+    return patch.object(sys.modules['os'], "environ", {})(
+        patch.object(sys.modules['os'].path, "isfile")(
+            patch.object(sys.modules['os'], "access")(fun)))
+
+
+class TestWhich(unittest.TestCase):
+
+    @staticmethod
+    def test_always_true():
+
+        @both_true
+        def _test(access_mock, isfile_mock):
+            from autotest.client.os_dep import which
+            assert which("more")
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_is_not_file():
+
+        @is_not_file
+        def _test(access_mock, isfile_mock):
+            from autotest.client.os_dep import which
+            assert not which("more")
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_not_executable():
+
+        @not_executable
+        def _test(access_mock, isfile_mock):
+            from autotest.client.os_dep import which
+            assert not which("more")
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_fail_if_empty_path_and_no_extra_dirs():
+
+        # delete path
+        @empty_path
+        def _test(access_mock, isfile_mock):
+            from autotest.client.os_dep import which
+            assert not which("more", extra_dirs=[])
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_uses_default_extra_dirs():
+
+        @empty_path
+        def _test(access_mock, isfile_mock):
+            from autotest.client.os_dep import which
+            from autotest.client.os_dep import COMMON_BIN_PATHS
+            assert which("more") in (os.path.abspath(os.path.join(p, "more"))
+                                     for p in COMMON_BIN_PATHS)
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_uses_non_default_extra_dirs():
+
+        # delete path
+        @empty_path
+        def _test(access_mock, isfile_mock):
+            from autotest.client.os_dep import which
+            assert os.path.abspath(os.path.join(os.sep, "nosuch", "more")) == \
+                which("more", extra_dirs=[os.path.join(os.sep, "nosuch")])
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_resolves_based_on_cwd_if_contains_path():
+
+        @both_true
+        def _test(access_mock, isfile_mock):
+            from autotest.client.os_dep import which
+            assert os.path.join(os.getcwd(), "foo", "more") == which(
+                os.path.join("foo", "more"))
+        # pylint: disable=E1120
+        _test()
+
+
+class TestCommand(unittest.TestCase):
+
+    @staticmethod
+    def test_command_raises_value_error():
+        @is_not_file
+        def _test(*args):
+            try:
+                os_dep.command("nosuch")
+                assert False
+            except ValueError, e:
+                assert "nosuch" in e.message
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_command_raises_value_error_on_unlikely_path():
+        @is_not_file
+        def _test(*args):
+            try:
+                os_dep.command("\1")
+                assert False
+            except ValueError, e:
+                assert "\1" in e.message
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_command_success():
+        @both_true
+        def _test(*args):
+            cat = os.path.abspath(os.path.join(os.sep, "bin", "cat"))
+            assert cat == os_dep.command(cat)
+        # pylint: disable=E1120
+        _test()
+
+
+class TestCommands(unittest.TestCase):
+
+    @staticmethod
+    def test_commands():
+        @patch.object(os_dep, "command")
+        def _test(command_mock):
+            paths = ['/a', '/b', '/c']
+            command_mock.side_effect = paths
+            try:
+                cmds = os_dep.commands('a', 'b', 'c')
+                assert cmds == paths
+            except ValueError, e:
+                assert "nosuch" in e.message
+        # pylint: disable=E1120
+        _test()
+
+
+class TestDirEntry(unittest.TestCase):
+
+    @staticmethod
+    def test_eq():
+        a = os_dep.Ldconfig.DirEntry("a", "", 1, 2)
+        aa = os_dep.Ldconfig.DirEntry("b", "", 1, 2)
+        b = os_dep.Ldconfig.DirEntry("b", "", 2, 3)
+        assert a == aa
+        assert a != b
+
+
+class TestLibrary(unittest.TestCase):
+
+    @staticmethod
+    def test_add_single_dir_reject_duplicates_same_path():
+        l = os_dep.Ldconfig()
+        a = os_dep.Ldconfig.DirEntry("a", "", 1, 2)
+        l.lddirs = [a]
+        l._add_single_dir(a)
+        assert l.lddirs == [a]
+
+    @staticmethod
+    def test_add_single_dir_reject_duplicates_not_same_path():
+        l = os_dep.Ldconfig()
+        a = os_dep.Ldconfig.DirEntry("a", "", 1, 2)
+        l.lddirs = [a]
+        # rejects because ino and dev are the same
+        l._add_single_dir(os_dep.Ldconfig.DirEntry("b", "", 1, 2))
+        assert l.lddirs == [a]
+
+    @staticmethod
+    def test_add_single_dir_adds():
+        l = os_dep.Ldconfig()
+        a = os_dep.Ldconfig.DirEntry("a", "", 1, 2)
+        b = os_dep.Ldconfig.DirEntry("b", "", 2, 3)
+        l.lddirs = [a]
+        l._add_single_dir(b)
+        assert l.lddirs == [a, b]
+
+    @staticmethod
+    def test_add_dir_calls_stat():
+        @patch.object(sys.modules['os'], "stat", side_effect={"asdf": MagicMock(st_ino=2, st_dev=2)}.get)
+        def _test(stat_mock):
+            from autotest.client.os_dep import Ldconfig
+            l = Ldconfig()
+            l._add_dir("asdf")
+            assert l.lddirs[0] == Ldconfig.DirEntry("asdf", "", 2, 2)
+            assert l.lddirs[0].path == "asdf"
+            assert l.lddirs[0].flag == ""
+            assert l.lddirs[0].ino == 2
+            assert l.lddirs[0].dev == 2
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_add_dir_splits_on_eq():
+        @patch.object(sys.modules['os'], "stat", side_effect={
+            "asdf": MagicMock(st_ino=2, st_dev=2),
+            "qwer": MagicMock(st_ino=3, st_dev=3)}.get)
+        def _test(stat_mock):
+            from autotest.client.os_dep import Ldconfig
+            l = Ldconfig()
+            l._add_dir("asdf=glibc2")
+            assert l.lddirs[0] == Ldconfig.DirEntry("asdf", "glibc2", 2, 2)
+            l._add_dir("qwer%s      =glibc2" % os.sep)
+            assert l.lddirs[1] == Ldconfig.DirEntry("qwer", "glibc2", 3, 3)
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_add_dir_ignores_stat_ioerror():
+        @patch.object(sys.modules['os'], "stat", side_effect=IOError)
+        @patch.object(os_dep, "logging")
+        def _test(logging_mock, stat_mock):
+            l = os_dep.Ldconfig()
+            l._add_dir("asdf")
+            assert l.lddirs == []
+            assert logging_mock.debug.called
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_add_dir_ignores_stat_oserror():
+        @patch.object(sys.modules['os'], "stat", side_effect=OSError)
+        @patch.object(os_dep, "logging")
+        def _test(logging_mock, stat_mock):
+            l = os_dep.Ldconfig()
+            l._add_dir("asdf")
+            assert l.lddirs == []
+            assert logging_mock.debug.called
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_read_config_file():
+        l = os_dep.Ldconfig()
+
+        @patch.object(l, "_add_dir")
+        @patch.object(l, "_parse_conf_include")
+        def _test(parse_conf_include_mock, add_dir_mock):
+            l._parse_config_line(["include foo", "  # comment", "",
+                                  "hwcap 0 nosegneg", "asdf",
+                                  "include *",
+                                  "include glob1 glob2    glob3 \t \t \t glob4"], "filename", 55)
+            assert add_dir_mock.call_args_list == [call("asdf")]
+            assert parse_conf_include_mock.call_args_list == [call(
+                "filename", "foo", 55),
+                call(
+                    "filename", "*", 55),
+                call(
+                    "filename", "glob1", 55),
+                call(
+                    "filename", "glob2", 55),
+                call(
+                    "filename", "glob3", 55),
+                call(
+                    "filename", "glob4", 55),
+            ]
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_parse_conf_stops_at_max_recursion():
+        @patch.object(os_dep, "open", create=True)
+        def _test(open_mock):
+            l = os_dep.Ldconfig()
+            l.parse_conf("", l.MAX_RECURSION_DEPTH + 2)
+            assert not open_mock.called
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_parse_conf_opens_mock():
+        @patch.object(os_dep, "open", create=True)
+        def _test(open_mock):
+            l = os_dep.Ldconfig()
+            l.parse_conf("")
+            assert open_mock.called
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_parse_conf_ignores_open_exception():
+        @patch.object(os_dep, "open", create=True, side_effect=IOError)
+        def _test(open_mock):
+            l = os_dep.Ldconfig()
+            l.parse_conf("")
+            assert open_mock.called
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_parse_conf_include_joins_when_given_relative_path_with_slash():
+        @patch.object(os_dep, "glob", return_value=[])
+        @patch.object(os_dep.Ldconfig, "parse_conf")
+        def _test(parse_conf, glob_mock):
+            l = os_dep.Ldconfig()
+            l._parse_conf_include(os.path.join(os.sep, "etc", "ld.so.conf"),
+                                  os.path.join("a", "b", "c"), 1)
+            assert glob_mock.call_args_list == [
+                call(os.path.join(os.path.join(os.sep, "etc"),
+                                  os.path.join("a", "b", "c")))]
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_parse_conf_include_joins_when_given_relative_path():
+        @patch.object(os_dep, "glob", return_value=[])
+        @patch.object(os_dep.Ldconfig, "parse_conf")
+        def _test(parse_conf, glob_mock):
+            l = os_dep.Ldconfig()
+            l._parse_conf_include(os.path.join(os.sep, "etc", "ld.so.conf"),
+                                  "foo", 1)
+            assert glob_mock.call_args_list == [
+                call(os.path.join(os.path.join(os.sep, "etc"),
+                                  "foo"))]
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_parse_conf_include_does_not_join_when_no_slash_in_filename():
+        @patch.object(os_dep, "glob", return_value=[])
+        def _test(glob_mock):
+            l = os_dep.Ldconfig()
+
+            @patch.object(l, "parse_conf")
+            def _test2(parse_conf_mock):
+                l._parse_conf_include("noslash", "foo", 1)
+                assert glob_mock.call_args_list == [call("foo")]
+            # pylint: disable=E1120
+            _test2()
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_parse_conf_include_iterates_over_globs():
+        @patch.object(os_dep, "glob", return_value=["a", "b", "c"])
+        def _test(glob_mock):
+            l = os_dep.Ldconfig()
+
+            @patch.object(l, "parse_conf")
+            def _test2(parse_conf_mock):
+                l._parse_conf_include(
+                    os.path.join(os.sep, "etc", "ld.so.conf"),
+                    "foo", 1)
+                assert glob_mock.call_args_list == [
+                    call(os.path.join(os.sep, "etc", "foo"))]
+                assert parse_conf_mock.call_args_list == [call(
+                    "a", 2), call("b", 2),
+                    call("c", 2)]
+            # pylint: disable=E1120
+            _test2()
+        # pylint: disable=E1120
+        _test()
+
+# try:
+#     import pytest
+#
+#     def make_it(tmpdir):
+#         lib_dir = tmpdir.mkdir("lib")
+#         lib1_dir = lib_dir.mkdir("lib1")
+#         lib2_dir = lib_dir.mkdir("lib2")
+#         lib3_dir = lib_dir.mkdir("lib3")
+#         try:
+#             # symlink lib4 to lib3 to test duplicate detection
+#             lib_dir.join("lib4").mksymlinkto(lib3_dir, absolute=0)
+#         except AttributeError:
+#             # symlinks are ignored anyway so ignore failure to create
+#             pass
+#         t = tmpdir.mkdir("etc")
+#         t.chdir()
+#         ld_so_conf_dir = t.mkdir('ld.so.conf.d')
+#         # recursion
+#         ld_so_conf_dir.join('recurse.conf').write(
+#             "include %s" % t.join("ld.so.conf"))
+#         ld_so_conf_dir.join('type.conf').write("""%(0)s%(sep)s=glibc2
+#     %(0)s     =glibc2
+#     %(1)s%(sep)s   =glibc2
+#     """ % {'0': lib1_dir, '1': lib2_dir, 'sep': os.sep})
+#         ld_so_conf_dir.join('hwcap.conf').write("hwcap 0 nosegnet")
+#         ld_so_conf_dir.join('comment.conf').write(
+#             "# this is a comment\n%s # another comment" % lib3_dir)
+#         t.join("ld.so.conf").write("include %s\n%s" %
+#                                    (t.join("ld.so.conf.d", "*.conf"), lib_dir.join("lib4")))
+#         return t
+#
+#     @pytest.mark.skipif("os.stat(__file__).st_ino == 0", reason="requires valid inode and device numbers")
+#     def test_on_filesystem(tmpdir):
+#         ld_so_conf_dir = make_it(tmpdir)
+#         l = os_dep.Ldconfig()
+#         paths = list(l.ldconfig(
+#             str(ld_so_conf_dir.join("ld.so.conf")), extra_dirs=[]))
+#         print
+#         # for d in l.lddirs:
+#         #     print d
+#         assert l.lddirs[0].path.endswith("lib3")
+#         assert l.lddirs[1].path.endswith("lib1")
+#         assert l.lddirs[1].flag == "glibc2"
+#         assert l.lddirs[2].path.endswith("lib2")
+#         assert l.lddirs[2].flag == "glibc2"
+#         assert paths[0].endswith("lib3")
+#         assert paths[1].endswith("lib1")
+#         assert paths[2].endswith("lib2")
+#
+#
+# except ImportError:
+#     pass
+
+
+class TestUniqueList(unittest.TestCase):
+
+    def test_unique_list(self):
+        thous = range(1, 1000)
+        lst = list(itertools.chain(thous, thous))
+        assert thous == os_dep.unique_not_false_list(lst)
+        lst = list(itertools.chain(thous, reversed(thous)))
+        assert thous == os_dep.unique_not_false_list(lst)
+
+
+class TestHeaders(unittest.TestCase):
+
+    @staticmethod
+    def test_header_raises_value_error():
+        @is_not_file
+        def _test(*args):
+            try:
+                os_dep.header("nosuch.h")
+                assert False
+            except ValueError, e:
+                assert "nosuch.h" in e.message
+        # pylint: disable=E1120
+        _test()
+
+    @staticmethod
+    def test_success():
+
+        @both_true
+        def _test(*args):
+            from autotest.client.os_dep import which_header
+            assert which_header("stdio.h")
+        # pylint: disable=E1120
+        _test()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Rewrite commands, libraries and headers to use common searching functions.

The lib searcher was re-implemented to match as close as possible the C
ldconfig implementation.  The C source code was translated line-by-line
as close as possible into python, so we preserve the exact same
behaviour with regards to recurrsion.

Unittests included to check all the interesting corner cases.

Also try to match `which` behaviour as close as possible.

Disabled pytest specific unittests.

Signed-off-by: Ross Brattain <ross.b.brattain@intel.com>