### PR TITLE
scheduler: fix corner case with metahost scheduling on reserved hosts

### DIFF
--- a/scheduler/scheduler_models.py
+++ b/scheduler/scheduler_models.py
@@ -383,6 +383,15 @@ class Label(DBObject):
             self.name, self.id, self.atomic_group_id)
 
 
+class ACLGroup(DBObject):
+    _table_name = 'afe_acl_groups'
+    _fields = ('id', 'name', 'description')
+
+    def __repr__(self):
+        return 'ACLGroup(name=%r, id=%d, description=%r)' % (
+             self.name, self.id, self.description)
+
+
 class Host(DBObject):
     _table_name = 'afe_hosts'
     _fields = ('id', 'hostname', 'locked', 'synch_id', 'status',


### PR DESCRIPTION
Consider having a host reserved in Autotest with label 'L'. Run a
job-by-label (metahost) for 1 label-'L' host. The current scheduler will
not exclude your reserved host from the set of possible hosts to run the
metahost job on, because it only checks that your user has permission to
run on candidate hosts, not if those candidate hosts are already in-use.
I'm assuming that reservations in Autotest are specifically intended to
indicate a host is "in-use". I think this is the principle of least
surprise for reservations. With the changes in this commit, candidate
hosts' ACLs are checked against the "Everyone" ACL for set-identity and
excluded if there is an ACL in place.

Signed-off-by: Nishanth Aravamudan <nacc@linux.vnet.ibm.com>