### PR TITLE
Fix platform.dist() after python3.5

### DIFF
--- a/client/shared/distro.py
+++ b/client/shared/distro.py
@@ -263,7 +263,13 @@ class StdLibProbe(Probe):
         release = UNKNOWN_DISTRO_RELEASE
         arch = UNKNOWN_DISTRO_ARCH
 
-        d_name, d_version_release, d_codename = platform.dist()
+        try:
+            d_name, d_version_release, d_codename = platform.dist()
+        except AttributeError:
+            import distro
+            d_name = distro.name()
+            d_version_release = distro.version()
+            d_codename = distro.codename()
         if d_name:
             name = d_name
 

--- a/client/tools/boottool.py
+++ b/client/tools/boottool.py
@@ -864,7 +864,14 @@ class Grubby(object):
 
     def _dist_uses_grub2(self):
         if self.get_architecture().startswith('ppc64'):
-            (d_name, d_version, d_id) = platform.dist()
+            try:
+                d_name, d_version, d_id = platform.dist()
+            except AttributeError:
+                import distro
+                d_name = distro.name()
+                d_version = distro.version()
+                d_id = distro.codename()
+
             if d_name.lower() == 'redhat' and d_version >= 7:
                 return True
             if d_name.lower() == 'suse' and d_version >= 12:


### PR DESCRIPTION
platform.dist() deprecated since 3.5 [1]
Use distro module instead.

[1] https://docs.python.org/3.7/library/platform.html#unix-platforms

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>