### PR TITLE
Fix broken link to admin page

### DIFF
--- a/frontend/client/src/autotest/public/TkoClient.html
+++ b/frontend/client/src/autotest/public/TkoClient.html
@@ -12,7 +12,7 @@
     
     <span class="links-box" style="float: right;">
       <a href="/afe">Frontend</a> |
-      <a href="server/admin">Admin</a> |
+      <a href="/afe/server/admin">Admin</a> |
       Results DB |
       <a href="https://github.com/autotest/autotest/wiki">Documentation</a>
       <div id="motd" class="motd"></div>


### PR DESCRIPTION
Admin link was throwing 404 as it was pointing to wrong url