### PR TITLE
results2junit.py: Make sure text is not none before trying to modify it

### DIFF
--- a/client/tools/results2junit.py
+++ b/client/tools/results2junit.py
@@ -47,9 +47,10 @@ def text_clean(text):
     deal with properly so this function just removes them from the text passed in.
     '''
     retval = text
-    retval = retval.replace('\xe2\x80\x98', "'")
-    retval = retval.replace('\xe2\x80\x99', "'")
-    retval = retval.replace('\xe2', "")
+    if text is not None:
+        retval = retval.replace('\xe2\x80\x98', "'")
+        retval = retval.replace('\xe2\x80\x99', "'")
+        retval = retval.replace('\xe2', "")
     return retval
 
 # file_load


### PR DESCRIPTION
If the text is None, the replace will cause AttributeError.
Make sure it's not None before trying to modify it.

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>