### PR TITLE
Handle "except" syntax compatibility for versions after python2.5

### DIFF
--- a/cli/action_common.py
+++ b/cli/action_common.py
@@ -204,7 +204,7 @@ class atest_add_or_remove(topic_common.atest):
             self.execute_rpc(op=op,                       # The opcode
                              **{'id': item, what: uhs})   # The data
             setattr(self, 'good_%s' % what, uhs)
-        except topic_common.CliError, full_error:
+        except topic_common.CliError as full_error:
             bad_uhs = self.parse_json_exception(full_error)
             good_uhs = list(set(uhs) - set(bad_uhs))
             if bad_uhs and good_uhs:
@@ -241,7 +241,7 @@ class atest_add_or_remove(topic_common.atest):
                     self._add_remove_uh_to_topic(item, what)
                 except AttributeError:
                     pass
-                except topic_common.CliError, err:
+                except topic_common.CliError as err:
                     # The error was already logged by
                     # self.failure()
                     pass

--- a/cli/action_common.py
+++ b/cli/action_common.py
@@ -241,7 +241,7 @@ class atest_add_or_remove(topic_common.atest):
                     self._add_remove_uh_to_topic(item, what)
                 except AttributeError:
                     pass
-                except topic_common.CliError as err:
+                except topic_common.CliError:
                     # The error was already logged by
                     # self.failure()
                     pass

--- a/cli/atest.py
+++ b/cli/atest.py
@@ -127,7 +127,7 @@ def main():
             results = action_obj.execute()
         except topic_common.CliError:
             pass
-        except Exception, err:
+        except Exception as err:
             traceback.print_exc()
             action_obj.generic_error("Unexpected exception: %s" % err)
         else:

--- a/cli/autotest-rpc-change-protection-level
+++ b/cli/autotest-rpc-change-protection-level
@@ -30,7 +30,7 @@ hosts = afe_proxy.run('get_hosts', hostname__in=leftover_args[1:])
 for host in hosts:
     try:
         afe_proxy.run('modify_host', host['id'], protection=protection_level)
-    except Exception, exc:
+    except Exception as exc:
         print 'For host %s:', host['hostname']
         traceback.print_exc()
     else:

--- a/cli/autotest-rpc-change-protection-level
+++ b/cli/autotest-rpc-change-protection-level
@@ -30,7 +30,7 @@ hosts = afe_proxy.run('get_hosts', hostname__in=leftover_args[1:])
 for host in hosts:
     try:
         afe_proxy.run('modify_host', host['id'], protection=protection_level)
-    except Exception as exc:
+    except Exception:
         print 'For host %s:', host['hostname']
         traceback.print_exc()
     else:

--- a/cli/host.py
+++ b/cli/host.py
@@ -373,7 +373,7 @@ class host_mod(host):
                     # TODO: Make the AFE return True or False,
                     # especially for lock
                     successes.append(host)
-                except topic_common.CliError, full_error:
+                except topic_common.CliError as full_error:
                     # Already logged by execute_rpc()
                     pass
 

--- a/cli/host.py
+++ b/cli/host.py
@@ -373,7 +373,7 @@ class host_mod(host):
                     # TODO: Make the AFE return True or False,
                     # especially for lock
                     successes.append(host)
-                except topic_common.CliError as full_error:
+                except topic_common.CliError:
                     # Already logged by execute_rpc()
                     pass
 

--- a/cli/rpc.py
+++ b/cli/rpc.py
@@ -42,7 +42,7 @@ class rpc_comm(object):
         self.web_server = get_autotest_server(web_server)
         try:
             self.proxy = self._connect(rpc_path)
-        except rpc_client_lib.AuthError, s:
+        except rpc_client_lib.AuthError as s:
             raise AuthError(s)
 
     def _connect(self, rpc_path):

--- a/cli/threads.py
+++ b/cli/threads.py
@@ -70,7 +70,7 @@ class ThreadPool:
                 return
             try:
                 self.function(data)
-            except Exception, full_error:
+            except Exception as full_error:
                 # Put a catch all here.
                 print ('Unexpected failure in the thread calling %s: %s' %
                        (self.function.__name__, full_error))

--- a/cli/topic_common.py
+++ b/cli/topic_common.py
@@ -152,7 +152,7 @@ def _get_item_key(item, key):
             raise ValueError('empty subkey in %r' % key)
         try:
             nested_item = nested_item[subkey]
-        except KeyError, e:
+        except KeyError as e:
             raise KeyError('%r - looking up key %r in %r' %
                            (e, key, nested_item))
     else:
@@ -418,7 +418,7 @@ class atest(object):
                 values, leftover = item_parse_info.get_values(options,
                                                               leftover)
                 setattr(self, item_parse_info.attribute_name, values)
-        except CliError, s:
+        except CliError as s:
             self.invalid_syntax(s)
 
         if (req_items and not getattr(self, req_items, None)):
@@ -459,7 +459,7 @@ class atest(object):
         self.username = options.username
         try:
             self.afe = rpc.afe_comm(self.web_server, username=self.username)
-        except rpc.AuthError, s:
+        except rpc.AuthError as s:
             self.failure(str(s), fatal=True)
 
         return (options, leftover)
@@ -482,7 +482,7 @@ class atest(object):
         while retry:
             try:
                 return self.afe.run(op, **data)
-            except urllib2.URLError, err:
+            except urllib2.URLError as err:
                 if hasattr(err, 'reason'):
                     if 'timed out' not in err.reason:
                         self.invalid_syntax('Invalid server name %s: %s' %
@@ -508,7 +508,7 @@ class atest(object):
                     raise CliError("Timed-out contacting the Autotest server")
             except mock.CheckPlaybackError:
                 raise
-            except Exception, full_error:
+            except Exception as full_error:
                 # There are various exceptions throwns by JSON,
                 # urllib & httplib, so catch them all.
                 self.failure(full_error, item=item,

--- a/client/base_sysinfo.py
+++ b/client/base_sysinfo.py
@@ -289,7 +289,7 @@ class base_sysinfo(object):
                                               os.path.dirname(symlink_dest))
         try:
             os.symlink(symlink_src, symlink_dest)
-        except Exception, e:
+        except Exception as e:
             raise Exception('%s: whilst linking %s to %s' % (e, symlink_src,
                                                              symlink_dest))
 
@@ -367,11 +367,11 @@ class base_sysinfo(object):
             finally:
                 out_messages.close()
                 in_messages.close()
-        except ValueError, e:
+        except ValueError as e:
             logging.info(e)
         except (IOError, OSError):
             logging.info("Not logging %s (lack of permissions)", logpath)
-        except Exception, e:
+        except Exception as e:
             logging.info("System log collection failed: %s", e)
 
     @staticmethod

--- a/client/bkr_proxy.py
+++ b/client/bkr_proxy.py
@@ -206,7 +206,7 @@ def copy_remote(data, dest, use_put=None):
         res = utils.urlopen(req)
         ret = res.info()
         res.close()
-    except urllib2.HTTPError, e:
+    except urllib2.HTTPError as e:
         if e.code == 500:
             # the server aborted this recipe DIE DIE DIE
             raise BkrProxyException("We have been aborted!!!")

--- a/client/cmdparser.py
+++ b/client/cmdparser.py
@@ -223,9 +223,9 @@ class CommandParser(object):
                 args = getattr(self, cmd)(args, options)
             except TypeError:
                 args = getattr(self, cmd)()
-        except SystemExit, return_code:
+        except SystemExit as return_code:
             sys.exit(return_code.code)
-        except Exception, error_detail:
+        except Exception as error_detail:
             if DEBUG:
                 raise
             sys.stderr.write("Command failed: %s -> %s\n" % (cmd, error_detail))
@@ -312,7 +312,7 @@ class CommandParser(object):
             myharness = harness.select(harness_name, myjob, harness_args)
             if not getattr(myharness, 'bootstrap'):
                 raise error.HarnessError("Does not support bootstrapping\n")
-        except Exception, error_detail:
+        except Exception as error_detail:
             if DEBUG:
                 raise
             sys.stderr.write("Harness %s failed to initialize -> %s\n" % (harness_name, error_detail))
@@ -322,7 +322,7 @@ class CommandParser(object):
         # get remote control file and stick it in FETCHDIRTEST
         try:
             control = myharness.bootstrap(FETCHDIRTEST)
-        except Exception, ex:
+        except Exception as ex:
             sys.stderr.write("bootstrap failed -> %s\n" % ex)
             raise SystemExit(1)
         logging.debug("bootstrap passing control file %s to run" % control)

--- a/client/fsdev_disks.py
+++ b/client/fsdev_disks.py
@@ -167,7 +167,7 @@ def mkfs_all_disks(job, disk_list, fs_type, fs_makeopt, fs_mnt_opt):
         if disk["mounted"]:
             try:
                 fs.unmount(mnt_path)
-            except Exception, info:
+            except Exception as info:
                 raise Exception("umount failed: exception = %s, args = %s" %
                                 (sys.exc_info()[0], info.args))
             except Exception:
@@ -190,9 +190,9 @@ def mkfs_all_disks(job, disk_list, fs_type, fs_makeopt, fs_mnt_opt):
             if fs_mnt_opt != "":
                 opts += " -o " + fs_mnt_opt
             fs.mount(mountpoint=mnt_path, fstype=fs_type, args=opts)
-        except NameError, info:
+        except NameError as info:
             raise Exception("mount name error: %s" % info)
-        except Exception, info:
+        except Exception as info:
             raise Exception("mount failed: exception = %s, args = %s" %
                             (type(info), info.args))
 
@@ -543,7 +543,7 @@ class fsdev_disks:
             if name == "scheduler":
                 nval = re.match(".*\[(.*)\].*", nval).group(1)
 
-        except IOError, info:
+        except IOError as info:
 
             # Special case: for some reason 'max_sectors_kb' often doesn't work
             # with large values; try '128' if we haven't tried it already.

--- a/client/harness_beaker.py
+++ b/client/harness_beaker.py
@@ -230,7 +230,7 @@ class harness_beaker(harness.harness):
         except HarnessException:
             # hook to bail out on reservesys systems and not run autotest
             return None
-        except Exception, ex:
+        except Exception as ex:
             os.remove(control_file_path)
             raise error.HarnessError('beaker_harness: convert failed with -> %s' % ex)
 
@@ -258,7 +258,7 @@ class harness_beaker(harness.harness):
         logging.debug('trying to get recipe from LC:')
         try:
             recipe = self.bkr_proxy.get_recipe()
-        except Exception, exc:
+        except Exception as exc:
             raise error.HarnessError('Failed to retrieve xml: %s' % exc)
         return recipe
 
@@ -480,7 +480,7 @@ class harness_beaker(harness.harness):
             else:
                 self.watchdog_pid = pid
                 logging.debug('harness: Watchdog process started, pid: %d', self.watchdog_pid)
-        except OSError, e:
+        except OSError as e:
             logging.error('harness: fork in start_watchdog failed: %d (%s)\n' % (e.errno, e.strerror))
 
     def kill_watchdog(self):

--- a/client/job.py
+++ b/client/job.py
@@ -121,7 +121,7 @@ class base_client_job(base_job.base_job):
         try:
             self._post_record_init(control, options, drop_caches,
                                    extra_copy_cmdline)
-        except Exception, err:
+        except Exception as err:
             self.record(
                 'ABORT', None, None, 'client.job.__init__ failed: %s' %
                 str(err))
@@ -517,7 +517,7 @@ class base_client_job(base_job.base_job):
             raise
         except error.JobError:
             raise  # Caught further up and turned into an ABORT.
-        except Exception, e:
+        except Exception as e:
             # Converts all other exceptions thrown by the test regardless
             # of phase into a TestError(TestBaseException) subclass that
             # reports them with their full stack trace.
@@ -554,7 +554,7 @@ class base_client_job(base_job.base_job):
         def group_func():
             try:
                 self._runtest(url, tag, timeout, args, dargs)
-            except error.TestBaseException, detail:
+            except error.TestBaseException as detail:
                 # The error is already classified, record it properly.
                 self.record(detail.exit_status, subdir, testname, str(detail))
                 raise
@@ -610,7 +610,7 @@ class base_client_job(base_job.base_job):
         try:
             self._rungroup(subdir, testname, group_func, timeout)
             return 'GOOD'
-        except error.TestBaseException, detail:
+        except error.TestBaseException as detail:
             return detail.exit_status
 
     def _rungroup(self, subdir, testname, function, timeout, *args, **dargs):
@@ -635,13 +635,13 @@ class base_client_job(base_job.base_job):
                 result = function(*args, **dargs)
                 self.record('END GOOD', subdir, testname)
                 return result
-            except error.TestBaseException, e:
+            except error.TestBaseException as e:
                 self.record('END %s' % e.exit_status, subdir, testname)
                 raise
-            except error.JobError, e:
+            except error.JobError as e:
                 self.record('END ABORT', subdir, testname)
                 raise
-            except Exception, e:
+            except Exception as e:
                 # This should only ever happen due to a bug in the given
                 # function's code.  The common case of being called by
                 # run_test() will never reach this.  If a control file called
@@ -674,7 +674,7 @@ class base_client_job(base_job.base_job):
             raise
         # If there was a different exception, turn it into a TestError.
         # It will be caught by step_engine or _run_step_fn.
-        except Exception, e:
+        except Exception as e:
             raise error.UnhandledTestError(e)
 
     def cpu_count(self):
@@ -891,7 +891,7 @@ class base_client_job(base_job.base_job):
             # wait for the task to finish
             try:
                 parallel.fork_waitfor(self.resultdir, pid)
-            except Exception, e:
+            except Exception as e:
                 exceptions.append(e)
             # copy the logs from the subtask into the main log
             new_log_path = old_log_path + (".%d" % i)
@@ -925,7 +925,7 @@ class base_client_job(base_job.base_job):
         # write out a job HTML report
         try:
             report.write_html_report(self.resultdir)
-        except Exception, e:
+        except Exception as e:
             logging.error("Error writing job HTML report: %s", e)
 
         # We are about to exit 'complete' so clean up the control file.
@@ -1038,9 +1038,9 @@ class base_client_job(base_job.base_job):
             return local_vars['__ret']
         except SystemExit:
             raise  # Send error.JobContinue and JobComplete on up to runjob.
-        except error.TestNAError, detail:
+        except error.TestNAError as detail:
             self.record(detail.exit_status, None, fn, str(detail))
-        except Exception, detail:
+        except Exception as detail:
             raise error.UnhandledJobError(detail)
 
     def _create_frame(self, global_vars, ancestry, fn_name):
@@ -1108,11 +1108,11 @@ class base_client_job(base_job.base_job):
         exec(JOB_PREAMBLE, global_control_vars, global_control_vars)
         try:
             execfile(self.control, global_control_vars, global_control_vars)
-        except error.TestNAError, detail:
+        except error.TestNAError as detail:
             self.record(detail.exit_status, None, self.control, str(detail))
         except SystemExit:
             raise  # Send error.JobContinue and JobComplete on up to runjob.
-        except Exception, detail:
+        except Exception as detail:
             # Syntax errors or other general Python exceptions coming out of
             # the top level of the control file itself go through here.
             raise error.UnhandledJobError(detail)
@@ -1270,7 +1270,7 @@ def runjob(control, drop_caches, options):
     except error.JobComplete:
         sys.exit(1)
 
-    except error.JobError, instance:
+    except error.JobError as instance:
         logging.error("JOB ERROR: " + str(instance))
         if myjob:
             command = None
@@ -1283,7 +1283,7 @@ def runjob(control, drop_caches, options):
         else:
             sys.exit(1)
 
-    except Exception, e:
+    except Exception as e:
         # NOTE: job._run_step_fn and job.step_engine will turn things into
         # a JobError for us.  If we get here, its likely an autotest bug.
         msg = str(e) + '\n' + traceback.format_exc()

--- a/client/job.py
+++ b/client/job.py
@@ -638,7 +638,7 @@ class base_client_job(base_job.base_job):
             except error.TestBaseException as e:
                 self.record('END %s' % e.exit_status, subdir, testname)
                 raise
-            except error.JobError as e:
+            except error.JobError:
                 self.record('END ABORT', subdir, testname)
                 raise
             except Exception as e:

--- a/client/kernelexpand.py
+++ b/client/kernelexpand.py
@@ -307,7 +307,7 @@ if __name__ == '__main__':
 
     try:
         components = decompose_kernel(kernel)
-    except NameError, e:
+    except NameError as e:
         sys.stderr.write(e.args[0] + "\n")
         sys.exit(1)
 

--- a/client/kernelexpand_unittest.py
+++ b/client/kernelexpand_unittest.py
@@ -62,7 +62,7 @@ class kernelexpandTest(unittest.TestCase):
             success = True
         except NameError:
             pass
-        except Exception, e:
+        except Exception as e:
             self.fail('expected NameError, got something else')
 
         if success:
@@ -85,7 +85,7 @@ class kernelexpandTest(unittest.TestCase):
             success = True
         except NameError:
             pass
-        except Exception, e:
+        except Exception as e:
             self.fail('expected NameError, got something else')
 
         if success:
@@ -112,7 +112,7 @@ class kernelexpandTest(unittest.TestCase):
             success = True
         except NameError:
             pass
-        except Exception, e:
+        except Exception as e:
             self.fail('expected NameError, got something else')
 
         if success:

--- a/client/kernelexpand_unittest.py
+++ b/client/kernelexpand_unittest.py
@@ -62,7 +62,7 @@ class kernelexpandTest(unittest.TestCase):
             success = True
         except NameError:
             pass
-        except Exception as e:
+        except Exception:
             self.fail('expected NameError, got something else')
 
         if success:
@@ -85,7 +85,7 @@ class kernelexpandTest(unittest.TestCase):
             success = True
         except NameError:
             pass
-        except Exception as e:
+        except Exception:
             self.fail('expected NameError, got something else')
 
         if success:
@@ -112,7 +112,7 @@ class kernelexpandTest(unittest.TestCase):
             success = True
         except NameError:
             pass
-        except Exception as e:
+        except Exception:
             self.fail('expected NameError, got something else')
 
         if success:

--- a/client/local_host.py
+++ b/client/local_host.py
@@ -39,7 +39,7 @@ class LocalHost(hosts.Host):
                 command, timeout=timeout, ignore_status=True,
                 stdout_tee=stdout_tee, stderr_tee=stderr_tee, stdin=stdin,
                 args=args)
