### PR TITLE
Added an option to ignore certain directories for unittests

### DIFF
--- a/utils/unittest_suite_nose.py
+++ b/utils/unittest_suite_nose.py
@@ -6,7 +6,7 @@ __author__ = 'Jorge Niedbalski R. <jnr@pyrosome.org>'
 import logging
 import os
 import sys
-
+import re
 import nose
 from nose.plugins import Plugin
 from nose.plugins.attrib import AttributeSelector
@@ -52,6 +52,16 @@ logger = logging.getLogger(__name__)
 class AutoTestSelector(Selector):
 
     def wantDirectory(self, dirname):
+        skip_dirs = []
+        if self.config.options.skip_dirs != []:
+            skip_dirs = re.split(os.sep + "{0,1}\s+|" + os.sep + "{0,1}\Z", self.config.options.skip_dirs)
+
+        skip_dirs = filter(None, skip_dirs)
+
+        for dir in skip_dirs:
+            if re.match(os.path.abspath(dir), dirname):
+                logger.debug('Skipping tests in directory: %s' % dirname)
+                return False
         return True
 
     def wantModule(self, module):
@@ -109,6 +119,11 @@ class AutoTestRunner(Plugin):
                           dest="skip_tests",
                           default=[],
                           help='A space separated list of tests to skip')
+
+        parser.add_option("--autotest-skip-dirs",
+                          dest="skip_dirs",
+                          default=[],
+                          help='A space separated list of directories to skip')
 
     def prepareTestLoader(self, loader):
         loader.selector = AutoTestSelector(loader.config)


### PR DESCRIPTION
This option makes it easy to ignore unittests in certain directories. It becomes especially convenient if you have 3rd party libraries in your autotest project directory or you don't want to run a certain group of tests.
