### PR TITLE
Fixed Improper Method Call: `mkstemp`

### DIFF
--- a/client/kernel_config_unittest.py
+++ b/client/kernel_config_unittest.py
@@ -130,6 +130,7 @@ class TestKernelConfig(unittest.TestCase):
 
     def tearDown(self):
         os.unlink(self.config_modules_path)
+        os.close(self.config_modules_fd)
 
 
 if __name__ == "__main__":

--- a/server/hosts/abstract_ssh.py
+++ b/server/hosts/abstract_ssh.py
@@ -57,7 +57,7 @@ class AbstractSSHHost(SiteHost):
         self.port = port
         self.password = password
         self._use_rsync = None
-        self.known_hosts_file = tempfile.mkstemp()[1]
+        self.fd, self.known_hosts_file = tempfile.mkstemp()
 
         """
         Master SSH connection background job, socket temp directory and socket
@@ -556,6 +556,7 @@ class AbstractSSHHost(SiteHost):
         super(AbstractSSHHost, self).close()
         self._cleanup_master_ssh()
         os.remove(self.known_hosts_file)
+        os.close(self.fd)
 
     def _cleanup_master_ssh(self):
         """


### PR DESCRIPTION
## Details
While triaging your project, we found that your project had used `mkstemp()` method in several places to create temporary files. However, it came to our attention that - either the file descriptors that were generated by the method weren't being closed at all or the `mkstemp()` method wasn't being used correctly. These issues can lead to a [file descriptor leak](https://cwe.mitre.org/data/definitions/775.html) which should be prevented. It is suggested that file descriptors should be closed after use.

### Proof of Concept
For the file descriptor leak related proof, one can execute the following script:

```py
from tempfile import mkstemp

for i in range(10000):
    print(f"Opening file descriptor for {i}-th time")
    fd, name = mkstemp()
    print(f"FD: {fd}")
```
During execution, the program is going to face an error/exception, since in Linux, each processes are allowed to have 1024 file descriptors associated with them. Among them, file descriptor 0, 1, 2 are assigned to `stdin`, `stdout`, and `stderr` respectively.


## Changes
- As a prevention, I have used `os.close()` method to close the file descriptors after their use.
Suggestions related to these changes are welcomed.


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