-        except error.CmdError, e:
+        except error.CmdError as e:
             # this indicates a timeout exception
             raise error.AutotestHostRunError('command timed out', e.result_obj)
 

--- a/client/lv_utils.py
+++ b/client/lv_utils.py
@@ -73,7 +73,7 @@ def vg_ramdisk(vg_name, ramdisk_vg_size,
 
         logging.info("Finding free loop device")
         result = utils.run("losetup --find", verbose=True)
-    except error.CmdError, ex:
+    except error.CmdError as ex:
         logging.error(ex)
         vg_ramdisk_cleanup(ramdisk_filename, vg_ramdisk_dir,
                            vg_name, use_tmpfs)
@@ -88,7 +88,7 @@ def vg_ramdisk(vg_name, ramdisk_vg_size,
         result = utils.run("pvcreate %s" % loop_device)
         logging.info("Creating volume group %s", vg_name)
         result = utils.run("vgcreate %s %s" % (vg_name, loop_device))
-    except error.CmdError, ex:
+    except error.CmdError as ex:
         logging.error(ex)
         vg_ramdisk_cleanup(ramdisk_filename, vg_ramdisk_dir,
                            vg_name, loop_device, use_tmpfs)
@@ -362,7 +362,7 @@ def thin_lv_create(vg_name, thinpool_name="lvthinpool", thinpool_size="1.5G",
                                                       vg_name)
     try:
         utils.run(tp_cmd)
-    except error.CmdError, detail:
+    except error.CmdError as detail:
         logging.debug(detail)
         raise error.TestError("Create thin volume pool failed.")
     logging.debug("Created thin volume pool: %s", thinpool_name)
@@ -371,7 +371,7 @@ def thin_lv_create(vg_name, thinpool_name="lvthinpool", thinpool_size="1.5G",
                                 vg_name, thinpool_name))
     try:
         utils.run(lv_cmd)
-    except error.CmdError, detail:
+    except error.CmdError as detail:
         logging.debug(detail)
         raise error.TestError("Create thin volume failed.")
     logging.debug("Created thin volume:%s", thinlv_name)
@@ -421,7 +421,7 @@ def lv_take_snapshot(vg_name, lv_name,
            (lv_snapshot_name, vg_name, lv_name, lv_snapshot_size))
     try:
         result = utils.run(cmd)
-    except error.CmdError, ex:
+    except error.CmdError as ex:
         if ('Logical volume "%s" already exists in volume group "%s"' %
             (lv_snapshot_name, vg_name) in ex.result_obj.stderr and
             re.search(re.escape(lv_snapshot_name + " [active]"),
@@ -508,7 +508,7 @@ def lv_revert(vg_name, lv_name, lv_snapshot_name):
                                   lv_name)
         result = result.stdout.rstrip()
 
-    except error.TestError, ex:
+    except error.TestError as ex:
         # detect if merge of snapshot was postponed
         # and attempt to reactivate the volume.
         active_lv_pattern = re.escape("%s [active]" % lv_snapshot_name)
@@ -576,7 +576,7 @@ def lv_mount(vg_name, lv_name, mount_loc, create_filesystem=""):
                                                        vg_name, lv_name))
             logging.debug(result.stdout.rstrip())
         result = utils.run("mount /dev/%s/%s %s" % (vg_name, lv_name, mount_loc))
-    except error.CmdError, ex:
+    except error.CmdError as ex:
         logging.warning(ex)
         return False
     return True
@@ -592,7 +592,7 @@ def lv_umount(vg_name, lv_name, mount_loc):
 
     try:
         utils.run("umount /dev/%s/%s" % (vg_name, lv_name))
-    except error.CmdError, ex:
+    except error.CmdError as ex:
         logging.warning(ex)
         return False
     return True

--- a/client/os_dep_unittest.py
+++ b/client/os_dep_unittest.py
@@ -137,7 +137,7 @@ class TestCommand(unittest.TestCase):
             try:
                 os_dep.command("nosuch")
                 assert False
-            except ValueError, e:
+            except ValueError as e:
                 assert "nosuch" in e.message
         # pylint: disable=E1120
         _test()
@@ -149,7 +149,7 @@ class TestCommand(unittest.TestCase):
             try:
                 os_dep.command("\1")
                 assert False
-            except ValueError, e:
+            except ValueError as e:
                 assert "\1" in e.message
         # pylint: disable=E1120
         _test()
@@ -175,7 +175,7 @@ class TestCommands(unittest.TestCase):
             try:
                 cmds = os_dep.commands('a', 'b', 'c')
                 assert cmds == paths
-            except ValueError, e:
+            except ValueError as e:
                 assert "nosuch" in e.message
         # pylint: disable=E1120
         _test()
@@ -469,7 +469,7 @@ class TestHeaders(unittest.TestCase):
             try:
                 os_dep.header("nosuch.h")
                 assert False
-            except ValueError, e:
+            except ValueError as e:
                 assert "nosuch.h" in e.message
         # pylint: disable=E1120
         _test()

--- a/client/parallel.py
+++ b/client/parallel.py
@@ -26,9 +26,9 @@ def fork_start(tmp, l):
             l()
         except error.AutotestError:
             raise
-        except Exception, e:
+        except Exception as e:
             raise error.UnhandledTestError(e)
-    except Exception, detail:
+    except Exception as detail:
         try:
             try:
                 logging.error('child process failed')

--- a/client/partition.py
+++ b/client/partition.py
@@ -594,7 +594,7 @@ class partition(object):
             # We throw away the output here - we only need it on error, in
             # which case it's in the exception
             utils.system_output("yes | %s" % mkfs_cmd)
-        except error.CmdError, e:
+        except error.CmdError as e:
             logging.error(e.result_obj)
             if record:
                 self.job.record('FAIL', None, mkfs_cmd, error.format_error())
@@ -841,7 +841,7 @@ class virtual_partition:
                       'partition')
         try:
             os_dep.commands('sfdisk', 'losetup', 'kpartx')
-        except ValueError, e:
+        except ValueError as e:
             e_msg = 'Unable to create virtual partition: %s' % e
             raise error.AutotestError(e_msg)
 
@@ -877,7 +877,7 @@ class virtual_partition:
         try:
             cmd = 'dd if=/dev/zero of=%s bs=1024 count=%d' % (img_path, size)
             utils.run(cmd)
-        except error.CmdError, e:
+        except error.CmdError as e:
             e_msg = 'Error creating disk image %s: %s' % (img_path, e)
             raise error.AutotestError(e_msg)
         return img_path
@@ -896,7 +896,7 @@ class virtual_partition:
             loop_path = utils.system_output(cmd)
             cmd = 'losetup -f %s' % img_path
             utils.run(cmd)
