### PR TITLE
client.setup: fix installation issue

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -31,7 +31,7 @@ def _get_files(path):
 
 
 def get_filelist():
-    pd_filelist = ['config/*', 'deps/*']
+    pd_filelist = ['config/*']
     pd_filelist.extend(_get_files(os.path.join(client_dir, 'deps')))
     pd_filelist.extend(_get_files(os.path.join(client_dir, 'profilers')))
     pd_filelist.extend(_get_files(os.path.join(client_dir, 'tools')))


### PR DESCRIPTION
Installation aborted with following error on RHEL distributions,
so made this patch to fix it.

> error: can't copy 'client/deps/grubby': doesn't exist or not a regular file