### PR TITLE
Fix execfile() after python3.0

### DIFF
--- a/client/job.py
+++ b/client/job.py
@@ -497,8 +497,14 @@ class base_client_job(base_job.base_job):
                 raise error.TestError("Dependency %s does not exist" % dep)
 
             os.chdir(dep_dir)
-            if execfile('%s.py' % dep, {}) is None:
-                logging.info('Dependency %s successfully built', dep)
+            try:
+                if execfile('%s.py' % dep, {}) is None:
+                    logging.info('Dependency %s successfully built', dep)
+            except NameError:
+                with open('%s.py' % dep) as f:
+                    code = compile(f.read(), '%s.py' % dep, 'exec')
+                    exec(code, {})
+                    logging.info('Dependency %s successfully built', dep)
 
     def _runtest(self, url, tag, timeout, args, dargs):
         try:

--- a/contrib/coverage.py
+++ b/contrib/coverage.py
@@ -406,7 +406,12 @@ class coverage:
             sys.path[0] = os.path.dirname(sys.argv[0])
             # the line below is needed since otherwise __file__ gets fucked
             __main__.__dict__["__file__"] = sys.argv[0]
-            execfile(sys.argv[0], __main__.__dict__)
+            try:
+                execfile(sys.argv[0], __main__.__dict__)
+            except NameError:
+                with open(sys.argv[0]) as f:
+                    code = compile(f.read(), sys.argv[0], 'exec')
+                    exec(code, __main__.__dict__)
         if settings.get('collect'):
             self.collect()
         if not args:

--- a/mirror/mirror
+++ b/mirror/mirror
@@ -34,7 +34,12 @@ def import_config_file(path):
     namespace = namespace_type()
 
     # execute the file using the given namespace
-    execfile(path, namespace.__dict__)
+    try:
+        execfile(path, namespace.__dict__)
+    except NameError:
+        with open(path) as f:
+            code = compile(f.read(), path, 'exec')
+            exec(code, namespace.__dict__)
 
     return namespace
 

--- a/server/server_job.py
+++ b/server/server_job.py
@@ -1001,7 +1001,12 @@ class base_server_job(base_job.base_job):
                 existing_machines_text = None
             if machines_text != existing_machines_text:
                 utils.open_write_close(MACHINES_FILENAME, machines_text)
-        execfile(code_file, namespace, namespace)
+        try:
+            execfile(code_file, namespace, namespace)
+        except NameError:
+            with open(code_file) as f:
+                code = compile(f.read(), codefile, 'exec')
+                exec(code, namespace, namespace)
 
     def _parse_status(self, new_line):
         if not self._using_parser:


### PR DESCRIPTION
Built-in function execfile has been removed in python3.0

Use open, read and exec instead.

[1] https://docs.python.org/3.0/whatsnew/3.0.html?highlight=execfile#builtins

Signed-off-by: Po-Hsu Lin \<po-hsu.lin@canonical.com\>