### PR TITLE
client.shared.iso9660: Insert module before check

### DIFF
--- a/client/shared/iso9660.py
+++ b/client/shared/iso9660.py
@@ -76,7 +76,9 @@ def can_mount():
         logging.debug('Can not use mount: missing "mount" tool')
         return False
 
-    if 'iso9660' not in open('/proc/kallsyms').read():
+    utils.system("modprobe iso9660", 10, True)  # insert in case it's module
+
+    if 'iso9660' not in open('/proc/filesystems').read():
         logging.debug('Can not use mount: lack of iso9660 kernel support')
         return False
 


### PR DESCRIPTION
When the iso9660 module is not loaded, the "/proc/kallsyms" doesn't list
it. This patch executes modprobe first.

Additionally it replaces the "/proc/kallsyms" with "/proc/filesystems"
which is recommended for supported filesystem checks.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>