### PR TITLE
setup/settings: Support venv to get top autotest path

### DIFF
--- a/client/setup.py
+++ b/client/setup.py
@@ -1,5 +1,6 @@
 # pylint: disable=E0611
 import os
+import sys
 from distutils.core import setup
 
 try:
@@ -60,7 +61,11 @@ def get_scripts():
 
 
 def get_data_files():
-    return [(os.environ.get('AUTOTEST_TOP_PATH', '/etc/autotest'),
+    if hasattr(sys, "real_prefix"):
+        default_autotest_top = os.path.join(sys.prefix, "etc", "autotest")
+    else:
+        default_autotest_top = "/etc/autotest"
+    return [(os.environ.get('AUTOTEST_TOP_PATH', default_autotest_top),
              [autotest_dir + '/global_config.ini',
               autotest_dir + '/shadow_config.ini', ]), ]
 

--- a/client/shared/settings.py
+++ b/client/shared/settings.py
@@ -28,7 +28,11 @@ shared_dir = os.path.dirname(sys.modules[__name__].__file__)
 client_dir = os.path.dirname(shared_dir)
 root_dir = os.path.dirname(client_dir)
 
-system_wide_dir = os.environ.get('AUTOTEST_TOP_PATH', '/etc/autotest')
+if hasattr(sys, "real_prefix"):
+    default_autotest_top = os.path.join(sys.prefix, "etc", "autotest")
+else:
+    default_autotest_top = "/etc/autotest"
+system_wide_dir = os.environ.get('AUTOTEST_TOP_PATH', default_autotest_top)
 
 # Check if the config files are in the system wide directory
 settings_path_system_wide = os.path.join(system_wide_dir,


### PR DESCRIPTION
When running autotest from venv we should be using sys.prefix as top
directory instead of /etc/autotest, unless user sets the
AUTOTEST_TOP_PATH.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>