### PR TITLE
add Hygon Dhyana support for get_cpu_vendor_name and support kvm arch

### DIFF
--- a/client/base_utils.py
+++ b/client/base_utils.py
@@ -345,12 +345,13 @@ def get_cpu_vendor_name():
     """
     Get the current cpu vendor name
 
-    :returns: string 'intel' or 'amd' or 'power7' depending on the current CPU architecture.
+    :returns: string 'intel' or 'amd' or 'hygon' or 'power7' depending on the current CPU architecture.
     :rtype: `string`
     """
     vendors_map = {
         'intel': ("GenuineIntel", ),
         'amd': ("AMD", ),
+        'hygon': ("HygonGenuine", ),
         'power7': ("POWER7", )
     }
 

--- a/client/kvm_control.py
+++ b/client/kvm_control.py
@@ -14,6 +14,13 @@ def get_kvm_arch():
     :returns: 'kvm_amd' or 'kvm_intel' or 'kvm_power7'
     :rtype: `string`
     """
+    kvm_archs = {
+        "amd": "kvm_amd",
+        "hygon": "kvm_amd",
+        "intel": "kvm_intel",
+        "power7": "kvm_power7"
+    }
+
     flags = {
         'kvm_amd': "svm",
         'kvm_intel': "vmx"
@@ -22,9 +29,9 @@ def get_kvm_arch():
     vendor_name = utils.get_cpu_vendor_name()
 
     if not vendor_name:
-        raise error.TestError("CPU Must be AMD, Intel or Power7")
+        raise error.TestError("CPU Must be AMD, Hygon, Intel or Power7")
 
-    arch_type = 'kvm_%s' % vendor_name
+    arch_type = kvm_archs.get(vendor_name, None)
     cpu_flag = flags.get(arch_type, None)
 
     if cpu_flag is None and vendor_name in ('power7', ):

--- a/client/kvm_control_unittest.py
+++ b/client/kvm_control_unittest.py
@@ -52,10 +52,16 @@ class test_kvm_control(unittest.TestCase):
         self._mock_cpu_info("AuthenticAMD\nsvm")
         self.assertTrue(kvm_control.get_kvm_arch() == 'kvm_amd')
 
+        self._mock_cpu_info("HygonGenuine\nsvm")
+        self.assertTrue(kvm_control.get_kvm_arch() == 'kvm_amd')
+
         self._mock_cpu_info("POWER7")
         self.assertTrue(kvm_control.get_kvm_arch() == 'kvm_power7')
 
         self._mock_cpu_info("AuthenticAMD")
+        self.assertRaises(error.TestError, kvm_control.get_kvm_arch)
+
+        self._mock_cpu_info("HygonGenuine")
         self.assertRaises(error.TestError, kvm_control.get_kvm_arch)
 
         self._mock_cpu_info("InvalidCPU")


### PR DESCRIPTION
Add Hygon CPU Vendor ID checking in get_cpu_vendor_name and return hygon

add kvm arch support for Hygon reuse kvm_amd as Hygon Dhyana(Family 18h) share similiar arch with AMD Family 17h, and add related unittest.