### PR TITLE
Fixed Improper Method Call: Replaced `mktemp`

### DIFF
--- a/client/shared/remote.py
+++ b/client/shared/remote.py
@@ -992,8 +992,10 @@ class RemoteRunner(object):
         else:
             self.session = session
         # Init stdout pipe and stderr pipe.
-        self.stdout_pipe = tempfile.mktemp()
-        self.stderr_pipe = tempfile.mktemp()
+        self.fd_stdout, self.stdout_pipe = tempfile.mkstemp()
+        os.close(self.fd_stdout)
+        self.fd_stderr, self.stderr_pipe = tempfile.mkstemp()
+        os.close(self.fd_stderr)
 
     def run(self, command, timeout=60, ignore_status=False):
         """

--- a/client/shared/service.py
+++ b/client/shared/service.py
@@ -19,7 +19,7 @@
 import logging
 import os
 import re
-from tempfile import mktemp
+from tempfile import mkstemp
 
 from autotest.client import utils
 
@@ -647,9 +647,10 @@ class _SystemdServiceManager(_GenericServiceManager):
         :param runlevel: default systemd target
         :type runlevel: str
         """
-        tmp_symlink = mktemp(dir="/etc/systemd/system")
+        fd_symlink, tmp_symlink = mkstemp(dir="/etc/systemd/system")
         os.symlink("/usr/lib/systemd/system/%s" % runlevel, tmp_symlink)
         os.rename(tmp_symlink, "/etc/systemd/system/default.target")
+        os.close(fd_symlink)
 
 
 _command_generators = {"init": sys_v_init_command_generator,


### PR DESCRIPTION
## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [remote.py](https://github.com/autotest/autotest/blob/master/client/shared/remote.py#L995), there is a method that creates a temporary file using an unsafe API mktemp. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of mktemp with `mkstemp`.

> In file: [service.py](https://github.com/autotest/autotest/blob/master/client/shared/service.py#L650), there is a method that creates a temporary file using an unsafe API mktemp. The use of this method is discouraged in the Python documentation. iCR suggested that a temporary file should be created using `mkstemp` which is a safe API. iCR replaced the usage of mktemp with `mkstemp`.

We also found an occurance in file `base_job_unittest.py`. Since we think it's a test related file, we didn't change it.


## Changes
Replacecd `mktemp` with `mkstemp` method and closed the related file-descriptors safely.


## Previously Found & Fixed
- https://www.github.com/invesalius/invesalius3/pull/679
- https://www.github.com/Azure/azure-linux-extensions/pull/1816
- https://www.github.com/celery/billiard/pull/394


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
