### PR TITLE
Fix cgi.escape after python3.2

### DIFF
--- a/client/shared/jsontemplate.py
+++ b/client/shared/jsontemplate.py
@@ -42,8 +42,11 @@ import pprint
 import re
 
 # For formatters
-import cgi  # cgi.escape
 import urllib  # for urllib.encode
+try:
+    from cgi import escape  # for cgi.escape
+except ImportError:
+    from html import escape # for html.escape
 
 
 class Error(Exception):
@@ -569,7 +572,7 @@ def _ToString(x):
 
 
 def _HtmlAttrValue(x):
-    return cgi.escape(x, quote=True)
+    return escape(x, quote=True)
 
 
 def _AbsUrl(relative_url, context, unused_args):
@@ -594,7 +597,7 @@ def _AbsUrl(relative_url, context, unused_args):
 # This is a *public* constant, so that callers can use it construct their own
 # formatter lookup dictionaries, and pass them in to Template.
 _DEFAULT_FORMATTERS = {
-    'html': cgi.escape,
+    'html': escape,
 
     # The 'htmltag' name is deprecated.  The html-attr-value name is preferred
     # because it can be read with "as":
@@ -621,7 +624,7 @@ _DEFAULT_FORMATTERS = {
 
     # Just show a plain URL on an HTML page (without anchor text).
     'plain-url': lambda x: '<a href="%s">%s</a>' % (
-        cgi.escape(x, quote=True), cgi.escape(x)),
+        escape(x, quote=True), escape(x)),
 
     # A context formatter
     'AbsUrl': _AbsUrl,

--- a/frontend/afe/views.py
+++ b/frontend/afe/views.py
@@ -1,8 +1,11 @@
-import cgi
 import sys
 import traceback
 
 import httplib2
+try:
+    from cgi import escape  # for cgi.escape
+except ImportError:
+    from html import escape # for html.escape
 from autotest.client.shared import utils
 from autotest.frontend import views_common
 from autotest.frontend.afe import models, rpc_handler, rpc_interface
@@ -66,6 +69,6 @@ def handler500(request):
     context = Context({
         'type': sys.exc_type,
         'value': sys.exc_value,
-        'traceback': cgi.escape(trace)
+        'traceback': escape(trace)
     })
     return HttpResponseServerError(t.render(context))


### PR DESCRIPTION
cgi.escape has been deprecated since 3.2 [1]
Use html.escape instead.

[1] https://docs.python.org/3.5/library/cgi.html

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>