### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/client/base_utils.py
+++ b/client/base_utils.py
@@ -688,7 +688,7 @@ def parse_lsmod_for_module(l_raw, module_name, escape=True):
         module_search = module_name
     # ^module_name spaces size spaces used optional spaces optional submodules
     # use multiline regex to scan the entire output as one string without having to splitlines
-    # use named matches so we can extract the dictionaty with groupdict
+    # use named matches so we can extract the dictionary with groupdict
     lsmod = re.search(r"^(?P<name>%s)\s+(?P<size>\d+)\s+(?P<used>\d+)\s*(?P<submodules>\S+)?$" %
                       module_search, l_raw, re.M)
     if lsmod:

--- a/client/shared/base_packages.py
+++ b/client/shared/base_packages.py
@@ -116,13 +116,13 @@ def check_diskspace(repo, min_free=None):
     Check if the remote directory over at the pkg repo has available diskspace
 
     If the amount of free space is not supplied, it is taken from the global
-    configuration file, section [PACKAGES], key 'mininum_free_space'. The unit
+    configuration file, section [PACKAGES], key 'minimum_free_space'. The unit
     used are in SI, that is, 1 GB = 10**9 bytes.
 
     :type repo: string
     :param repo: a remote package repo URL
     :type min_free: int
-    :param: min_free mininum amount of free space, in GB (10**9 bytes)
+    :param: min_free minimum amount of free space, in GB (10**9 bytes)
     :raise error.RepoUnknownError: general repository error condition
     :raise error.RepoDiskFullError: repository does not have at least the
         requested amount of free disk space.

--- a/client/shared/iso9660.py
+++ b/client/shared/iso9660.py
@@ -289,7 +289,7 @@ class Iso9660Mount(BaseIso9660):
 
 def iso9660(path):
     '''
-    Checks the avaiable tools on a system and chooses class accordingly
+    Checks the available tools on a system and chooses class accordingly
 
     This is a convinience function, that will pick the first avaialable
     iso9660 capable tool.

--- a/client/shared/progressbar.py
+++ b/client/shared/progressbar.py
@@ -20,8 +20,8 @@ class ProgressBar:
         '''
         Initializes a new progress bar
 
-        :type mininum: integer
-        :param mininum: mininum (initial) value on the progress bar
+        :type minimum: integer
+        :param minimum: minimum (initial) value on the progress bar
         :type maximum: integer
         :param maximum: maximum (final) value on the progress bar
         :type width: integer

--- a/client/shared/utils.py
+++ b/client/shared/utils.py
@@ -2300,7 +2300,7 @@ def safe_rmdir(path, timeout=10):
                     giving up (seconds)
     :type timeout: int
     :raises: OSError, with errno 39 in case after the timeout
-             shutil.rmtree could not successfuly complete. If any attempt
+             shutil.rmtree could not successfully complete. If any attempt
              to rmtree fails with errno different than 39, that exception
              will be just raised.
     """

--- a/client/tools/JUnit_api.py
+++ b/client/tools/JUnit_api.py
@@ -1463,7 +1463,7 @@ class errorType(GeneratedsSuper):
 
     """The error message. e.g., if a java exception is thrown, the return
     value of getMessage()The type of error that occurred. e.g., if a
-    java execption is thrown the full class name of the exception."""
+    java exception is thrown the full class name of the exception."""
     subclass = None
     superclass = None
 

--- a/documentation/source/main/developer/SubmissionChecklist.rst
+++ b/documentation/source/main/developer/SubmissionChecklist.rst
@@ -14,7 +14,7 @@ In order to keep code review in one place, making the work of our maintainers
 easier, we decided to make pull requests the primary means to contributing to
 all projects inside the autotest umbrella.
 
-That means it is highly preferrable to send pull requests, rather than patches
+That means it is highly preferable to send pull requests, rather than patches
 to the mailing list. If you feel strongly against using pull requests, we'll
 take your patches, but please consider using the recommended method, as it is
 considered nicer with the maintainers.

--- a/documentation/source/main/developer/Tests/TestCodingStyle.rst
+++ b/documentation/source/main/developer/Tests/TestCodingStyle.rst
@@ -68,7 +68,7 @@ Do
 Use of the commands API, or os.system
 -------------------------------------
 
