### PR TITLE
frontend/HostDataSource.java: Add HostDataSource string identifier

### DIFF
--- a/frontend/client/src/autotest/afe/HostDataSource.java
+++ b/frontend/client/src/autotest/afe/HostDataSource.java
@@ -17,6 +17,7 @@ public class HostDataSource extends RpcDataSource {
     protected static final String LOCKED_TEXT = "locked_text";
     protected static final String OTHER_LABELS = "other_labels";
     protected static final String HOST_ACLS = "host_acls";
+    protected static final String EVERYONE_ACL = "everyone_acl";
 
     public HostDataSource() {
         super("get_hosts", "get_num_hosts");


### PR DESCRIPTION
Add a missing string identifier to HostDataSource, fixing
a compilation bug added with commit 0bc0c0b7.

Signed-off-by: Lucas Meneghel Rodrigues <lmr@redhat.com>