### PR TITLE
autotest-local: Fix test directory usage

### DIFF
--- a/client/autotest_local.py
+++ b/client/autotest_local.py
@@ -44,13 +44,14 @@ class AutotestLocalApp:
 
     def parse_cmdline(self):
         self.options, args = self.opt_parser.parse_args()
-        self.args = self.cmd_parser.parse_args(args, self.options)
 
         if self.options.test_directory is not None:
             if os.path.isdir(self.options.test_directory):
                 os.environ['CUSTOM_DIR'] = self.options.test_directory
             else:
                 print "The custom directory specifed does not exist, ignoring it..."
+
+        self.args = self.cmd_parser.parse_args(args, self.options)
 
         # Check for a control file if not in prebuild mode.
         if len(args) != 1 and self.options.client_test_setup is None:


### PR DESCRIPTION
Fix the problem that CUSTOM_DIR is assigned after
cmdparser uses it.

Signed-off-by: Aska.Wu <aska.wu@acer.com>