-        except error.CmdError, e:
+        except error.CmdError as e:
             e_msg = ('Error attaching image %s to a loop device: %s' %
                      (img_path, e))
             raise error.AutotestError(e_msg)
@@ -916,7 +916,7 @@ class virtual_partition:
             sfdisk_cmd_file.write(single_part_cmd)
             sfdisk_cmd_file.close()
             utils.run('sfdisk %s < %s' % (loop_path, sfdisk_file_path))
-        except error.CmdError, e:
+        except error.CmdError as e:
             e_msg = 'Error partitioning device %s: %s' % (loop_path, e)
             raise error.AutotestError(e_msg)
 
@@ -936,7 +936,7 @@ class virtual_partition:
             utils.run(cmd)
             l_cmd = 'kpartx -l %s | cut -f1 -d " "' % loop_path
             device = utils.system_output(l_cmd)
-        except error.CmdError, e:
+        except error.CmdError as e:
             e_msg = 'Error creating entries for %s: %s' % (loop_path, e)
             raise error.AutotestError(e_msg)
         return os.path.join('/dev/mapper', device)
@@ -951,7 +951,7 @@ class virtual_partition:
         try:
             cmd = 'kpartx -d %s' % self.loop
             utils.run(cmd)
-        except error.CmdError, e:
+        except error.CmdError as e:
             e_msg = 'Error removing entries for loop %s: %s' % (self.loop, e)
             raise error.AutotestError(e_msg)
 
@@ -964,7 +964,7 @@ class virtual_partition:
         try:
             cmd = 'losetup -d %s' % self.loop
             utils.run(cmd)
-        except error.CmdError, e:
+        except error.CmdError as e:
             e_msg = ('Error detaching image %s from loop device %s: %s' %
                      (self.img, self.loop, e))
             raise error.AutotestError(e_msg)

--- a/client/profilers/kvm_stat/kvm_stat.py
+++ b/client/profilers/kvm_stat/kvm_stat.py
@@ -39,11 +39,11 @@ class kvm_stat(profiler.profiler):
             try:
                 utils.run("%s --batch" % self.stat_path)
                 self.is_enabled = True
-            except error.CmdError, e:
+            except error.CmdError as e:
                 if 'debugfs' in str(e):
                     try:
                         utils.run('mount -t debugfs debugfs /sys/kernel/debug')
-                    except error.CmdError, e:
+                    except error.CmdError as e:
                         logging.error('Failed to mount debugfs:\n%s', str(e))
                 else:
                     logging.error('Failed to execute kvm_stat:\n%s', str(e))

--- a/client/samples/interactive_console/control
+++ b/client/samples/interactive_console/control
@@ -23,7 +23,7 @@ try:
         app = TerminalIPythonApp.instance()
         app.initialize(argv=[])
         app.start()
-    except AttributeError, e:
+    except AttributeError as e:
         # IPython < 0.11
         ipshell = IPython.Shell.IPShellEmbed(argv=[], banner='autotest console')
         ipshell()

--- a/client/samples/interactive_console/control
+++ b/client/samples/interactive_console/control
@@ -23,7 +23,7 @@ try:
         app = TerminalIPythonApp.instance()
         app.initialize(argv=[])
         app.start()
-    except AttributeError as e:
+    except AttributeError:
         # IPython < 0.11
         ipshell = IPython.Shell.IPShellEmbed(argv=[], banner='autotest console')
         ipshell()

--- a/client/setup_job.py
+++ b/client/setup_job.py
@@ -75,7 +75,7 @@ def init_test(options, testdir):
                          (test_name, test_name))
             exec import_stmt + '\n' + init_stmt in locals_dict, globals_dict
             client_test = globals_dict['auto_test']
-        except ImportError, e:
+        except ImportError as e:
             # skips error if test is control file without python test
             if re.search(test_name, str(e)):
                 pass
@@ -83,7 +83,7 @@ def init_test(options, testdir):
             else:
                 logging.error('%s import error: %s.  Skipping %s' %
                               (test_name, e, test_name))
-        except Exception, e:
+        except Exception as e:
             # Log other errors (e.g., syntax errors) and collect the test.
             logging.error("%s: %s", test_name, e)
     finally:
@@ -156,7 +156,7 @@ def setup_test(client_test):
                 versionfile = os.path.join(client_test.srcdir, '.version')
                 pickle.dump(client_test.version, open(versionfile, 'w'))
             good_setup = True
-        except Exception, err:
+        except Exception as err:
             logging.error(err)
             raise error.AutoservError('Failed to build client test %s on '
                                       'server.' % test_name)

--- a/client/shared/backports/collections/namedtuple.py
+++ b/client/shared/backports/collections/namedtuple.py
@@ -123,7 +123,7 @@ def namedtuple(typename, field_names, verbose=False, rename=False):
         _property=property, _tuple=tuple)
     try:
         exec template in namespace
-    except SyntaxError, e:
+    except SyntaxError as e:
         raise SyntaxError(e.message + ':\n' + template)
     result = namespace[typename]
 

--- a/client/shared/backports/simplejson/tool.py
+++ b/client/shared/backports/simplejson/tool.py
@@ -31,7 +31,7 @@ def main():
         obj = json.load(infile,
                         object_pairs_hook=json.OrderedDict,
                         use_decimal=True)
-    except ValueError, e:
+    except ValueError as e:
         raise SystemExit(e)
     json.dump(obj, outfile, sort_keys=True, indent='    ', use_decimal=True)
     outfile.write('\n')

--- a/client/shared/base_barrier.py
+++ b/client/shared/base_barrier.py
@@ -408,7 +408,7 @@ class barrier(object):
                 logging.warn("timeout calling host, retry")
                 sleep(10)
                 pass
-            except socket.error, err:
+            except socket.error as err:
                 (code, str) = err
                 if (code != errno.ECONNREFUSED):
                     raise

--- a/client/shared/base_job.py
+++ b/client/shared/base_job.py
@@ -120,7 +120,7 @@ class job_directory(object):
         if is_writable:
             try:
                 os.makedirs(self.path)
-            except OSError, e:
+            except OSError as e:
                 if e.errno != errno.EEXIST or not os.path.isdir(self.path):
                     raise self.UncreatableDirectoryException(self.path, e)
         elif not os.path.isdir(self.path):
@@ -1277,7 +1277,7 @@ class base_job(object):
         try:
             outputdir = self._job_directory(path, True)
             return outputdir
-        except self._job_directory.JobDirectoryException, e:
+        except self._job_directory.JobDirectoryException as e:
             logging.exception('%s directory creation failed with %s',
                               subdir, e)
             raise error.TestError('%s directory creation failed' % subdir)

--- a/client/shared/base_packages.py
+++ b/client/shared/base_packages.py
@@ -134,7 +134,7 @@ def check_diskspace(repo, min_free=None):
         df = repo_run_command(repo,
                               'df -PB %d . | tail -1' % 10 ** 9).stdout.split()
         free_space_gb = int(df[3])
-    except Exception, e:
+    except Exception as e:
         raise error.RepoUnknownError('Unknown Repo Error: %s' % e)
     if free_space_gb < min_free:
         raise error.RepoDiskFullError('Not enough disk space available '
@@ -293,7 +293,7 @@ class HttpFetcher(RepositoryFetcher):
             http_cmd = self.wget_cmd_pattern % (self.url, dest_file_path)
             try:
                 self.run_command(http_cmd, _run_command_dargs={'timeout': 30})
-            except Exception, e:
+            except Exception as e:
                 msg = 'HTTP test failed, unable to contact %s: %s'
                 raise error.PackageFetchError(msg % (self.url, e))
         finally:
@@ -436,7 +436,7 @@ class LocalFilesystemFetcher(RepositoryFetcher):
             self.run_command('cp %s %s' % (local_path, dest_path))
             logging.debug('Successfully fetched %s from %s', filename,
                           local_path)
-        except error.CmdError, e:
+        except error.CmdError as e:
             raise error.PackageFetchError(
                 'Package %s could not be fetched from %s'
                 % (filename, self.url), e)
@@ -552,7 +552,7 @@ class BasePackageManager(object):
             check_diskspace(repo)
             check_write(repo)
         except (error.RepoWriteError, error.RepoUnknownError,
-                error.RepoDiskFullError), e:
+                error.RepoDiskFullError) as e:
             raise error.RepoError("ERROR: Repo %s: %s" % (repo, e))
 
     def upkeep(self, custom_repos=None):
@@ -616,7 +616,7 @@ class BasePackageManager(object):
                                          repo_url=repo_url, install=True)
 
                 fetcher.install_pkg_post(pkg_name, fetch_dir, install_dir, preserve_install_dir)
-            except error.PackageFetchError, why:
+            except error.PackageFetchError as why:
                 raise error.PackageInstallError(
                     'Installation of %s(type:%s) failed : %s'
                     % (name, pkg_type, why))
@@ -785,7 +785,7 @@ class BasePackageManager(object):
                 shutil.copy(file_path, upload_path)
                 os.chmod(os.path.join(upload_path,
                                       os.path.basename(file_path)), 0644)
-        except (IOError, os.error), why:
+        except (IOError, os.error) as why:
             logging.error("Upload of %s to %s failed: %s", file_path,
                           upload_path, why)
 
@@ -814,7 +814,7 @@ class BasePackageManager(object):
                 utils.run("cp %s %s " % (local_path, upload_path))
                 up_path = os.path.join(upload_path, "*")
                 utils.run("chmod 644 %s" % up_path)
-        except (IOError, os.error), why:
+        except (IOError, os.error) as why:
             raise error.PackageUploadError("Upload of %s to %s failed: %s"
                                            % (dir_path, upload_path, why))
 
@@ -857,7 +857,7 @@ class BasePackageManager(object):
                                                      path))
             else:
                 os.remove(os.path.join(pkg_dir, filename))
-        except (IOError, os.error), why:
+        except (IOError, os.error) as why:
             raise error.PackageRemoveError("Could not remove %s from %s: %s "
                                            % (filename, pkg_dir, why))
 

--- a/client/shared/base_syncdata.py
+++ b/client/shared/base_syncdata.py
@@ -46,7 +46,7 @@ def net_recv_object(sock, timeout=60):
             data += sock.recv(d_len - len(data))
         data = pickle.loads(data)
         return data
-    except (socket.timeout, ValueError), e:
+    except (socket.timeout, ValueError) as e:
         raise error.NetCommunicationError("Failed to receive python"
                                           " object over the network.")
 
@@ -300,7 +300,7 @@ class SyncData(object):
                 logging.warn("timeout calling host %s, retry" %
                              (self.masterid))
                 time.sleep(1)
-            except socket.error, err:
+            except socket.error as err:
                 (code, _) = err
                 if (code != errno.ECONNREFUSED):
                     raise

--- a/client/shared/base_syncdata.py
+++ b/client/shared/base_syncdata.py
@@ -46,7 +46,7 @@ def net_recv_object(sock, timeout=60):
             data += sock.recv(d_len - len(data))
         data = pickle.loads(data)
         return data
-    except (socket.timeout, ValueError) as e:
+    except (socket.timeout, ValueError):
         raise error.NetCommunicationError("Failed to receive python"
                                           " object over the network.")
 

--- a/client/shared/boottool.py
+++ b/client/shared/boottool.py
@@ -38,7 +38,7 @@ class boottool(Grubby):
                 install_grubby_if_necessary()
                 Grubby.__init__(self, self.path)
                 self.instantiated = True
-            except Exception, e:
+            except Exception as e:
                 raise error.JobError("Unable to instantiate boottool: %s" % e)
 
     def __getattr__(self, name):

--- a/client/shared/control_data.py
+++ b/client/shared/control_data.py
@@ -175,7 +175,7 @@ def parse_control(path, raise_warnings=False):
                 key, val = fn(n)
 
                 vars[key] = val
-            except AssertionError as e:
+            except AssertionError:
                 pass
 
     return ControlData(vars, path, raise_warnings)

--- a/client/shared/control_data.py
+++ b/client/shared/control_data.py
@@ -36,7 +36,7 @@ class ControlData(object):
         for key, val in vars.iteritems():
             try:
                 self.set_attr(key, val, raise_warnings)
-            except Exception, e:
+            except Exception as e:
                 if raise_warnings:
                     raise
                 print "WARNING: %s; skipping" % e
@@ -160,7 +160,7 @@ def _extract_name(n):
 def parse_control(path, raise_warnings=False):
     try:
         mod = compiler.parseFile(path)
-    except SyntaxError, e:
+    except SyntaxError as e:
         raise ControlVariableException("Error parsing %s because %s" %
                                        (path, e))
 
@@ -175,7 +175,7 @@ def parse_control(path, raise_warnings=False):
                 key, val = fn(n)
 
                 vars[key] = val
