### PR TITLE
tools/JUnit_api: handle exceptions while doing str encode

### DIFF
--- a/client/tools/JUnit_api.py
+++ b/client/tools/JUnit_api.py
@@ -1617,7 +1617,10 @@ class failureType(GeneratedsSuper):
         self.exportAttributes(outfile, level, already_processed, namespace_, name_='failureType')
         if self.hasContent_():
             outfile.write('>')
-            outfile.write(str(self.valueOf_).encode(ExternalEncoding))
+            try:
+                outfile.write(str(self.valueOf_).encode(ExternalEncoding))
+            except UnicodeDecodeError as err:
+                print("Unable to display failure log as content encode error: %s" % err)
             self.exportChildren(outfile, level + 1, namespace_, name_)
             outfile.write('</%s%s>\n' % (namespace_, name_))
         else:


### PR DESCRIPTION
Possibly hit UnicodeDecodeError exception when use tools/results2junit.py
to covert test result to junit format xml and failed to generate it.

The patch tries to catch it and does not interrupt generate process.

Error message example:
UnicodeDecodeError: 'ascii' codec can't decode byte 0x94 in position 28701:
ordinal not in range(128)

Signed-off-by: Xiao Liang <xiliang@redhat.com>