### PR TITLE
Fixup: Count cpus in host

### DIFF
--- a/client/base_utils.py
+++ b/client/base_utils.py
@@ -402,13 +402,17 @@ def get_file_arch(filename):
 
 
 def count_cpus():
-    """number of CPUs in the local machine according to /proc/cpuinfo"""
-    f = file('/proc/cpuinfo', 'r')
-    cpus = 0
-    for line in f.readlines():
-        if line.lower().startswith('processor'):
-            cpus += 1
-    return cpus
+    """Total number of CPUs in the local machine"""
+    if os.path.isfile("/sys/devices/system/cpu/present"):
+        cpus = utils.system_output("echo $( expr $(cat /sys/devices/system/cpu/present|awk -F'-' '{print $2}') + 1 )")
+        return int(cpus)
+    else:
+        f = file('/proc/cpuinfo', 'r')
+        cpus = 0
+        for line in f.readlines():
+            if line.lower().startswith('processor'):
+                cpus += 1
+        return cpus
 
 
 def sysctl(key, value=None):


### PR DESCRIPTION
Total number of host cpus not always matches
cpuinfo output (e:g:- power8 ppc arch).

This patch addresses the same by taking total cpus
from sysfs(/sys/devices/system/cpu/present) and
fallback incase of the file not found to the old method.