### PR TITLE
find_desired_python: cope with empty version

### DIFF
--- a/client/shared/base_check_version.py
+++ b/client/shared/base_check_version.py
@@ -49,7 +49,7 @@ class base_check_python_version:
         best_python = (0, 0), ''
         for python in pythons:
             version = self.extract_version(python)
-            if version >= (2, 4):
+            if version and version >= (2, 4):
                 possible_versions.append((version, python))
 
         possible_versions.sort()


### PR DESCRIPTION
Setup: Fedora 26 ships with pylint-3 as default:

  lrwxrwxrwx. 1 root root 10 Aug  2 11:57 /usr/bin/pylint -> pylint-3.6

This triggers autotest to look for python2.x and restart, but
the glob that's looked for is 'python2*' (not 'python2.*') and
extract_version() can't recognize plain 'python2'. Accept that
and just move along.

Signed-off-by: Ed Santiago <santiago@redhat.com>