-            except AssertionError, e:
+            except AssertionError as e:
                 pass
 
     return ControlData(vars, path, raise_warnings)

--- a/client/shared/error.py
+++ b/client/shared/error.py
@@ -138,7 +138,7 @@ def context_aware(fn):
         try:
             try:
                 return fn(*args, **kwargs)
-            except Exception, e:
+            except Exception as e:
                 if not exception_context(e):
                     set_exception_context(e, get_context())
                 raise

--- a/client/shared/hosts/base_classes.py
+++ b/client/shared/hosts/base_classes.py
@@ -361,10 +361,10 @@ class Host(object):
                                  ' inodes')
                     self.reboot()
                 return  # verify succeeded, then repair succeeded
-            except error.AutoservHostIsShuttingDownError, err:
+            except error.AutoservHostIsShuttingDownError as err:
                 logging.exception('verify failed')
                 self._call_repair_func(err, self._repair_wait_for_reboot)
-            except error.AutoservDiskFullHostError, err:
+            except error.AutoservDiskFullHostError as err:
                 logging.exception('verify failed')
                 self._call_repair_func(err, self.repair_full_disk,
                                        self._get_mountpoint(err.path))
@@ -377,7 +377,7 @@ class Host(object):
                 break
             except (error.AutoservSshPingHostError, error.AutoservSSHTimeout,
                     error.AutoservSshPermissionDeniedError,
-                    error.AutoservDiskFullHostError), err:
+                    error.AutoservDiskFullHostError) as err:
                 logging.exception('verify failed')
                 logging.info('Trying to reinstall the machine')
                 self._call_repair_func(err, self.machine_install)
@@ -388,7 +388,7 @@ class Host(object):
             try:
                 self.repair_software_only()
                 break
-            except error.AutoservHardwareRepairRequiredError, err:
+            except error.AutoservHardwareRepairRequiredError as err:
                 logging.exception('software repair failed, '
                                   'hardware repair requested')
                 hardware_repair_requests += 1
@@ -403,7 +403,7 @@ class Host(object):
                     logging.info('hardware repair requested %d times, '
                                  'trying software repair again',
                                  hardware_repair_requests)
