### PR TITLE
client.shared.settings: Cope with standard python config locations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 include RELEASE-VERSION
 include README.rst
 include LICENSE
+include global_config.ini
+include shadow_config.ini

--- a/client/setup.py
+++ b/client/setup.py
@@ -1,6 +1,5 @@
 # pylint: disable=E0611
 import os
-import sys
 from distutils.core import setup
 
 try:
@@ -60,16 +59,6 @@ def get_scripts():
             os.path.join(client_dir, 'autotest-daemon-monitor')]
 
 
-def get_data_files():
-    if hasattr(sys, "real_prefix"):
-        default_autotest_top = os.path.join(sys.prefix, "etc", "autotest")
-    else:
-        default_autotest_top = "/etc/autotest"
-    return [(os.environ.get('AUTOTEST_TOP_PATH', default_autotest_top),
-             [autotest_dir + '/global_config.ini',
-              autotest_dir + '/shadow_config.ini', ]), ]
-
-
 def get_package_dir():
     return {'autotest.client': client_dir, 'autotest': autotest_dir}
 
@@ -88,8 +77,7 @@ def run():
           package_dir=get_package_dir(),
           package_data=get_package_data(),
           packages=get_packages(),
-          scripts=get_scripts(),
-          data_files=get_data_files())
+          scripts=get_scripts())
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -98,8 +98,7 @@ def get_packages():
 
 
 def get_data_files():
-    return (client.setup.get_data_files() +
-            tko.setup.get_data_files() +
+    return (tko.setup.get_data_files() +
             utils.setup.get_data_files() +
             mirror.setup.get_data_files())
 
@@ -141,6 +140,7 @@ def run():
           data_files=get_data_files(),
           cmdclass=cmdclass,
           command_options=command_options,
+          include_package_data=True,
           )
 
 


### PR DESCRIPTION
In linux world the configs are most commonly stored in "/etc", but in
purely python world they are "resources" as every other asset. Let's
change the way we discover the locations of those file to respect the
python defaults while still prioritizing the "/etc" as was before for
compatibility reasons.

This should suit most cases as distribution packages (RPM) can put the
config files in /etc but "python setup.py install" will use the
"resource" path (usually /usr/lib/python2.7/...) while still respecting
the /etc if created manually by users.

This is needed to avoid creating files in "/etc", which is not allowed
in easy_install or in non-priviledged mode.

Signed-off-by: Lukáš Doktor <ldoktor@redhat.com>