-Autotest already provides utility methods that are preferrable over os.system
+Autotest already provides utility methods that are preferable over os.system
 or commands.getstatus() and the likes. The APIs are called utils.system, utils.run,
 utils.system_output. They raise exceptions in case of a return code !=0, so
 keep this in mind (either you pass ignore_status=True or trap an exception

--- a/documentation/source/main/local/DistroDetection.rst
+++ b/documentation/source/main/local/DistroDetection.rst
@@ -95,7 +95,7 @@ To do that simply call the function :func:`register_probe`:
 
 .. autofunction:: register_probe
 
-Now, remember that for things to happen smootlhy your registered probe must be a subclass of :class:`Probe`.
+Now, remember that for things to happen smoothly your registered probe must be a subclass of :class:`Probe`.
 
 
 API Reference

--- a/documentation/source/main/remote/Conmux-OriginalDocumentation.rst
+++ b/documentation/source/main/remote/Conmux-OriginalDocumentation.rst
@@ -37,7 +37,7 @@ is elm3b70.
     elm3b70 login:
 
 Once connected we can interact normally with the console stream. To
-perform front pannel operation such as peforming an hard reset we switch
+perform front pannel operation such as performing an hard reset we switch
 to command mode. This is achieved using the escape sequence ~$. Note the
 prompt Command>
 
@@ -55,7 +55,7 @@ The following commands are generally available:
 +-------------+------------------------------------------------------------------------------------------------------------------------------------+
 | Command     | Description                                                                                                                        |
 +-------------+------------------------------------------------------------------------------------------------------------------------------------+
-| quit        | quit this console session, note that this disconnects us from the session it does not affect the integity of the session itself.   |
+| quit        | quit this console session, note that this disconnects us from the session it does not affect the integrity of the session itself.   |
 +-------------+------------------------------------------------------------------------------------------------------------------------------------+
 | hardreset   | force a hard reset on the machine, this may be a simple reset or a power off/on sequence whatever is required by this system.      |
 +-------------+------------------------------------------------------------------------------------------------------------------------------------+

--- a/documentation/source/main/sysadmin/PackagingExample.rst
+++ b/documentation/source/main/sysadmin/PackagingExample.rst
@@ -8,7 +8,7 @@ packaging repository. After that there will be a section going over how
 to add another seperate machine as a remote repository for packages.
 
 By setting up packaging in Autotest you can reduce the amount of files
-transferred to clients running jobs which generally descreases the
+transferred to clients running jobs which generally decreases the
 amount of setup time Autotest has to do for clients.
 
 Setting up your Autotest server as a packaging repository

--- a/server/frontend.py
+++ b/server/frontend.py
@@ -3,7 +3,7 @@
 
 """
 This class allows you to communicate with the frontend to submit jobs etc
-It is designed for writing more sophisiticated server-side control files that
+It is designed for writing more sophisticated server-side control files that
 can recursively add and manage other jobs.
 
 We turn the JSON dictionaries into real objects that are more idiomatic


### PR DESCRIPTION
There are small typos in:
- client/base_utils.py
- client/shared/base_packages.py
- client/shared/iso9660.py
- client/shared/progressbar.py
- client/shared/utils.py
- client/tools/JUnit_api.py
- documentation/source/main/developer/SubmissionChecklist.rst
- documentation/source/main/developer/Tests/TestCodingStyle.rst
- documentation/source/main/local/DistroDetection.rst
- documentation/source/main/remote/Conmux-OriginalDocumentation.rst
- documentation/source/main/sysadmin/PackagingExample.rst
- server/frontend.py

Fixes:
- Should read `preferable` rather than `preferrable`.
- Should read `minimum` rather than `mininum`.
- Should read `successfully` rather than `successfuly`.
- Should read `sophisticated` rather than `sophisiticated`.
- Should read `smoothly` rather than `smootlhy`.
- Should read `performing` rather than `peforming`.
- Should read `integrity` rather than `integity`.
- Should read `exception` rather than `execption`.
- Should read `dictionary` rather than `dictionaty`.
- Should read `decreases` rather than `descreases`.
- Should read `available` rather than `avaiable`.

Closes #1064