-            except error.AutoservHardwareHostError, err:
+            except error.AutoservHardwareHostError as err:
                 logging.exception('verify failed')
                 # software repair failed, try hardware repair
                 logging.info('Hardware problem found, '

--- a/client/shared/jsontemplate.py
+++ b/client/shared/jsontemplate.py
@@ -1199,7 +1199,7 @@ def _DoSubstitute(args, context, callback):
     else:
         try:
             value = context.Lookup(name)
-        except TypeError, e:
+        except TypeError as e:
             raise EvaluationError(
                 'Error evaluating %r in context %r: %r' % (name, context, e))
 
@@ -1211,7 +1211,7 @@ def _DoSubstitute(args, context, callback):
                 value = func(value)
         except KeyboardInterrupt:
             raise
-        except Exception, e:
+        except Exception as e:
             raise EvaluationError(
                 'Formatting value %r with formatter %s raised exception: %r' %
                 (value, formatters, e), original_exception=e)
@@ -1240,7 +1240,7 @@ def _Execute(statements, context, callback):
             try:
                 func, args = statement
                 func(args, context, callback)
-            except UndefinedVariable, e:
+            except UndefinedVariable as e:
                 # Show context for statements
                 start = max(0, i - 3)
                 end = i + 3

--- a/client/shared/log.py
+++ b/client/shared/log.py
@@ -58,7 +58,7 @@ def record(fn):
         try:
             result = fn(self, *args, **dargs)
             job.record('GOOD', subdir, operation)
-        except Exception, detail:
+        except Exception as detail:
             job.record('FAIL', subdir, operation, str(detail))
             raise
         return result

--- a/client/shared/magic.py
+++ b/client/shared/magic.py
@@ -1042,7 +1042,7 @@ def guess_type(filename):
 
     try:
         data = open(filename, 'r').read(8192)
-    except Exception, e:
+    except Exception as e:
         logging.error(str(e))
         return None
 

--- a/client/shared/openvswitch.py
+++ b/client/shared/openvswitch.py
@@ -298,14 +298,14 @@ class OpenVSwitchControlCli_140(OpenVSwitchControlCli, VersionableClass):
     def del_br(self, br_name):
         try:
             self.ovs_vsctl(["del-br", br_name])
-        except error.CmdError, e:
+        except error.CmdError as e:
             logging.debug(e.result_obj)
             raise
 
     def br_exist(self, br_name):
         try:
             self.ovs_vsctl(["br-exists", br_name])
-        except error.CmdError, e:
+        except error.CmdError as e:
             if e.result_obj.exit_status == 2:
                 return False
             else:
@@ -348,7 +348,7 @@ class OpenVSwitchControlCli_140(OpenVSwitchControlCli, VersionableClass):
         bridge = None
         try:
             bridge = self.ovs_vsctl(["port-to-br", port_name]).stdout
-        except error.CmdError, e:
+        except error.CmdError as e:
             if e.result_obj.exit_status == 1:
                 pass
         return bridge
@@ -487,7 +487,7 @@ class OpenVSwitch(OpenVSwitchSystem):
         self.tmpdir = "/%s/openvswitch" % (tmpdir)
         try:
             os.mkdir(self.tmpdir)
-        except OSError, e:
+        except OSError as e:
             if e.errno != 17:
                 raise
 

--- a/client/shared/remote.py
+++ b/client/shared/remote.py
@@ -178,9 +178,9 @@ def handle_prompts(session, username, password, prompt, timeout=10,
                 if debug:
                     logging.debug("Got shell prompt -- logged in")
                 break
-        except aexpect.ExpectTimeoutError, e:
+        except aexpect.ExpectTimeoutError as e:
             raise LoginTimeoutError(e.output)
-        except aexpect.ExpectProcessTerminatedError, e:
+        except aexpect.ExpectProcessTerminatedError as e:
             raise LoginProcessTerminatedError(e.status, e.output)
 
 
@@ -264,7 +264,7 @@ def wait_for_login(client, host, port, username, password, prompt,
             return remote_login(client, host, port, username, password, prompt,
                                 linesep, log_filename, internal_timeout,
                                 interface)
-        except LoginError, e:
+        except LoginError as e:
             logging.debug(e)
         time.sleep(2)
     # Timeout expired; try one more time but don't catch exceptions
@@ -332,12 +332,12 @@ def _remote_scp(session, password_list, transfer_timeout=600, login_timeout=20):
                                                  text)
             elif match == 2:  # "lost connection"
                 raise SCPError("SCP client said 'lost connection'", text)
-        except aexpect.ExpectTimeoutError, e:
+        except aexpect.ExpectTimeoutError as e:
             if authentication_done:
                 raise SCPTransferTimeoutError(e.output)
             else:
                 raise SCPAuthenticationTimeoutError(e.output)
-        except aexpect.ExpectProcessTerminatedError, e:
+        except aexpect.ExpectProcessTerminatedError as e:
             if e.status == 0:
                 logging.debug("SCP process terminated with status 0")
                 break

--- a/client/shared/report.py
+++ b/client/shared/report.py
@@ -355,9 +355,9 @@ if __name__ == "__main__":
         write_html_report(results_dir=options.results_dir,
                           report_path=options.report_path,
                           encoding=options.encoding)
-    except InvalidAutotestResultDirError, e:
+    except InvalidAutotestResultDirError as e:
         logging.error(e)
         sys.exit(ERROR_INVALID_RESULT_DIR)
-    except InvalidOutputDirError, e:
+    except InvalidOutputDirError as e:
         logging.error(e)
         sys.exit(ERROR_INVALID_REPORT_PATH)

--- a/client/shared/rss_client.py
+++ b/client/shared/rss_client.py
@@ -103,7 +103,7 @@ class FileTransferClient(object):
         self._socket.settimeout(timeout)
         try:
             self._socket.connect((address, port))
-        except socket.error, e:
+        except socket.error as e:
             raise FileTransferConnectError("Cannot connect to server at "
                                            "%s:%s" % (address, port), e)
         try:
@@ -136,7 +136,7 @@ class FileTransferClient(object):
         except socket.timeout:
             raise FileTransferTimeoutError("Timeout expired while sending "
                                            "data to server")
-        except socket.error, e:
+        except socket.error as e:
             raise FileTransferSocketError("Could not send data to server", e)
 
     def _receive(self, size, timeout=60):
@@ -159,7 +159,7 @@ class FileTransferClient(object):
         except socket.timeout:
             raise FileTransferTimeoutError("Timeout expired while receiving "
                                            "data from server")
-        except socket.error, e:
+        except socket.error as e:
             raise FileTransferSocketError("Error receiving data from server",
                                           e)
         return "".join(strs)
@@ -201,7 +201,7 @@ class FileTransferClient(object):
                     self._send_packet(data, end_time - time.time())
                     if len(data) < CHUNKSIZE:
                         break
-            except FileTransferError, e:
+            except FileTransferError as e:
                 e.filename = filename
                 raise
         finally:
@@ -219,7 +219,7 @@ class FileTransferClient(object):
                     f.write(data)
                     if len(data) < CHUNKSIZE:
                         break
-            except FileTransferError, e:
+            except FileTransferError as e:
                 e.filename = filename
                 raise
         finally:

--- a/client/shared/software_manager.py
+++ b/client/shared/software_manager.py
@@ -476,7 +476,7 @@ class YumBackend(RpmBackend):
             return None
         try:
             d_provides = self.yum_base.searchPackageProvides(args=[name])
-        except Exception, e:
+        except Exception as e:
             logging.error("Error searching for package that "
                           "provides %s: %s", name, e)
             d_provides = []

--- a/client/shared/test.py
+++ b/client/shared/test.py
@@ -448,7 +448,7 @@ class base_test(object):
                 self.job.enable_warnings("NETWORK")
             # Pass already-categorized errors on up.
             raise
-        except Exception, e:
+        except Exception as e:
             if self.network_destabilizing:
                 self.job.enable_warnings("NETWORK")
             # Anything else is an ERROR in our own code, not execute().
@@ -824,7 +824,7 @@ def _call_test_function(func, *args, **dargs):
     except error.AutotestError:
         # Pass already-categorized errors on up as is.
         raise
-    except Exception, e:
+    except Exception as e:
         # Other exceptions must be treated as a FAIL when
         # raised during the test functions
         raise error.UnhandledTestFail(e)

--- a/client/shared/test.py
+++ b/client/shared/test.py
@@ -431,7 +431,7 @@ class base_test(object):
                 finally:
                     self.job.logging.restore()
                     try:
-                        raise exc_info[0], exc_info[1], exc_info[2]
+                        raise exc_info[0](exc_info[1])
                     finally:
                         # http://docs.python.org/library/sys.html#sys.exc_info
                         # Be nice and prevent a circular reference.

--- a/client/shared/test_utils/unittest.py
+++ b/client/shared/test_utils/unittest.py
@@ -475,7 +475,7 @@ class TestCase(object):
         try:
             try:
                 self.setUp()
-            except SkipTest, e:
+            except SkipTest as e:
                 result.addSkip(self, str(e))
                 return
             except Exception:
@@ -487,11 +487,11 @@ class TestCase(object):
                 testMethod()
             except self.failureException:
                 result.addFailure(self, sys.exc_info())
-            except _ExpectedFailure, e:
+            except _ExpectedFailure as e:
                 result.addExpectedFailure(self, e.exc_info)
             except _UnexpectedSuccess:
                 result.addUnexpectedSuccess(self)
-            except SkipTest, e:
+            except SkipTest as e:
                 result.addSkip(self, str(e))
             except Exception:
                 result.addError(self, sys.exc_info())
@@ -810,16 +810,16 @@ class TestCase(object):
         """
         try:
             difference1 = set1.difference(set2)
-        except TypeError, e:
+        except TypeError as e:
             self.fail('invalid type when attempting set difference: %s' % e)
-        except AttributeError, e:
+        except AttributeError as e:
             self.fail('first argument does not support set difference: %s' % e)
 
         try:
             difference2 = set2.difference(set1)
-        except TypeError, e:
+        except TypeError as e:
             self.fail('invalid type when attempting set difference: %s' % e)
-        except AttributeError, e:
+        except AttributeError as e:
             self.fail('second argument does not support set difference: %s' % e)
 
         if not (difference1 or difference2):
@@ -1567,7 +1567,7 @@ Examples:
             else:
                 self.testNames = (self.defaultTest,)
             self.createTests()
-        except getopt.error, msg:
+        except getopt.error as msg:
             self.usageExit(msg)
 
     def createTests(self):

--- a/client/shared/utils.py
+++ b/client/shared/utils.py
@@ -2315,7 +2315,7 @@ def safe_rmdir(path, timeout=10):
             shutil.rmtree(path)
             success = True
             break
-        except OSError, err_info:
+        except OSError as err_info:
             # We are only going to try if the error happened due to
             # directory not empty (errno 39). Otherwise, raise the
             # original exception.

--- a/client/shared/utils_cgroup.py
+++ b/client/shared/utils_cgroup.py
@@ -155,7 +155,7 @@ class Cgroup(object):
                 pwd = os.path.join(pwd, cgroup) + '/'
                 if not os.path.exists(pwd):
                     os.mkdir(pwd)
-        except Exception, inst:
+        except Exception as inst:
             raise error.TestError("cg.mk_cgroup(): %s" % inst)
         self.cgroups.append(pwd)
         return len(self.cgroups) - 1
@@ -176,7 +176,7 @@ class Cgroup(object):
                           (self.module, cgroup, cmd, args_str))
             status, output = commands.getstatusoutput(cgexec_cmd)
             return status, output
-        except error.CmdError, detail:
+        except error.CmdError as detail:
             raise error.TestFail("Execute %s in cgroup failed!\n%s" %
                                  (cmd, detail))
 
@@ -194,7 +194,7 @@ class Cgroup(object):
         except ValueError:
             logging.warn("cg.rm_cgroup(): Removed cgroup which wasn't created"
                          "using this Cgroup")
-        except Exception, inst:
+        except Exception as inst:
             raise error.TestError("cg.rm_cgroup(): %s" % inst)
 
     def cgdelete_all_cgroups(self):
@@ -228,7 +228,7 @@ class Cgroup(object):
                 cmd += " -r"
             utils.run(cmd, ignore_status=False)
             self.cgroups.remove(cgroup_pwd)
-        except error.CmdError, detail:
+        except error.CmdError as detail:
             raise error.TestFail("cgdelete %s failed!\n%s" %
                                  (cgroup, detail))
 
@@ -246,7 +246,7 @@ class Cgroup(object):
             cgclassify_cmd = ("cgclassify -g %s:%s %d" %
                               (self.module, cgroup, pid))
             utils.run(cgclassify_cmd, ignore_status=False)
-        except error.CmdError, detail:
+        except error.CmdError as detail:
             raise error.TestFail("Classify process to tasks file failed!:%s" %
                                  detail)
 
@@ -263,7 +263,7 @@ class Cgroup(object):
             pwd = self.cgroups[pwd]
         try:
             return [_.strip() for _ in open(os.path.join(pwd, 'tasks'), 'r')]
-        except Exception, inst:
+        except Exception as inst:
             raise error.TestError("cg.get_pids(): %s" % inst)
 
     def test(self, cmd):
@@ -314,7 +314,7 @@ class Cgroup(object):
             pwd = self.cgroups[pwd]
         try:
             open(os.path.join(pwd, 'tasks'), 'w').write(str(pid))
-        except Exception, inst:
+        except Exception as inst:
             raise error.TestError("cg.set_cgroup(): %s" % inst)
         if self.is_cgroup(pid, pwd):
             raise error.TestError("cg.set_cgroup(): Setting %d pid into %s "
@@ -368,7 +368,7 @@ class Cgroup(object):
                 return ret
             else:
                 return [""]
-        except Exception, inst:
+        except Exception as inst:
             raise error.TestError("cg.get_property(): %s" % inst)
 
     def set_property_h(self, prop, value, pwd=None, check=True, checkprop=None):
@@ -412,7 +412,7 @@ class Cgroup(object):
             pwd = self.cgroups[pwd]
         try:
             open(os.path.join(pwd, prop), 'w').write(value)
-        except Exception, inst:
+        except Exception as inst:
             raise error.TestError("cg.set_property(): %s" % inst)
 
         if check is not False:
@@ -446,7 +446,7 @@ class Cgroup(object):
             cgroup = self.get_cgroup_name(pwd)
             cgset_cmd = "cgset -r %s='%s' %s" % (prop, value, cgroup)
             utils.run(cgset_cmd, ignore_status=False)
-        except error.CmdError, detail:
+        except error.CmdError as detail:
             raise error.TestFail("Modify %s failed!:\n%s" % (prop, detail))
 
         if check is not False:
@@ -532,7 +532,7 @@ class CgroupModules(object):
             if self.modules[2][i]:
                 try:
                     utils.system('umount %s -l' % self.modules[1][i])
-                except Exception, failure_detail:
+                except Exception as failure_detail:
                     logging.warn("CGM: Couldn't unmount %s directory: %s",
                                  self.modules[1][i], failure_detail)
         try:
@@ -597,7 +597,7 @@ class CgroupModules(object):
         """
         try:
             i = self.modules[0].index(module)
-        except Exception, inst:
+        except Exception as inst:
             logging.error("module %s not found: %s", module, inst)
             return None
         return self.modules[1][i]
@@ -704,7 +704,7 @@ def service_cgconfig_control(action):
             utils.run("service cgconfig %s" % action)
             logging.debug("%s cgconfig successfully", action)
             return True
-        except error.CmdError, detail:
+        except error.CmdError as detail:
             logging.error("Failed to %s cgconfig:\n%s", action, detail)
             return False
     elif action == "status" or action == "exists":
@@ -774,6 +774,6 @@ def all_cgroup_delete():
     """
     try:
         utils.run("cgclear", ignore_status=False)
-    except error.CmdError, detail:
+    except error.CmdError as detail:
         logging.warn("cgclear: Fail to clear all cgroups, some specific system"
                      " cgroups might exist and affect further testing.")

--- a/client/shared/utils_cgroup.py
+++ b/client/shared/utils_cgroup.py
@@ -774,6 +774,6 @@ def all_cgroup_delete():
     """
     try:
         utils.run("cgclear", ignore_status=False)
-    except error.CmdError as detail:
+    except error.CmdError:
         logging.warn("cgclear: Fail to clear all cgroups, some specific system"
                      " cgroups might exist and affect further testing.")

--- a/client/shared/utils_unittest.py
+++ b/client/shared/utils_unittest.py
@@ -632,7 +632,7 @@ class test_run(unittest.TestCase):
         cmd = 'exit 11'
         try:
             utils.run(cmd, verbose=False)
-        except utils.error.CmdError, err:
+        except utils.error.CmdError as err:
             self.__check_result(err.result_obj, cmd, exit_status=11)
 
     def test_ignore_status(self):
@@ -645,7 +645,7 @@ class test_run(unittest.TestCase):
         utils.logging.warn.expect_any_call()
         try:
             utils.run('echo -n output && sleep 10', timeout=1, verbose=False)
-        except utils.error.CmdError, err:
+        except utils.error.CmdError as err:
             self.assertEquals(err.result_obj.stdout, 'output')
 
     def test_stdout_stderr_tee(self):

--- a/client/test.py
+++ b/client/test.py
@@ -81,7 +81,7 @@ class test(common_test.base_test):
             self.debugdir_tmp_file = ('/tmp/autotest_results_dir.%s' %
                                       os.getpid())
             utils.open_write_close(self.debugdir_tmp_file, self.debugdir + "\n")
-        except Exception, e:
+        except Exception as e:
             logging.warning('Crash handling disabled: %s', e)
         else:
             self.crash_handling_enabled = True

--- a/client/test_config.py
+++ b/client/test_config.py
@@ -167,20 +167,20 @@ class config_loader:
     def __isint(self, parameter):
         try:
             int(parameter)
-        except Exception, e_stack:
+        except Exception as e_stack:
             return False
         return True
 
     def __isfloat(self, parameter):
         try:
             float(parameter)
-        except Exception, e_stack:
+        except Exception as e_stack:
             return False
         return True
 
     def __isstr(self, parameter):
         try:
             str(parameter)
-        except Exception, e_stack:
+        except Exception as e_stack:
             return False
         return True

--- a/client/test_config.py
+++ b/client/test_config.py
@@ -167,20 +167,20 @@ class config_loader:
     def __isint(self, parameter):
         try:
             int(parameter)
-        except Exception as e_stack:
+        except Exception:
             return False
         return True
 
     def __isfloat(self, parameter):
         try:
             float(parameter)
-        except Exception as e_stack:
+        except Exception:
             return False
         return True
 
     def __isstr(self, parameter):
         try:
             str(parameter)
-        except Exception as e_stack:
+        except Exception:
             return False
         return True

--- a/client/tools/JUnit_api.py
+++ b/client/tools/JUnit_api.py
@@ -73,7 +73,7 @@ def parsexml_(*args, **kwargs):
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError, exp:
+except ImportError as exp:
 
     class GeneratedsSuper(object):
 
@@ -97,7 +97,7 @@ except ImportError, exp:
             for value in values:
                 try:
                     fvalue = float(value)
-                except (TypeError, ValueError), exp:
+                except (TypeError, ValueError) as exp:
                     raise_parse_error(node, 'Requires sequence of integers')
             return input_data
 
@@ -115,7 +115,7 @@ except ImportError, exp:
             for value in values:
                 try:
                     fvalue = float(value)
-                except (TypeError, ValueError), exp:
+                except (TypeError, ValueError) as exp:
                     raise_parse_error(node, 'Requires sequence of floats')
             return input_data
 
@@ -133,7 +133,7 @@ except ImportError, exp:
             for value in values:
                 try:
                     fvalue = float(value)
-                except (TypeError, ValueError), exp:
+                except (TypeError, ValueError) as exp:
                     raise_parse_error(node, 'Requires sequence of doubles')
             return input_data
 
@@ -784,14 +784,14 @@ class testsuite(GeneratedsSuper):
             already_processed.append('tests')
             try:
                 self.tests = int(value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
         value = find_attr_value_('errors', node)
         if value is not None and 'errors' not in already_processed:
             already_processed.append('errors')
             try:
                 self.errors = int(value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
         value = find_attr_value_('name', node)
         if value is not None and 'name' not in already_processed:
@@ -813,14 +813,14 @@ class testsuite(GeneratedsSuper):
             already_processed.append('time')
             try:
                 self.time = float(value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad float/double attribute (time): %s' % exp)
         value = find_attr_value_('failures', node)
         if value is not None and 'failures' not in already_processed:
             already_processed.append('failures')
             try:
                 self.failures = int(value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
         value = find_attr_value_('xsi:type', node)
         if value is not None and 'xsi:type' not in already_processed:
@@ -1083,7 +1083,7 @@ class testsuiteType(testsuite):
             already_processed.append('id')
             try:
                 self.id = int(value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise_parse_error(node, 'Bad integer attribute: %s' % exp)
         value = find_attr_value_('package', node)
         if value is not None and 'package' not in already_processed:
@@ -1444,7 +1444,7 @@ class testcaseType(GeneratedsSuper):
             already_processed.append('time')
             try:
                 self.time = float(value)
-            except ValueError, exp:
+            except ValueError as exp:
                 raise ValueError('Bad float/double attribute (time): %s' % exp)
 
     def buildChildren(self, child_, node, nodeName_, fromsubclass_=False):

--- a/client/tools/JUnit_api.py
+++ b/client/tools/JUnit_api.py
@@ -73,7 +73,7 @@ def parsexml_(*args, **kwargs):
 
 try:
     from generatedssuper import GeneratedsSuper
-except ImportError as exp:
+except ImportError:
 
     class GeneratedsSuper(object):
 
@@ -97,7 +97,7 @@ except ImportError as exp:
             for value in values:
                 try:
                     fvalue = float(value)
-                except (TypeError, ValueError) as exp:
+                except (TypeError, ValueError):
                     raise_parse_error(node, 'Requires sequence of integers')
             return input_data
 
@@ -115,7 +115,7 @@ except ImportError as exp:
             for value in values:
                 try:
                     fvalue = float(value)
-                except (TypeError, ValueError) as exp:
+                except (TypeError, ValueError):
                     raise_parse_error(node, 'Requires sequence of floats')
             return input_data
 
@@ -133,7 +133,7 @@ except ImportError as exp:
             for value in values:
                 try:
                     fvalue = float(value)
-                except (TypeError, ValueError) as exp:
+                except (TypeError, ValueError):
                     raise_parse_error(node, 'Requires sequence of doubles')
             return input_data
 

--- a/client/tools/boottool.py
+++ b/client/tools/boottool.py
@@ -2008,7 +2008,7 @@ class BoottoolApp(object):
             self.log.debug('Forcing bootloader "%s"', self.opts.bootloader)
             try:
                 self.grubby._set_bootloader(self.opts.bootloader)
-            except ValueError, msg:
+            except ValueError as msg:
                 self.log.error(msg)
                 sys.exit(-1)
 

--- a/client/tools/crash_handler.py
+++ b/client/tools/crash_handler.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
         try:
             crashed_pid, crash_time, uid, signal, hostname, exe = sys.argv[1:]  # pylint: disable=E0632
             full_functionality = True
-        except ValueError, e:
+        except ValueError as e:
             # Probably due a kernel bug, we can't exactly map the parameters
             # passed to this script. So we have to reduce the functionality
             # of the script (just write the core at a fixed place).
@@ -224,5 +224,5 @@ if __name__ == "__main__":
             syslog.syslog("Application %s, PID %s crashed" % (exe, crashed_pid))
         write_cores(core_file, results_dir_list)
 
-    except Exception, e:
+    except Exception as e:
         syslog.syslog("Crash handler had a problem: %s" % e)

--- a/client/tools/crash_handler.py
+++ b/client/tools/crash_handler.py
@@ -198,7 +198,7 @@ if __name__ == "__main__":
         try:
             crashed_pid, crash_time, uid, signal, hostname, exe = sys.argv[1:]  # pylint: disable=E0632
             full_functionality = True
-        except ValueError as e:
+        except ValueError:
             # Probably due a kernel bug, we can't exactly map the parameters
             # passed to this script. So we have to reduce the functionality
             # of the script (just write the core at a fixed place).

--- a/client/tools/scan_results.py
+++ b/client/tools/scan_results.py
@@ -75,7 +75,7 @@ def main(resfiles):
     for resfile in resfiles:
         try:
             text = open(resfile).read()
-        except IOError, e:
+        except IOError as e:
             if e.errno == 21:  # Directory
                 continue
             else:

--- a/conmux/drivers/fence_apc_snmp.py
+++ b/conmux/drivers/fence_apc_snmp.py
@@ -128,24 +128,24 @@ def main():
 
         try:
             address = params["ipaddr"]
-        except KeyError, e:
+        except KeyError as e:
             sys.stderr.write("FENCE: Missing ipaddr param for fence_apc...exiting")
             sys.exit(1)
         try:
             login = params["login"]
-        except KeyError, e:
+        except KeyError as e:
             sys.stderr.write("FENCE: Missing login param for fence_apc...exiting")
             sys.exit(1)
 
         try:
             passwd = params["passwd"]
-        except KeyError, e:
+        except KeyError as e:
             sys.stderr.write("FENCE: Missing passwd param for fence_apc...exiting")
             sys.exit(1)
 
         try:
             port = params["port"]
-        except KeyError, e:
+        except KeyError as e:
             sys.stderr.write("FENCE: Missing port param for fence_apc...exiting")
             sys.exit(1)
 
@@ -157,7 +157,7 @@ def main():
                 action = POWER_ON
             elif a == "Reboot" or a == "REBOOT" or a == "reboot":
                 action = POWER_REBOOT
-        except KeyError, e:
+        except KeyError as e:
             action = POWER_REBOOT
 
         # End of stdin section
@@ -356,7 +356,7 @@ def execWithCaptureStatus(command, argv, searchPath=0, root='/', stdin=0,
     status = -1
     try:
         (pid, status) = os.waitpid(childpid, 0)
-    except OSError, (errno, msg):
+    except OSError as (errno, msg):
         print __name__, "waitpid:", msg
 
     if os.WIFEXITED(status) and (os.WEXITSTATUS(status) == 0):

--- a/conmux/drivers/fence_apc_snmp.py
+++ b/conmux/drivers/fence_apc_snmp.py
@@ -128,24 +128,24 @@ def main():
 
         try:
             address = params["ipaddr"]
-        except KeyError as e:
+        except KeyError:
             sys.stderr.write("FENCE: Missing ipaddr param for fence_apc...exiting")
             sys.exit(1)
         try:
             login = params["login"]
-        except KeyError as e:
+        except KeyError:
             sys.stderr.write("FENCE: Missing login param for fence_apc...exiting")
             sys.exit(1)
 
         try:
             passwd = params["passwd"]
-        except KeyError as e:
+        except KeyError:
             sys.stderr.write("FENCE: Missing passwd param for fence_apc...exiting")
             sys.exit(1)
 
         try:
             port = params["port"]
-        except KeyError as e:
+        except KeyError:
             sys.stderr.write("FENCE: Missing port param for fence_apc...exiting")
             sys.exit(1)
 
@@ -157,7 +157,7 @@ def main():
                 action = POWER_ON
             elif a == "Reboot" or a == "REBOOT" or a == "reboot":
                 action = POWER_REBOOT
-        except KeyError as e:
+        except KeyError:
             action = POWER_REBOOT
 
         # End of stdin section

--- a/contrib/coverage.py
+++ b/contrib/coverage.py
@@ -600,7 +600,7 @@ class coverage:
             lines, excluded_lines, line_map = self.find_executable_statements(
                 source.read(), exclude=self.exclude_re
             )
-        except SyntaxError, synerr:
+        except SyntaxError as synerr:
             raise CoverageException(
                 "Couldn't parse '%s' as Python source: '%s' at line %d" %
                 (filename, synerr.msg, synerr.lineno)

--- a/contrib/modelviz.py
+++ b/contrib/modelviz.py
@@ -184,7 +184,7 @@ def main():
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hd",
                                    ["help", "disable_fields"])
-    except getopt.GetoptError, error:
+    except getopt.GetoptError as error:
         print __doc__
         sys.exit(error)
     else:

--- a/contrib/virt/control.template
+++ b/contrib/virt/control.template
@@ -47,7 +47,7 @@ def run(machine):
     control = get_control(params, custom_cfg)
     try:
         at.run(control)
-    except Exception, details:
+    except Exception as details:
         job.record('FAIL', None, 'host kernel install (server)', str(details))
         control = get_control(params, custom_cfg, kernel_install=False)
         at.run(control)

--- a/frontend/afe/doctests/001_rpc_test.txt
+++ b/frontend/afe/doctests/001_rpc_test.txt
@@ -148,7 +148,7 @@ ValidationError: {'locked': 'Host already unlocked.'}
 >>> rpc_interface.modify_host('ipaj1000', locked=True)
 >>> try:
 ...     rpc_interface.modify_host('ipaj1000', locked=True)
-... except model_logic.ValidationError, err:
+... except model_logic.ValidationError as err:
 ...     pass
 >>> assert ('locked' in err.args[0]
 ...         and err.args[0]['locked'].startswith('Host already locked'))

--- a/frontend/afe/doctests/001_rpc_test.txt
+++ b/frontend/afe/doctests/001_rpc_test.txt
@@ -148,7 +148,7 @@ ValidationError: {'locked': 'Host already unlocked.'}
 >>> rpc_interface.modify_host('ipaj1000', locked=True)
 >>> try:
 ...     rpc_interface.modify_host('ipaj1000', locked=True)
-... except model_logic.ValidationError as err:
+... except model_logic.ValidationError:
 ...     pass
 >>> assert ('locked' in err.args[0]
 ...         and err.args[0]['locked'].startswith('Host already locked'))

--- a/frontend/afe/json_rpc/serviceHandler.py
+++ b/frontend/afe/json_rpc/serviceHandler.py
@@ -154,7 +154,7 @@ class ServiceHandler(object):
                          'id': result_dict['id'],
                          'error': result_dict['err']}
             data = json_encoder.encode(json_dict)
-        except TypeError as e:
+        except TypeError:
             err_traceback = traceback.format_exc()
             print err_traceback
             err = {"name": "JSONEncodeException",

--- a/frontend/afe/json_rpc/serviceHandler.py
+++ b/frontend/afe/json_rpc/serviceHandler.py
@@ -99,7 +99,7 @@ class ServiceHandler(object):
         try:
             meth = self.findServiceEndpoint(methName)
             results['result'] = self.invokeServiceEndpoint(meth, args)
-        except Exception, err:
+        except Exception as err:
             results['err_traceback'] = traceback.format_exc()
             results['err'] = err
 
@@ -154,7 +154,7 @@ class ServiceHandler(object):
                          'id': result_dict['id'],
                          'error': result_dict['err']}
             data = json_encoder.encode(json_dict)
-        except TypeError, e:
+        except TypeError as e:
             err_traceback = traceback.format_exc()
             print err_traceback
             err = {"name": "JSONEncodeException",

--- a/frontend/afe/model_logic.py
+++ b/frontend/afe/model_logic.py
@@ -721,7 +721,7 @@ class ModelExtensions(object):
             try:
                 python_value = f.to_python(
                     getattr(self, f.attname, f.get_default()))
-            except django.core.exceptions.ValidationError, e:
+            except django.core.exceptions.ValidationError as e:
                 error_dict[f.name] = str(e)
                 continue
 

--- a/frontend/afe/rpc_utils.py
+++ b/frontend/afe/rpc_utils.py
@@ -199,7 +199,7 @@ def prepare_generate_control_file(tests, kernel, label, profilers):
     # ensure tests are all the same type
     try:
         test_type = get_consistent_value(test_objects, 'test_type')
-    except InconsistencyException, exc:
+    except InconsistencyException as exc:
         test1 = exc.args[0]
         test2 = exc.args[1]
         raise model_logic.ValidationError(

--- a/frontend/db/backends/afe/base.py
+++ b/frontend/db/backends/afe/base.py
@@ -5,7 +5,7 @@ from django.db.backends.mysql.base import DatabaseWrapper as MySQLDatabaseWrappe
 
 try:
     import MySQLdb as Database
-except ImportError, e:
+except ImportError as e:
     from django.core.exceptions import ImproperlyConfigured
     raise ImproperlyConfigured("Error loading MySQLdb module: %s" % e)
 

--- a/frontend/shared/query_lib.py
+++ b/frontend/shared/query_lib.py
@@ -57,7 +57,7 @@ class QueryProcessor(object):
         try:
             return constraint.apply_constraint(queryset, value, comparison_type,
                                                is_inverse)
-        except ConstraintError, exc:
+        except ConstraintError as exc:
             raise exceptions.BadRequest('Selector %s: %s'
                                         % (selector_name, exc))
 

--- a/frontend/shared/resource_lib.py
+++ b/frontend/shared/resource_lib.py
@@ -53,12 +53,12 @@ class Resource(object):
         try:
             try:
                 instance = cls.from_uri_args(request, **kwargs)
-            except django.core.exceptions.ObjectDoesNotExist, exc:
+            except django.core.exceptions.ObjectDoesNotExist as exc:
                 raise http.Http404(exc)
 
             instance.read_query_parameters(request.GET)
             return instance.handle_request()
-        except exceptions.RequestError, exc:
+        except exceptions.RequestError as exc:
             return exc.response
 
     def handle_request(self):
@@ -199,7 +199,7 @@ class Resource(object):
         if content_type == _JSON_CONTENT_TYPE:
             try:
                 raw_dict = simplejson.loads(raw_data)
-            except ValueError, exc:
+            except ValueError as exc:
                 raise exceptions.BadRequest('Error decoding request body: '
                                             '%s\n%r' % (exc, raw_data))
             if not isinstance(raw_dict, dict):
@@ -262,7 +262,7 @@ class Entry(Resource):
     def put(self):
         try:
             self.update(self._decoded_input())
-        except model_logic.ValidationError, exc:
+        except model_logic.ValidationError as exc:
             raise exceptions.BadRequest('Invalid input: %s' % exc)
         return self._basic_response(self.full_representation())
 
@@ -458,7 +458,7 @@ class Collection(Resource):
             instance = self.entry_class.create_instance(input_dict, self)
             entry = self._entry_from_instance(instance)
             entry.update(input_dict)
-        except model_logic.ValidationError, exc:
+        except model_logic.ValidationError as exc:
             raise exceptions.BadRequest('Invalid input: %s' % exc)
         # RFC 2616 specifies that we provide the new URI in both the Location
         # header and the body

--- a/frontend/tko/migrations/0004_tko_graphing.py
+++ b/frontend/tko/migrations/0004_tko_graphing.py
@@ -11,7 +11,7 @@ class Migration(SchemaMigration):
         # on some systmes this constraint is created.
         try:
             db.delete_foreign_key('tko_iteration_result', 'test_idx')
-        except ValueError as e:
+        except ValueError:
             logging.warning("Failed to delete foreign key on tko_interation_result, it likely doesn't exist")
 
         # Removing primary key constraint on tko_iteration_result, allowing more than one keval per test

--- a/mirror/database.py
+++ b/mirror/database.py
@@ -92,7 +92,7 @@ class dict_database(database):
         try:
             # this may block
             fcntl.flock(fd, fcntl.LOCK_EX)
-        except Exception, err:
+        except Exception as err:
             os.close(fd)
             raise err
 

--- a/mirror/source.py
+++ b/mirror/source.py
@@ -151,7 +151,7 @@ class url_source(source):
         """
         try:
             info = urllib2.urlopen(url).info()
-        except IOError, err:
+        except IOError as err:
             # file is referenced but does not exist
             print 'WARNING: %s' % err
             return None

--- a/scheduler/drone_manager.py
+++ b/scheduler/drone_manager.py
@@ -282,7 +282,7 @@ class DroneManager(object):
             if len(lines) == 3:
                 contents.exit_status = int(lines[1])
                 contents.num_tests_failed = int(lines[2])
-        except ValueError, exc:
+        except ValueError as exc:
             return InvalidPidfile('Corrupt pid file: ' + str(exc.args))
 
         return contents

--- a/scheduler/drone_utility.py
+++ b/scheduler/drone_utility.py
@@ -273,7 +273,7 @@ class DroneUtility(object):
             file_object = open(file_path, 'a')
             file_object.write(contents)
             file_object.close()
-        except IOError, exc:
+        except IOError as exc:
             self._warn('Error write to file %s: %s' % (file_path, exc))
 
     def copy_file_or_directory(self, source_path, destination_path):

--- a/scheduler/monitor_db.py
+++ b/scheduler/monitor_db.py
@@ -810,7 +810,7 @@ class Dispatcher(object):
                                          metahost_profiles=metahost_profiles,
                                          atomic_group=atomic_group)
 
-            except Exception, ex:
+            except Exception as ex:
                 logging.exception(ex)
                 # TODO send email
 

--- a/scheduler/monitor_db_watcher.py
+++ b/scheduler/monitor_db_watcher.py
@@ -179,7 +179,7 @@ def main():
             pid = os.fork()
             if (pid > 0):
                 sys.exit(0)  # exit from first parent
-        except OSError, e:
+        except OSError as e:
             sys.stderr.write("fork #1 failed: (%d) %s\n" %
                              (e.errno, e.strerror))
             sys.exit(1)
@@ -194,7 +194,7 @@ def main():
             pid = os.fork()
             if (pid > 0):
                 sys.exit(0)  # exit from second parent
-        except OSError, e:
+        except OSError as e:
             sys.stderr.write("fork #2 failed: (%d) %s\n" %
                              (e.errno, e.strerror))
             sys.exit(1)

--- a/server/autoserv.py
+++ b/server/autoserv.py
@@ -32,7 +32,7 @@ try:
         atfork.stdlib_fixer.fix_logging_module()
     except Exception:
         pass
-except ImportError, e:
+except ImportError as e:
     from autotest.client.shared.settings import settings
     if settings.get_value('AUTOSERV', 'require_atfork_module', type=bool,
                           default=False):
@@ -234,7 +234,7 @@ def main():
     try:
         try:
             run_autoserv(pid_file_manager, results, parser)
-        except SystemExit, e:
+        except SystemExit as e:
             exit_code = e.code
         except Exception:
             traceback.print_exc()

--- a/server/autotest_remote.py
+++ b/server/autotest_remote.py
@@ -307,7 +307,7 @@ class BaseAutotest(installable_object.InstallableObject):
                 self.installed = True
                 return
             except (error.PackageInstallError, error.AutoservRunError,
-                    SettingsError), e:
+                    SettingsError) as e:
                 logging.info("Could not install autotest using the packaging "
                              "system: %s. Trying other methods", e)
 
@@ -457,7 +457,7 @@ class BaseAutotest(installable_object.InstallableObject):
             pkgmgr = packages.PackageManager('autotest', hostname=host.hostname,
                                              repo_urls=repos)
             prologue_lines.append('job.add_repository(%s)\n' % repos)
-        except SettingsError, e:
+        except SettingsError as e:
             # If repos is defined packaging is enabled so log the error
             if repos:
                 logging.error(e)
@@ -763,7 +763,7 @@ class _BaseRun(object):
                                            timeout=timeout,
                                            stdout_tee=client_log,
                                            stderr_tee=stderr_redirector)
-                except error.AutoservRunError, e:
+                except error.AutoservRunError as e:
                     result = e.result_obj
                     result.exit_status = None
                     disconnect_warnings.append(e.description)
@@ -844,7 +844,7 @@ class _BaseRun(object):
             logging.warning(warning)
             try:
                 self.host.hardreset(wait=False)
-            except (AttributeError, error.AutoservUnsupportedError), detail:
+            except (AttributeError, error.AutoservUnsupportedError) as detail:
                 warning = ("Hard reset unsupported on %s: %s" %
                            (self.hostname, detail))
                 logging.warning(warning)
@@ -885,7 +885,7 @@ class _BaseRun(object):
                 elif self.is_client_job_rebooting(last):
                     try:
                         self._wait_for_reboot(boot_id)
-                    except error.AutotestRunError, e:
+                    except error.AutotestRunError as e:
                         self.host.job.record("ABORT", None, "reboot", str(e))
                         self.host.job.record("END ABORT", None, None, str(e))
                         raise

--- a/server/base_utils.py
+++ b/server/base_utils.py
@@ -132,7 +132,7 @@ def __clean_tmp_dirs():
     for dir in __tmp_dirs[pid]:
         try:
             shutil.rmtree(dir)
-        except OSError, e:
+        except OSError as e:
             if e.errno == 2:
                 pass
     __tmp_dirs[pid] = []

--- a/server/control_segments/repair
+++ b/server/control_segments/repair
@@ -18,7 +18,7 @@ def repair(machine):
     try:
         _call_repair(machine)
         job.record('GOOD', None, 'repair', '%s repaired successfully' % machine)
-    except Exception, e:
+    except Exception as e:
         msg = 'repair failed on %s: %s\n' % (machine, str(e))
         job.record('FAIL', None, 'repair', msg)
         raise

--- a/server/control_segments/verify
+++ b/server/control_segments/verify
@@ -4,7 +4,7 @@ def verify(machine):
         host = hosts.create_host(machine, initialize=False, auto_monitor=False)
         host.verify()
         job.record('GOOD', None, 'verify', '%s verified successfully' % machine)
-    except Exception, e:
+    except Exception as e:
         msg = 'verify failed: %s' % e
         job.record('FAIL', None, 'verify', msg)
         raise

--- a/server/crashcollect.py
+++ b/server/crashcollect.py
@@ -124,7 +124,7 @@ def collect_command(host, command, dest_path):
         try:
             result = host.run(command, stdout_tee=devnull).stdout
             utils.open_write_close(dest_path, result)
-        except Exception, e:
+        except Exception as e:
             logging.warning("Collection of '%s' failed:\n%s", command, e)
     finally:
         devnull.close()
@@ -143,7 +143,7 @@ def collect_uncollected_logs(host):
                     logging.info("Retrieving logs from %s:%s into %s",
                                  hostname, remote_path, local_path)
                     host.get_file(remote_path + "/", local_path + "/")
-        except Exception, e:
+        except Exception as e:
             logging.warning("Error while trying to collect stranded "
                             "Autotest client logs: %s", e)
 
@@ -197,5 +197,5 @@ def collect_messages(host):
         os.remove(messages_raw)
         if os.path.exists(messages_at_start):
             os.remove(messages_at_start)
-    except Exception, e:
+    except Exception as e:
         logging.warning("Error while collecting /var/log/messages: %s", e)

--- a/server/frontend.py
+++ b/server/frontend.py
@@ -340,7 +340,7 @@ class AFE(RpcClient):
                 if not new_job:
                     continue
                 jobs.append(new_job)
-            except Exception, e:
+            except Exception as e:
                 traceback.print_exc()
         if not wait or not jobs:
             return

--- a/server/frontend.py
+++ b/server/frontend.py
@@ -340,7 +340,7 @@ class AFE(RpcClient):
                 if not new_job:
                     continue
                 jobs.append(new_job)
-            except Exception as e:
+            except Exception:
                 traceback.print_exc()
         if not wait or not jobs:
             return

--- a/server/hosts/__init__.py
+++ b/server/hosts/__init__.py
@@ -13,7 +13,7 @@ from base_classes import Host
 from remote import RemoteHost
 try:
     from site_host import SiteHost
-except ImportError, e:
+except ImportError as e:
     pass
 
 # host implementation classes

--- a/server/hosts/abstract_ssh.py
+++ b/server/hosts/abstract_ssh.py
@@ -279,7 +279,7 @@ class AbstractSSHHost(SiteHost):
                                              delete_dest, preserve_symlinks)
                 utils.run(rsync)
                 try_scp = False
-            except error.CmdError, e:
+            except error.CmdError as e:
                 logging.warn("trying scp, rsync failed: %s" % e)
 
         if try_scp:
@@ -297,7 +297,7 @@ class AbstractSSHHost(SiteHost):
                 scp = self._make_scp_cmd([remote_source], local_dest)
                 try:
                     utils.run(scp)
-                except error.CmdError, e:
+                except error.CmdError as e:
                     raise error.AutoservRunError(e.args[0], e.args[1])
 
         if not preserve_perm:
@@ -354,7 +354,7 @@ class AbstractSSHHost(SiteHost):
                                              delete_dest, preserve_symlinks)
                 utils.run(rsync)
                 try_scp = False
-            except error.CmdError, e:
+            except error.CmdError as e:
                 logging.warn("trying scp, rsync failed: %s" % e)
 
         if try_scp:
@@ -396,7 +396,7 @@ class AbstractSSHHost(SiteHost):
                 scp = self._make_scp_cmd(local_sources, remote_dest)
                 try:
                     utils.run(scp)
-                except error.CmdError, e:
+                except error.CmdError as e:
                     raise error.AutoservRunError(e.args[0], e.args[1])
 
     def ssh_ping(self, timeout=60):
@@ -410,7 +410,7 @@ class AbstractSSHHost(SiteHost):
         except error.AutoservSshPermissionDeniedError:
             # let AutoservSshPermissionDeniedError be visible to the callers
             raise
-        except error.AutoservRunError, e:
+        except error.AutoservRunError as e:
             # convert the generic AutoservRunError into something more
             # specific for this context
             raise error.AutoservSshPingHostError(e.description + '\n' +

--- a/server/hosts/install_server.py
+++ b/server/hosts/install_server.py
@@ -56,7 +56,7 @@ class CobblerInterface(object):
         """
         try:
             system = self.server.find_system({"name": host.hostname})[0]
-        except IndexError, detail:
+        except IndexError as detail:
             # TODO: Method to register this system as brand new
             logging.error("Error finding %s: %s", host.hostname, detail)
             raise ValueError("No system %s registered on install server" %
@@ -86,7 +86,7 @@ class CobblerInterface(object):
             # machines, so we need to synchronize the dhcpd file after changing
             # the value above
             self.server.sync_dhcp(self.token)
-        except xmlrpclib.Fault, err:
+        except xmlrpclib.Fault as err:
             # older Cobbler will not recognize the above command
             if "unknown remote method" not in err.faultString:
                 logging.error("DHCP sync failed, error code: %s, error string: %s",
@@ -106,7 +106,7 @@ class CobblerInterface(object):
             # machines, so we need to synchronize the dhcpd file after changing
             # the value above
             self.server.sync_dhcp(self.token)
-        except xmlrpclib.Fault, err:
+        except xmlrpclib.Fault as err:
             # older Cobbler will not recognize the above command
             if "unknown remote method" not in err.faultString:
                 logging.error("DHCP sync failed, error code: %s, error string: %s",

--- a/server/hosts/logfile_monitor.py
+++ b/server/hosts/logfile_monitor.py
@@ -159,7 +159,7 @@ def _log_and_ignore_exceptions(f):
     def wrapped(self, *args, **dargs):
         try:
             return f(self, *args, **dargs)
-        except Exception, e:
+        except Exception as e:
             print "LogfileMonitor.%s failed with exception %s" % (f.__name__, e)
             print "Exception ignored:"
             traceback.print_exc(file=sys.stdout)
@@ -247,7 +247,7 @@ class LogfileMonitorMixin(abstract_ssh.AbstractSSHHost):
         for patterns_path in set(self.pattern_paths):
             try:
                 patterns_path = resolve_patterns_path(patterns_path)
-            except InvalidPatternsPathError, e:
+            except InvalidPatternsPathError as e:
                 logging.warn('Specified patterns_path is invalid: %s, %s',
                              patterns_path, str(e))
             else:

--- a/server/hosts/monitors/monitors_util.py
+++ b/server/hosts/monitors/monitors_util.py
@@ -381,7 +381,7 @@ def follow_files(follow_paths, outstream, lastlines_dirpath=None, waitsecs=5):
         try:
             outstream.writelines(['\n'] + lines)
             outstream.flush()
-        except (IOError, OSError), e:
+        except (IOError, OSError) as e:
             # Something is wrong. Stop looping.
             break
 

--- a/server/hosts/monitors/monitors_util.py
+++ b/server/hosts/monitors/monitors_util.py
@@ -381,7 +381,7 @@ def follow_files(follow_paths, outstream, lastlines_dirpath=None, waitsecs=5):
         try:
             outstream.writelines(['\n'] + lines)
             outstream.flush()
-        except (IOError, OSError) as e:
+        except (IOError, OSError):
             # Something is wrong. Stop looping.
             break
 

--- a/server/hosts/netconsole.py
+++ b/server/hosts/netconsole.py
@@ -146,7 +146,7 @@ class NetconsoleHost(remote.RemoteHost):
         try:
             self.run('dmesg -n 8')
             self.run('modprobe netconsole %s' % self.__netconsole_params)
-        except error.AutoservRunError, e:
+        except error.AutoservRunError as e:
             # if it fails there isn't much we can do, just keep going
             print "ERROR occurred while loading netconsole: %s" % e
 

--- a/server/hosts/paramiko_host.py
+++ b/server/hosts/paramiko_host.py
@@ -177,7 +177,7 @@ class ParamikoHost(abstract_ssh.AbstractSSHHost):
         channel = None
         try:
             channel = self.transport.open_session()
-        except (socket.error, paramiko.SSHException, EOFError), e:
+        except (socket.error, paramiko.SSHException, EOFError) as e:
             logging.warn("Exception occurred while opening session: %s", e)
             if time.time() - start_time >= timeout:
                 raise error.AutoservSSHTimeout("ssh failed: %s" % e)
@@ -186,7 +186,7 @@ class ParamikoHost(abstract_ssh.AbstractSSHHost):
             # we couldn't get a channel; re-initing transport should fix that
             try:
                 self.transport.close()
-            except Exception, e:
+            except Exception as e:
                 logging.debug("paramiko.Transport.close failed with %s", e)
             self._init_transport()
             return self.transport.open_session()
@@ -261,7 +261,7 @@ class ParamikoHost(abstract_ssh.AbstractSSHHost):
         try:
             channel = self._open_channel(timeout)
             channel.exec_command(command)
-        except (socket.error, paramiko.SSHException, EOFError), e:
+        except (socket.error, paramiko.SSHException, EOFError) as e:
             # This has to match the string from paramiko *exactly*.
             if str(e) != 'Channel closed.':
                 raise error.AutoservSSHTimeout("ssh failed: %s" % e)

--- a/server/hosts/remote.py
+++ b/server/hosts/remote.py
@@ -231,7 +231,7 @@ class RemoteHost(base_classes.Host):
                 self.run('rm -f %s' % self.VAR_LOG_MESSAGES_COPY_PATH)
                 self.run('cp %s %s' % (messages_file,
                                        self.VAR_LOG_MESSAGES_COPY_PATH))
-            except Exception, e:
+            except Exception as e:
                 # Non-fatal error
                 logging.info('Failed to copy %s at startup: %s',
                              messages_file, e)

--- a/server/hosts/ssh_host.py
+++ b/server/hosts/ssh_host.py
@@ -123,7 +123,7 @@ class SSHHost(abstract_ssh.AbstractSSHHost):
             return self._run(command, timeout, ignore_status, stdout_tee,
                              stderr_tee, connect_timeout, env, options,
                              stdin, args)
-        except error.CmdError, cmderr:
+        except error.CmdError as cmderr:
             # We get a CmdError here only if there is timeout of that command.
             # Catch that and stuff it into AutoservRunError and raise it.
             raise error.AutoservRunError(cmderr.args[0], cmderr.args[1])

--- a/server/samples/run_test.srv
+++ b/server/samples/run_test.srv
@@ -20,7 +20,7 @@ def main():
 
     try:
         opts, args = getopt.getopt(args, 't:l:', [])
-    except getopt.GetoptError, e:
+    except getopt.GetoptError as e:
         usage()
         print e
         sys.exit(1)

--- a/server/server_job.py
+++ b/server/server_job.py
@@ -352,7 +352,7 @@ class base_server_job(base_job.base_job):
                          'ssh_port': self._ssh_port,
                          'ssh_pass': self._ssh_pass}
             self._execute_code(VERIFY_CONTROL_FILE, namespace, protect=False)
-        except Exception, e:
+        except Exception as e:
             msg = ('Verify failed\n' + str(e) + '\n' + traceback.format_exc())
             self.record('ABORT', None, None, msg)
             raise
@@ -545,7 +545,7 @@ class base_server_job(base_job.base_job):
 
                 # no error occurred, so we don't need to collect crashinfo
                 collect_crashinfo = False
-            except Exception, e:
+            except Exception as e:
                 try:
                     logging.exception(
                         'Exception escaped control file, job aborting:')
@@ -559,7 +559,7 @@ class base_server_job(base_job.base_job):
                 # Clean up temp directory used for copies of the control files
                 try:
                     shutil.rmtree(temp_control_file_dir)
-                except Exception, e:
+                except Exception as e:
                     logging.warn('Could not remove temp directory %s: %s',
                                  temp_control_file_dir, e)
 
@@ -594,10 +594,10 @@ class base_server_job(base_job.base_job):
         def group_func():
             try:
                 test.runtest(self, url, tag, args, dargs)
-            except error.TestBaseException, e:
+            except error.TestBaseException as e:
                 self.record(e.exit_status, subdir, testname, str(e))
                 raise
-            except Exception, e:
+            except Exception as e:
                 info = str(e) + "\n" + traceback.format_exc()
                 self.record('FAIL', subdir, testname, info)
                 raise
@@ -620,10 +620,10 @@ class base_server_job(base_job.base_job):
         try:
             self.record('START', subdir, name)
             result = function(*args, **dargs)
-        except error.TestBaseException, e:
+        except error.TestBaseException as e:
             self.record("END %s" % e.exit_status, subdir, name)
             exc_info = sys.exc_info()
-        except Exception, e:
+        except Exception as e:
             err_msg = str(e) + '\n'
             err_msg += traceback.format_exc()
             self.record('END ABORT', subdir, name, err_msg)
@@ -664,7 +664,7 @@ class base_server_job(base_job.base_job):
         try:
             self.record('START', None, 'reboot')
             reboot_func()
-        except Exception, e:
+        except Exception as e:
             err_msg = str(e) + '\n' + traceback.format_exc()
             self.record('END FAIL', None, 'reboot', err_msg)
             raise
@@ -1062,7 +1062,7 @@ class base_server_job(base_job.base_job):
         try:
             self._state.read_from_file(state_path)
             os.remove(state_path)
-        except OSError, e:
+        except OSError as e:
             # ignore file-not-found errors
             if e.errno != errno.ENOENT:
                 raise

--- a/server/server_job.py
+++ b/server/server_job.py
@@ -608,7 +608,7 @@ class base_server_job(base_job.base_job):
         if exc_info and isinstance(exc_info[1], error.TestBaseException):
             return False
         elif exc_info:
-            raise exc_info[0], exc_info[1], exc_info[2]
+            raise exc_info[0](exc_info[1])
         else:
             return True
 

--- a/server/subcommand.py
+++ b/server/subcommand.py
@@ -89,7 +89,7 @@ def parallel_simple(function, arglist, log=True, timeout=None,
         if return_results:
             try:
                 result = function(arg)
-            except Exception, e:
+            except Exception as e:
                 return [e]
             return [result]
         else:
@@ -177,7 +177,7 @@ class subcommand(object):
             result = self.lambda_function()
             os.write(w, cPickle.dumps(result, cPickle.HIGHEST_PROTOCOL))
             exit_code = 0
-        except Exception, e:
+        except Exception as e:
             logging.exception('function failed')
             exit_code = 1
             os.write(w, cPickle.dumps(e, cPickle.HIGHEST_PROTOCOL))

--- a/tko/autotest-db-delete-job
+++ b/tko/autotest-db-delete-job
@@ -176,7 +176,7 @@ if __name__ == '__main__':
         for tag in tag_list:
             try:
                 delete_job_full(tag)
-            except Exception, detail:
+            except Exception as detail:
                 logging.error("Could not delete job tag %s: %s",
                               tag, detail)
                 logging.error("It is likely that you tried to "

--- a/tko/autotest-tko-parse
+++ b/tko/autotest-tko-parse
@@ -279,7 +279,7 @@ def main():
                 flags |= fcntl.LOCK_NB
             try:
                 fcntl.flock(lockfile, flags)
-            except IOError, e:
+            except IOError as e:
                 # lock is not available and nonblock has been requested
                 if e.errno == errno.EWOULDBLOCK:
                     lockfile.close()

--- a/tko/parsers/test/execute_parser.py
+++ b/tko/parsers/test/execute_parser.py
@@ -33,7 +33,7 @@ def main():
     harness = scenario_base.new_parser_harness(results_dirpath)
     try:
         parser_result = harness.execute()
-    except Exception, e:
+    except Exception as e:
         parser_result = e
     scenario_base.store_parser_result(
         scenario_dirpath, parser_result, parser_result_tag)

--- a/tko/parsers/test/new_scenario.py
+++ b/tko/parsers/test/new_scenario.py
@@ -92,7 +92,7 @@ def main():
     harness = scenario_base.new_parser_harness(copied_dirpath)
     try:
         parser_result = harness.execute()
-    except Exception, e:
+    except Exception as e:
         parser_result = e
 
     scenario_base.store_parser_result(

--- a/utils/check_control_file_vars.py
+++ b/utils/check_control_file_vars.py
@@ -19,7 +19,7 @@ if not os.path.exists(sys.argv[1]):
 
 try:
     cd = control_data.parse_control(sys.argv[1], True)
-except Exception, e:
+except Exception as e:
     print "This control file does not adhear to the spec set forth in"
     print "https://github.com/autotest/autotest/wiki/ControlRequirements"
     print

--- a/utils/compile_gwt_clients.py
+++ b/utils/compile_gwt_clients.py
@@ -92,7 +92,7 @@ def install_completed_client(compiled_dir, project_client):
         try:
             os.rename(tmp_client_dir, install_dir)
             return True
-        except Exception, err:
+        except Exception as err:
             # If we can't rename the client raise an exception
             # and put the old client back
             shutil.rmtree(install_dir)

--- a/utils/packager.py
+++ b/utils/packager.py
@@ -100,7 +100,7 @@ def process_packages(pkgmgr, pkg_type, pkg_names, src_dir,
             try:
                 try:
                     base_packages.check_diskspace(temp_dir)
-                except error.RepoDiskFullError, e:
+                except error.RepoDiskFullError as e:
                     msg = ("Temporary directory for packages %s does not have "
                            "enough space available: %s" % (temp_dir, e))
                     raise error.RepoDiskFullError(msg)
@@ -157,7 +157,7 @@ def process_all_packages(pkgmgr, client_dir, remove=False):
     temp_dir = tempfile.mkdtemp()
     try:
         base_packages.check_diskspace(temp_dir)
-    except error.RepoDiskFullError, e:
+    except error.RepoDiskFullError as e:
         print ("Temp destination for packages is full %s, aborting upload: %s"
                % (temp_dir, e))
         os.rmdir(temp_dir)

--- a/utils/test_importer.py
+++ b/utils/test_importer.py
@@ -362,9 +362,9 @@ def get_tests_from_fs(parent_dir, control_pattern, add_noncompliant=False):
                         found_test = control_data.parse_control(file,
                                                                 raise_warnings=True)
                         tests[file] = found_test
-                    except control_data.ControlVariableException, e:
+                    except control_data.ControlVariableException as e:
                         logging.warn("Skipping %s\n%s", file, e)
-                    except Exception, e:
+                    except Exception as e:
                         logging.error("Bad %s\n%s", file, e)
                 else:
                     found_test = control_data.parse_control(file)
@@ -454,7 +454,7 @@ def update_from_whitelist(whitelist_set, add_experimental, add_noncompliant,
                 found_test = control_data.parse_control(file_path,
                                                         raise_warnings=True)
                 tests[file_path] = found_test
-            except control_data.ControlVariableException, e:
+            except control_data.ControlVariableException as e:
                 logging.warn("Skipping %s\n%s", file, e)
         else:
             profilers[file_path] = compiler.parseFile(file_path).doc


### PR DESCRIPTION
1. Handle "except" syntax compatibility for versions after python2.5
2. Drop the exception bound to the variable if the variable is not used