### PR TITLE
Fix pylint E1136 errors

### DIFF
--- a/client/harness_beaker.py
+++ b/client/harness_beaker.py
@@ -146,7 +146,8 @@ class harness_beaker(harness.harness):
                         f = arg_list.pop(0)
                         break
                 if not f:
-                    raise
+                    raise HarnessException("Argument -l not found in q_args "
+                                           "'%s'" % q_args)
                 self.bkr_proxy.task_upload_file(task_id, f)
             except Exception:
                 logging.critical('ERROR: Failed to process quick cmd %s' % cmd)

--- a/client/shared/mock.py
+++ b/client/shared/mock.py
@@ -832,7 +832,8 @@ class NonCallableMock(Base):
         expected_string = self._format_mock_call_signature(args, kwargs)
         call_args = self.call_args
         if len(call_args) == 3:
-            call_args = call_args[1:]
+            # Can't get here when selc.call_args is None, ignore E1136
+            call_args = call_args[1:]   # pylint: disable=E1136
         actual_string = self._format_mock_call_signature(*call_args)
         return message % (expected_string, actual_string)
 

--- a/client/shared/test_utils/mock.py
+++ b/client/shared/test_utils/mock.py
@@ -449,7 +449,8 @@ class mock_god(object):
                                       _dump_function_call(symbol, args, dargs))
 
         if len(self.recording) != 0:
-            func_call = self.recording[0]
+            # self.recording is subscriptable (deque), ignore E1136
+            func_call = self.recording[0]   # pylint: disable=E1136
             if func_call.symbol != symbol:
                 msg = ("Unexpected call: %s\nExpected: %s"
                        % (_dump_function_call(symbol, args, dargs),

--- a/client/shared/utils.py
+++ b/client/shared/utils.py
@@ -709,7 +709,7 @@ def is_url(path):
     """Return true if path looks like a URL"""
     # for now, just handle http and ftp
     url_parts = urlparse.urlparse(path)
-    return (url_parts[0] in ('http', 'ftp', 'git'))
+    return (url_parts[0] in ('http', 'ftp', 'git'))  # pylint: disable=E1136
 
 
 def urlopen(url, data=None, timeout=5):
@@ -797,7 +797,8 @@ def unmap_url(srcdir, src, destdir='.'):
     """
     if is_url(src):
         url_parts = urlparse.urlparse(src)
-        filename = os.path.basename(url_parts[2])
+        # ParseResult is subscriptable, ignore E1136
+        filename = os.path.basename(url_parts[2])  # pylint: disable=E1136
         dest = os.path.join(destdir, filename)
         return get_file(src, dest)
     else:

--- a/frontend/afe/resources.py
+++ b/frontend/afe/resources.py
@@ -362,7 +362,7 @@ class Test(resource_lib.InstanceEntry):
                                        ('name', 'control_file_type',
                                         'control_file_path'))
         test_type = model_attributes.TestTypes.get_value(
-            input['control_file_type'])
+            input_dict['control_file_type'])
         return models.Test.add_object(name=input_dict['name'],
                                       test_type=test_type,
                                       path=input_dict['control_file_path'])

--- a/frontend/shared/resource_lib.py
+++ b/frontend/shared/resource_lib.py
@@ -472,7 +472,7 @@ class Relationship(Entry):
     _permitted_methods = ('GET', 'DELETE')
 
     # subclasses must override this with a dict mapping name to entry class
-    related_classes = None
+    related_classes = {}
 
     def __init__(self, **kwargs):
         assert len(self.related_classes) == 2

--- a/frontend/shared/rest_client.py
+++ b/frontend/shared/rest_client.py
@@ -14,7 +14,8 @@ _request_headers = {}
 
 
 def _get_request_headers(uri):
-    server = urlparse.urlparse(uri)[0:2]
+    # ParseResult is subscriptable, ignore E1136
+    server = urlparse.urlparse(uri)[0:2]    # pylint: disable=E1136
     if server in _request_headers:
         return _request_headers[server]
 
@@ -26,7 +27,8 @@ def _get_request_headers(uri):
 
 
 def _clear_request_headers(uri):
-    server = urlparse.urlparse(uri)[0:2]
+    # ParseResult is subscriptable, ignore E1136
+    server = urlparse.urlparse(uri)[0:2]    # pylint: disable=E1136
     if server in _request_headers:
         del _request_headers[server]
 

--- a/utils/external_packages.py
+++ b/utils/external_packages.py
@@ -78,7 +78,7 @@ class ExternalPackage(object):
     """
     subclasses = []
     urls = ()
-    local_filename = None
+    local_filename = ""
     hex_sum = None
     module_name = None
     version = None


### PR DESCRIPTION
This pull request is focused on fixing the E1136 errors enabled in the latest pylint/inspektor. It contains two actual bugfixes, the rest only handles false-negatives.