### PR TITLE
client/tools/results2junit.py: Be more robust against unreadable debu…

### DIFF
--- a/client/tools/results2junit.py
+++ b/client/tools/results2junit.py
@@ -195,13 +195,21 @@ def main(basedir, resfiles):
             elif r[1] == 'TEST_NA':
                 failures = failures + 1
                 fid = os.path.join(basedir, tname, 'debug', '%s.DEBUG' % tname)
-                contents = text_clean(file_load(fid))
+                debug_contents = file_load(fid)
+                if not debug_contents:
+                    contents = 'Could not find debug file %s' % fid
+                else:
+                    contents = text_clean(debug_contents)
                 tcfailure = api.failureType(message='Test %s is Not Applicable: %s' % (tname, r[3]), type_='Failure', valueOf_="\n<![CDATA[\n%s\n]]>\n" % contents)
                 tc.failure = tcfailure
             elif r[1] == 'ERROR':
                 failures = failures + 1
                 fid = os.path.join(basedir, tname, 'debug', '%s.DEBUG' % tname)
-                contents = text_clean(file_load(fid))
+                debug_contents = file_load(fid)
+                if not debug_contents:
+                    contents = 'Could not find debug file %s' % fid
+                else:
+                    contents = text_clean(debug_contents)
                 tcfailure = api.failureType(message='Test %s has failed' % tname, type_='Failure', valueOf_="\n<![CDATA[\n%s\n]]>\n" % contents)
                 tc.failure = tcfailure
             else:


### PR DESCRIPTION
…g files

Fixes #984

Sometimes when a job fails in a particular way, this conversion script
dies where it should just report the particular test as failed. Fix
the script by being more careful on whether it could actually read
from the test debug file and handling each situation accordingly.

Signed-off-by: Lucas Meneghel Rodrigues <lookkas@gmail.com>