### PR TITLE
Travis CI: workaround bug on GCE machines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ git:
     submodules: false
 
 before_script:
+    - sudo apt-get update
     - sudo apt-get install -y --force-yes protobuf-compiler python-protobuf
     - make -C tko
 


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/5221, it's
necessary (temporarily?) to do an `apt-get update` before attempting
to install packages using `apg-get install`.

Signed-off-by: Cleber Rosa <crosa@redhat.com>